### PR TITLE
Fix: Respect use_controlnet and use_ipadapter config flags

### DIFF
--- a/src/streamdiffusion/config.py
+++ b/src/streamdiffusion/config.py
@@ -126,19 +126,22 @@ def _extract_wrapper_params(config: Dict[str, Any]) -> Dict[str, Any]:
         'normalize_seed_weights': config.get('normalize_seed_weights', True),
         'compile_engines_only': config.get('compile_engines_only', False),
     }
-    if 'controlnets' in config and config['controlnets']:
+    # Check use_controlnet flag first - if explicitly set to False, respect that
+    use_controlnet = config.get('use_controlnet', False)
+    if use_controlnet and 'controlnets' in config and config['controlnets']:
         param_map['use_controlnet'] = True
         param_map['controlnet_config'] = _prepare_controlnet_configs(config)
     else:
-        param_map['use_controlnet'] = config.get('use_controlnet', False)
+        param_map['use_controlnet'] = False
         param_map['controlnet_config'] = config.get('controlnet_config')
     
-    # Set IPAdapter usage if IPAdapters are configured
-    if 'ipadapters' in config and config['ipadapters']:
+    # Check use_ipadapter flag first - if explicitly set to False, respect that
+    use_ipadapter = config.get('use_ipadapter', False)
+    if use_ipadapter and 'ipadapters' in config and config['ipadapters']:
         param_map['use_ipadapter'] = True
         param_map['ipadapter_config'] = _prepare_ipadapter_configs(config)
     else:
-        param_map['use_ipadapter'] = config.get('use_ipadapter', False)
+        param_map['use_ipadapter'] = False
         param_map['ipadapter_config'] = config.get('ipadapter_config')
     
     # Pipeline hook configurations (Phase 4: Configuration Integration)


### PR DESCRIPTION
Previously, if 'controlnets' or 'ipadapters' lists existed in config, the use_controlnet/use_ipadapter flags were ignored and always set to True. This caused TensorRT engines to be built with ControlNet/IPAdapter support even when disabled, leading to OOM errors during compilation.

Now the explicit use_controlnet and use_ipadapter boolean flags are checked first, and only if True will the feature be enabled."