### PR TITLE
chore(installer): overhaul install scripts — portable paths, TRT verification, pin alignment

### DIFF
--- a/.charlie/config.yml
+++ b/.charlie/config.yml
@@ -1,0 +1,9 @@
+checkCommands:
+  fix: ruff check --fix . && ruff format .
+  lint: pip install ruff && ruff check .
+  # Type checking not yet configured - add when ready:
+  # types: pip install pyrefly && pyrefly check
+  # Tests not yet available - add when CPU-compatible tests exist:
+  # test: pip install pytest && pytest tests/ -x -q --ignore=tests/gpu/
+beta:
+  canApprovePullRequests: false

--- a/.charlie/instructions/code-style.md
+++ b/.charlie/instructions/code-style.md
@@ -1,0 +1,13 @@
+# StreamDiffusion Code Style
+
+Charlie reads CLAUDE.md automatically for project context. These are additional rules.
+
+## Rules
+
+- [R1] Follow existing patterns in the codebase — check surrounding code before suggesting changes
+- [R2] Ensure ruff lint and format checks pass: `ruff check . && ruff format --check .` (line-length 119)
+- [R3] CUDA kernels and device operations must include error checking — never ignore return codes
+- [R4] TensorRT engine building/loading code must handle version compatibility explicitly
+- [R5] Use type hints for all new public functions and class methods
+- [R6] TouchDesigner extension methods must follow the TD callback pattern (onXxx naming)
+- [R7] Do not commit CLAUDE.md, MEMORY.md, or .claude/ — these are local-only files

--- a/.claude/hooks/git-commit-enforcer.py
+++ b/.claude/hooks/git-commit-enforcer.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook to enforce safe git commits via commit_enhanced.sh
+instead of raw 'git commit' commands.
+
+This hook intercepts any 'git commit' bash command and redirects it
+to scripts/git/commit_enhanced.sh for validation and safety checks.
+
+Benefits:
+- Automatic lint validation (ruff, black, isort)
+- Local file exclusion (CLAUDE.md, MEMORY.md, _archive/)
+- Commit message format validation
+- Branch-specific protection
+"""
+
+import json
+import os
+import re
+import sys
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+    command = tool_input.get("command", "")
+
+    # Only intercept Bash tool
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    # Detect git commit patterns
+    # Match: git commit, git commit -m, git commit --message, etc.
+    git_commit_pattern = r"\bgit\s+commit\b"
+    if not re.search(git_commit_pattern, command):
+        sys.exit(0)
+
+    # Respect --no-verify flag - user explicitly wants to bypass hooks
+    no_verify_pattern = r"\b(--no-verify|-n)\b"
+    if re.search(no_verify_pattern, command):
+        # Allow raw command to pass through
+        sys.exit(0)
+
+    # SMART DETECTION: Allow legitimate git commit cases to pass through
+    # Only intercept standard new commits (git commit -m "message")
+    ALLOWED_PATTERNS = [
+        r"--amend",  # Amending previous commit
+        r"--no-edit",  # Merge/rebase completion
+        r"--allow-empty",  # Empty commits (rare but valid)
+        r"--fixup",  # Fixup commits for rebase
+        r"--squash",  # Squash commits for rebase
+    ]
+
+    # Check if any allowed pattern is present
+    for pattern in ALLOWED_PATTERNS:
+        if re.search(pattern, command):
+            # Allow special commit types to pass through
+            sys.exit(0)
+
+    # ONLY intercept: git commit -m "message" (standard new commits)
+    # This is the pattern that should go through commit_enhanced.bat
+    if not re.search(r'-m\s+["\']', command):
+        # No -m flag = likely interactive or special case
+        sys.exit(0)
+
+    # Extract commit message if present
+    # Patterns: -m "message", -m 'message', --message "message"
+    message = ""
+
+    # Try -m with quotes
+    msg_match = re.search(r'-m\s+["\']([^\'"]+)["\']', command)
+    if msg_match:
+        message = msg_match.group(1)
+    else:
+        # Try --message with quotes
+        msg_match = re.search(r'--message\s+["\']([^\'"]+)["\']', command)
+        if msg_match:
+            message = msg_match.group(1)
+        else:
+            # Try -m without quotes (single word)
+            msg_match = re.search(r'-m\s+([^\s"\']+)', command)
+            if msg_match:
+                message = msg_match.group(1)
+
+    # Build safe commit command
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "F:/RD_PROJECTS/COMPONENTS/claude-context-local")
+    safe_script = f"{project_dir}/scripts/git/commit_enhanced.sh"
+
+    # Construct updated command - shell script runs natively in Git Bash
+    if message:
+        updated_command = f'./scripts/git/commit_enhanced.sh "{message}"'
+    else:
+        # No message provided - script will prompt or use default
+        updated_command = "./scripts/git/commit_enhanced.sh"
+
+    # Return hook decision with updated command
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "permissionDecisionReason": (
+                "Routing through safe commit handler (commit_enhanced.sh) "
+                "for validation, lint checks, and local file protection"
+            ),
+            "updatedInput": {"command": updated_command},
+        }
+    }
+
+    print(json.dumps(output))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,45 @@
+# Line endings
+*.sh text eol=lf
+*.py text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.toml text eol=lf
+*.txt text eol=lf
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Merge strategies
+*.py merge=diff3
+*.json merge=diff3
+*.yaml merge=diff3
+*.yml merge=diff3
+*.toml merge=diff3
+*.md merge=diff3
+CHANGELOG.md merge=union
+
+# Binary files (ML models, images, compiled artifacts)
+*.onnx binary
+*.engine binary
+*.trt binary
+*.pth binary
+*.pt binary
+*.safetensors binary
+*.pkl binary
+*.pb binary
+*.h5 binary
+
+# Images
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+
+# Archives
+*.zip binary
+*.tar binary
+*.gz binary
+*.whl binary

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,61 @@
+#!/bin/sh
+# Pre-commit hook to prevent accidental commit of local-only files
+# Prevents commits of CLAUDE.md, MEMORY.md, .claude/ directory
+# Allows DELETIONS (D) but blocks additions (A) or modifications (M)
+
+echo "Checking for local-only files..."
+
+# Check if any local-only files are being ADDED or MODIFIED (not deleted)
+PROBLEMATIC_FILES=$(git diff --cached --name-status | grep -E "^[AM]\s+(CLAUDE\.md|MEMORY\.md|\.claude/)")
+
+if [ -n "$PROBLEMATIC_FILES" ]; then
+    echo "ERROR: Attempting to add or modify local-only files!"
+    echo ""
+    echo "The following files must remain local only:"
+    echo "- CLAUDE.md (development context, project-specific AI instructions)"
+    echo "- MEMORY.md (session memory)"
+    echo "- .claude/ (Claude Code configuration, hooks, skills)"
+    echo ""
+    echo "Problematic files:"
+    echo "$PROBLEMATIC_FILES"
+    echo ""
+    echo "DELETIONS are allowed (removing from git tracking)"
+    echo "ADDITIONS/MODIFICATIONS are blocked (privacy protection)"
+    echo ""
+    echo "To fix this, reset the problematic files:"
+    echo "  git reset HEAD <file>"
+    echo ""
+    exit 1
+fi
+
+# Check for deletions (which are allowed and expected)
+DELETED_FILES=$(git diff --cached --name-status | grep -E "^D\s+(CLAUDE\.md|MEMORY\.md|\.claude/)")
+if [ -n "$DELETED_FILES" ]; then
+    echo "  Local-only files being removed from git tracking (as intended)"
+fi
+
+echo "  No local-only files detected"
+echo "  Privacy protection active"
+
+# Optional: Check code quality for Python files (non-blocking)
+PYTHON_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$')
+
+if [ -n "$PYTHON_FILES" ]; then
+    echo ""
+    echo "Checking code quality (non-blocking)..."
+
+    if command -v ruff > /dev/null 2>&1; then
+        if ! ruff check $PYTHON_FILES > /dev/null 2>&1; then
+            echo "  WARNING: ruff found lint issues in staged Python files"
+            echo "  Run 'ruff check --fix .' to auto-fix, or 'ruff check .' to see details"
+            echo "  (Commit will proceed - fix lint issues when ready)"
+        else
+            echo "  Code quality checks passed"
+        fi
+    else
+        echo "  ruff not found - skipping lint check (install: pip install ruff)"
+    fi
+fi
+
+echo ""
+exit 0

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Default owners for all files
+* @forkni
+
+# CUDA/TensorRT specific code
+*.cu @forkni
+*.cuh @forkni
+*tensorrt* @forkni
+*trt* @forkni
+
+# CI/CD workflows
+.github/ @forkni
+
+# Core streaming pipeline
+src/streamdiffusion/ @forkni

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,114 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug", "status/needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of the bug.
+      placeholder: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Load model '...'
+        2. Set parameters '...'
+        3. Run inference '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: error
+    attributes:
+      label: Error Output
+      description: Paste the full error output or traceback.
+      render: shell
+
+  - type: markdown
+    attributes:
+      value: "## Environment"
+
+  - type: input
+    id: gpu
+    attributes:
+      label: GPU Model
+      placeholder: e.g. NVIDIA RTX 3090, A100 80GB
+    validations:
+      required: true
+
+  - type: input
+    id: cuda
+    attributes:
+      label: CUDA Version
+      placeholder: e.g. 11.8
+    validations:
+      required: true
+
+  - type: input
+    id: driver
+    attributes:
+      label: NVIDIA Driver Version
+      placeholder: e.g. 525.85.12
+    validations:
+      required: true
+
+  - type: input
+    id: tensorrt
+    attributes:
+      label: TensorRT Version (if applicable)
+      placeholder: e.g. 8.6.1
+
+  - type: input
+    id: python
+    attributes:
+      label: Python Version
+      placeholder: e.g. 3.10.12
+    validations:
+      required: true
+
+  - type: input
+    id: torch
+    attributes:
+      label: PyTorch Version
+      placeholder: e.g. 2.0.1+cu118
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - Ubuntu 22.04
+        - Ubuntu 20.04
+        - Windows 11
+        - Windows 10
+        - macOS (MPS)
+        - Other Linux
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: branch
+    attributes:
+      label: Branch / Commit
+      placeholder: e.g. SDTD_031_stable, main, commit hash
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, config files, or screenshots.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement", "status/needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe what you'd like to see.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: What problem does this feature solve? What's the use case?
+      placeholder: I'm trying to do X but currently Y is a limitation...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the feature or behavior you'd like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative approaches or workarounds you've tried?
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Feature Area
+      multiple: true
+      options:
+        - Inference / Pipeline
+        - TensorRT optimization
+        - CUDA kernels
+        - ControlNet / IP-Adapter
+        - TouchDesigner integration
+        - Livepeer integration
+        - API / Interface
+        - Installation / Setup
+        - Documentation
+        - Other
+
+  - type: dropdown
+    id: gpu_required
+    attributes:
+      label: GPU Required?
+      description: Does this feature require GPU-specific hardware?
+      options:
+        - No GPU requirement
+        - Any CUDA GPU
+        - Specific architecture (specify in description)
+        - TensorRT capable GPU
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, mockups, or references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,52 @@
+## Summary
+
+<!-- Brief description of changes -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature / enhancement
+- [ ] Performance improvement
+- [ ] CUDA / TensorRT optimization
+- [ ] TouchDesigner integration
+- [ ] Documentation
+- [ ] CI/CD / tooling
+
+## Related Issues
+
+<!-- Closes #issue_number -->
+
+## Testing
+
+<!-- How was this tested? Note GPU requirements explicitly. -->
+
+- [ ] Tested locally
+- [ ] CPU-only compatible (no GPU required to test)
+- [ ] Requires GPU testing (specify hardware below)
+
+**Test environment** (if GPU required):
+- GPU: <!-- e.g. RTX 3090, A100 -->
+- CUDA version: <!-- e.g. 11.8 -->
+- TensorRT version: <!-- e.g. 8.6 -->
+- OS: <!-- e.g. Ubuntu 22.04, Windows 11 -->
+
+## CUDA / TensorRT Impact
+
+- [ ] No CUDA/TensorRT changes
+- [ ] Modified CUDA kernels or memory management
+- [ ] TensorRT engine building or loading changes
+- [ ] Requires specific GPU architecture (specify: <!-- e.g. sm_86 -->)
+- [ ] Changes engine serialization format (breaking for existing .engine files)
+
+## TouchDesigner Impact
+
+- [ ] No TD changes
+- [ ] Modified TD Python extensions
+- [ ] Modified OSC/parameter interface
+- [ ] Requires TD version update (specify: <!-- e.g. 2023.11760+ -->)
+
+## Checklist
+
+- [ ] Code follows project style (ruff format, line-length 119)
+- [ ] Self-review completed
+- [ ] No local-only files included (CLAUDE.md, MEMORY.md, .claude/)

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,88 @@
+name: Branch Protection
+
+on:
+  push:
+    branches: [development, main]
+  pull_request:
+    branches: [development, main]
+
+jobs:
+  validate:
+    name: Validate Branch State
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for local-only files
+        run: |
+          echo "Checking for accidentally committed local files..."
+
+          FOUND_ISSUES=0
+
+          for file in CLAUDE.md MEMORY.md; do
+            if git ls-files | grep -q "^$file$"; then
+              echo "ERROR: $file is tracked in git (should be local-only)"
+              FOUND_ISSUES=1
+            fi
+          done
+
+          # Check for .claude/ directory
+          if git ls-files | grep -q "^\.claude/"; then
+            echo "ERROR: .claude/ directory is tracked in git (should be local-only)"
+            FOUND_ISSUES=1
+          fi
+
+          if [ $FOUND_ISSUES -eq 0 ]; then
+            echo "No local-only files detected"
+          else
+            echo ""
+            echo "Fix: Remove these files from git tracking with: git rm --cached <file>"
+            exit 1
+          fi
+
+  lint:
+    name: Code Quality Checks
+    runs-on: ubuntu-latest
+    needs: validate
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Run ruff check (linting + import sorting)
+        run: ruff check .
+        continue-on-error: true  # Non-blocking: codebase has not been fully lint-cleaned
+
+      - name: Check formatting (ruff format)
+        run: ruff format --check .
+        continue-on-error: true  # Non-blocking: apply formatting incrementally
+
+  # Test job placeholder - uncomment when CPU-compatible tests exist
+  # test:
+  #   name: Run Tests (CPU only)
+  #   runs-on: ubuntu-latest
+  #   needs: validate
+  #   if: github.ref == 'refs/heads/development'
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: '3.10'
+  #     - name: Install CPU-only PyTorch + package
+  #       run: |
+  #         pip install torch --index-url https://download.pytorch.org/whl/cpu
+  #         pip install -e ".[test]"
+  #     - name: Run CPU tests
+  #       run: pytest tests/ -v --ignore=tests/gpu/ --ignore=tests/tensorrt/

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,70 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "**/*.py"
+      - "**/*.cu"
+      - "**/*.cuh"
+      - "setup.py"
+      - "pyproject.toml"
+      - "Dockerfile"
+      - ".github/workflows/**"
+
+# Prevent multiple runs on rapid PR updates
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        continue-on-error: true  # Don't fail PR status if Claude has issues
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "*"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request for a real-time diffusion inference pipeline
+            (StreamDiffusion Livepeer fork) with CUDA/TensorRT acceleration and TouchDesigner integration.
+
+            Focus on:
+            - Correctness and potential bugs
+            - CUDA memory management and error handling (check for missing cudaError_t checks)
+            - TensorRT engine compatibility and version handling
+            - Performance considerations for real-time inference
+            - Python code quality and style (ruff, line-length 119)
+            - Security concerns
+            - Backward compatibility with existing TouchDesigner integrations
+
+            Note: CLAUDE.md is available locally for project-specific guidance.
+            Be constructive and specific in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+
+      - name: Comment on failure
+        if: failure()
+        run: gh pr comment ${{ github.event.pull_request.number }} --body "Claude Code review encountered an error. Check the Actions log for details."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,46 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+# Prevent multiple runs on rapid comments
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  claude:
+    # Only run when @claude is mentioned in the comment/issue
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: "*"

--- a/.github/workflows/merge-development-to-main.yml
+++ b/.github/workflows/merge-development-to-main.yml
@@ -1,0 +1,111 @@
+name: Merge Development to Main
+
+on:
+  workflow_dispatch:
+    inputs:
+      create_backup:
+        description: 'Create backup tag before merge'
+        required: true
+        type: boolean
+        default: true
+      dry_run:
+        description: 'Dry run (preview only, no actual merge)'
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  merge:
+    name: Merge development → main
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update branches from remote
+        run: |
+          git fetch origin development:development
+          git fetch origin main:main
+
+      - name: Create backup tag
+        if: ${{ inputs.create_backup == true && inputs.dry_run == false }}
+        run: |
+          TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+          BACKUP_TAG="backup-main-before-merge-$TIMESTAMP"
+
+          git checkout main
+          git tag "$BACKUP_TAG"
+          git push origin "$BACKUP_TAG"
+
+          echo "Backup tag created: $BACKUP_TAG"
+          echo "BACKUP_TAG=$BACKUP_TAG" >> $GITHUB_ENV
+
+      - name: Preview merge (Dry Run)
+        if: ${{ inputs.dry_run == true }}
+        run: |
+          git checkout main
+
+          echo "=== DRY RUN: Files that would change ==="
+          git diff --name-status main development || true
+
+          echo ""
+          echo "=== Commits to be merged ==="
+          git log main..development --oneline
+
+          echo ""
+          echo "=== DRY RUN COMPLETE: No changes made ==="
+
+      - name: Perform merge
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          git checkout main
+
+          echo "Merging development into main..."
+          git merge --no-ff development -m "$(cat <<'EOF'
+          chore: Merge development to main
+
+          - Automated merge via GitHub Actions
+          EOF
+          )"
+
+          if [ $? -ne 0 ]; then
+            echo "ERROR: Merge failed - conflicts detected"
+            git merge --abort
+            exit 1
+          fi
+
+          echo "Merge completed successfully"
+
+      - name: Push to main
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          git push origin main
+          echo "Main branch updated successfully"
+
+      - name: Create merge summary
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          echo "=== MERGE SUMMARY ==="
+          echo "Development to Main merge successful"
+          echo "Method: Git --no-ff merge"
+
+          if [ -n "$BACKUP_TAG" ]; then
+            echo "Backup tag: $BACKUP_TAG"
+            echo ""
+            echo "To rollback: git reset --hard $BACKUP_TAG && git push --force-with-lease origin main"
+          fi
+
+          echo ""
+          echo "Changes merged:"
+          git diff --stat HEAD~1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# Pre-commit hooks configuration
+# Installation: pip install pre-commit && pre-commit install
+
+repos:
+  # Ruff - Fast Python linter and formatter
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.11
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+
+  # Standard pre-commit hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-added-large-files
+        args: ['--maxkb=5000']  # Larger limit for ML project (model configs, etc.)

--- a/4.9.0.80
+++ b/4.9.0.80
@@ -1,0 +1,16 @@
+Looking in indexes: https://pypi.org/simple, https://pypi.ngc.nvidia.com
+Collecting opencv-python-headless
+  Downloading opencv_python_headless-4.13.0.92-cp37-abi3-win_amd64.whl.metadata (20 kB)
+Collecting numpy>=2 (from opencv-python-headless)
+  Downloading numpy-2.4.4-cp311-cp311-win_amd64.whl.metadata (6.6 kB)
+Downloading opencv_python_headless-4.13.0.92-cp37-abi3-win_amd64.whl (40.1 MB)
+   ---------------------------------------- 40.1/40.1 MB 4.4 MB/s  0:00:09
+Downloading numpy-2.4.4-cp311-cp311-win_amd64.whl (12.6 MB)
+   ---------------------------------------- 12.6/12.6 MB 5.8 MB/s  0:00:02
+Installing collected packages: numpy, opencv-python-headless
+  Attempting uninstall: numpy
+    Found existing installation: numpy 1.26.4
+    Uninstalling numpy-1.26.4:
+      Successfully uninstalled numpy-1.26.4
+
+Successfully installed numpy-2.4.4 opencv-python-headless-4.13.0.92

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,140 @@
+# Contributing to StreamDiffusion Livepeer
+
+Thank you for your interest in contributing to this project!
+
+## Development Setup
+
+### Prerequisites
+
+- NVIDIA GPU with CUDA 11.8+ support
+- Python 3.10+
+- NVIDIA CUDA Toolkit 11.8 or 12.x
+- (Optional) TensorRT 8.6+ for acceleration
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/forkni/StreamDiffusion-Livepeer.git
+cd StreamDiffusion-Livepeer
+
+# Install PyTorch with CUDA (adjust version for your CUDA)
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cu118
+
+# Install the package
+pip install -e ".[xformers]"
+
+# Install TensorRT support (optional)
+pip install -e ".[tensorrt]"
+```
+
+### Install Pre-commit Hooks
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Or use the git hooks script:
+
+```bash
+../Scripts/git/install_hooks.sh
+```
+
+## Code Style
+
+This project uses [ruff](https://github.com/astral-sh/ruff) for linting and formatting.
+
+```bash
+# Check for issues
+ruff check .
+
+# Auto-fix issues
+ruff check --fix .
+
+# Format code
+ruff format .
+```
+
+**Key style rules:**
+- Line length: 119 characters (see `pyproject.toml`)
+- Double quotes for strings
+- Import sorting enforced (isort-compatible)
+
+## Branch Strategy
+
+- `main` — stable, production-ready
+- `development` — active development, feature branches merge here
+- Feature branches: `feature/your-feature-name`
+- Bug fixes: `fix/issue-description`
+
+## Pull Request Process
+
+1. Create a branch from `development`
+2. Make your changes
+3. Run lint: `ruff check . && ruff format --check .`
+4. Commit using conventional format (see below)
+5. Push and open a PR against `development`
+6. Wait for Claude Code AI review
+
+### Commit Format
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add SDXL ControlNet support
+fix: resolve TensorRT engine loading on Windows
+perf: optimize CUDA memory allocation for batch processing
+docs: update installation guide for CUDA 12
+chore: update diffusers dependency to 0.21
+```
+
+Prefixes: `feat`, `fix`, `perf`, `docs`, `chore`, `test`, `refactor`, `style`
+
+### Git Automation Scripts
+
+Enhanced commit workflow with validation:
+
+```bash
+# Standard commit (validates local-only files, checks lint)
+../Scripts/git/commit_enhanced.sh "feat: your feature"
+
+# Skip lint check (faster)
+../Scripts/git/commit_enhanced.sh --skip-md-lint "chore: quick fix"
+
+# Use pre-staged files only
+git add specific_file.py
+../Scripts/git/commit_enhanced.sh --staged-only "fix: specific fix"
+```
+
+## CUDA Development Guidelines
+
+- Always include CUDA error checking after kernel launches
+- Use `torch.cuda.synchronize()` before timing measurements
+- Document GPU memory requirements in docstrings
+- Test on multiple GPU architectures when possible (sm_75, sm_86, sm_89)
+
+## TensorRT Guidelines
+
+- Handle TensorRT version compatibility explicitly
+- Document minimum TensorRT version requirements
+- Avoid engine format changes without migration path
+
+## Local-Only Files
+
+The following files are local-only and must NOT be committed:
+
+- `CLAUDE.md` — AI assistant context
+- `MEMORY.md` — Session memory
+- `.claude/` — Claude Code configuration
+
+These are blocked by the pre-commit hook and `.gitignore`.
+
+## Getting Help
+
+- Open an issue with the `help wanted` label
+- Tag `@claude` in a PR or issue for AI-assisted help
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the Apache 2.0 License.

--- a/Install_StreamDiffusion.bat
+++ b/Install_StreamDiffusion.bat
@@ -3,10 +3,41 @@ echo ========================================
 echo  StreamDiffusionTD v0.3.1 Installation
 echo  Daydream Fork with StreamV2V
 echo ========================================
+echo.
 
-cd /d "D:\Users\alexk\FORKNI\STREAM_DIFFUSION\STREAM_DIFFUSION_LIVEPEER\StreamDiffusion"
+:: Prerequisite checks
+echo Checking prerequisites...
+
+py -3.11 --version >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: Python 3.11 not found via py launcher.
+    echo Install Python 3.11 from https://python.org and ensure the py launcher is available.
+    pause
+    exit /b 1
+)
+
+git --version >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: Git not found in PATH.
+    echo Install Git from https://git-scm.com/ (required for pip git+ packages).
+    pause
+    exit /b 1
+)
+
+where cl.exe >nul 2>&1
+if errorlevel 1 (
+    echo WARNING: C++ compiler (cl.exe) not found. Some packages may require it to build.
+    echo If installation fails, install Visual Studio Build Tools from:
+    echo   https://visualstudio.microsoft.com/visual-cpp-build-tools/
+    echo.
+)
+
+echo Prerequisites OK. Starting installation...
+echo.
+
+cd /d "%~dp0"
 cd StreamDiffusion-installer
 
-py -3.11 -m sd_installer --base-folder "D:\Users\alexk\FORKNI\STREAM_DIFFUSION\STREAM_DIFFUSION_LIVEPEER\StreamDiffusion" install --cuda cu128 --no-cache
+py -3.11 -m sd_installer --base-folder "%~dp0." install --cuda cu128 --no-cache
 
 pause

--- a/Install_StreamDiffusion.bat
+++ b/Install_StreamDiffusion.bat
@@ -1,0 +1,12 @@
+@echo off
+echo ========================================
+echo  StreamDiffusionTD v0.3.1 Installation
+echo  Daydream Fork with StreamV2V
+echo ========================================
+
+cd /d "D:\Users\alexk\FORKNI\STREAM_DIFFUSION\STREAM_DIFFUSION_LIVEPEER\StreamDiffusion"
+cd StreamDiffusion-installer
+
+py -3.11 -m sd_installer --base-folder "D:\Users\alexk\FORKNI\STREAM_DIFFUSION\STREAM_DIFFUSION_LIVEPEER\StreamDiffusion" install --cuda cu128 --no-cache
+
+pause

--- a/Install_TensorRT.bat
+++ b/Install_TensorRT.bat
@@ -3,22 +3,30 @@ echo ========================================
 echo  StreamDiffusionTD TensorRT Installation
 echo ========================================
 echo.
-cd /d "D:/Users/alexk/FORKNI/STREAM_DIFFUSION/STREAM_DIFFUSION_LIVEPEER/StreamDiffusion"
 
-echo Attempting to activate virtual environment...
+cd /d "%~dp0"
+
+:: Check venv exists before trying to activate
+if not exist "venv\Scripts\activate.bat" (
+    echo ERROR: Virtual environment not found at venv\Scripts\activate.bat
+    echo Run Install_StreamDiffusion.bat first to create the environment.
+    pause
+    exit /b 1
+)
+
+echo Activating virtual environment...
 call "venv\Scripts\activate.bat"
 
 if "%VIRTUAL_ENV%" == "" (
-    echo Failed to activate virtual environment.
+    echo ERROR: Failed to activate virtual environment.
     pause
     exit /b 1
-) else (
-    echo Virtual environment activated.
 )
+echo Virtual environment activated: %VIRTUAL_ENV%
 
 echo.
 echo Installing TensorRT via CLI...
-cd /d "D:/Users/alexk/FORKNI/STREAM_DIFFUSION/STREAM_DIFFUSION_LIVEPEER/StreamDiffusion\StreamDiffusion-installer"
+cd StreamDiffusion-installer
 python -m sd_installer install-tensorrt
 
 echo.

--- a/Install_TensorRT.bat
+++ b/Install_TensorRT.bat
@@ -1,0 +1,26 @@
+@echo off
+echo ========================================
+echo  StreamDiffusionTD TensorRT Installation
+echo ========================================
+echo.
+cd /d "D:/Users/alexk/FORKNI/STREAM_DIFFUSION/STREAM_DIFFUSION_LIVEPEER/StreamDiffusion"
+
+echo Attempting to activate virtual environment...
+call "venv\Scripts\activate.bat"
+
+if "%VIRTUAL_ENV%" == "" (
+    echo Failed to activate virtual environment.
+    pause
+    exit /b 1
+) else (
+    echo Virtual environment activated.
+)
+
+echo.
+echo Installing TensorRT via CLI...
+cd /d "D:/Users/alexk/FORKNI/STREAM_DIFFUSION/STREAM_DIFFUSION_LIVEPEER/StreamDiffusion\StreamDiffusion-installer"
+python -m sd_installer install-tensorrt
+
+echo.
+echo TensorRT installation finished
+pause

--- a/Start_StreamDiffusion.bat
+++ b/Start_StreamDiffusion.bat
@@ -1,13 +1,23 @@
+@echo off
+cd /d %~dp0
 
-            @echo off
-            cd /d %~dp0
-            
-            if exist venv (
-                call venv\Scripts\activate.bat
-                venv\Scripts\python.exe streamdiffusionTD\td_main.py
-            ) else (
-                call .venv\Scripts\activate.bat
-                .venv\Scripts\python.exe streamdiffusionTD\td_main.py
-            )
-            pause
-            
+:: ─── CUDA / PyTorch Performance Tuning ───
+:: Prevents memory fragmentation from per-frame torch.cat allocations
+set PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:128,expandable_segments:True
+:: Defers CUDA module loading until first use (~1-5s faster startup)
+set CUDA_MODULE_LOADING=LAZY
+:: Enables cuDNN v8 graph API for better conv kernel selection (VAE, preprocessors)
+set TORCH_CUDNN_V8_API_ENABLED=1
+:: Ensures async kernel launches (default=0, but explicit protects against debug leftovers)
+set CUDA_LAUNCH_BLOCKING=0
+:: Caches compiled Triton kernels to disk (eliminates 30-60s JIT warmup on restart)
+set TORCHINDUCTOR_FX_GRAPH_CACHE=1
+
+if exist venv (
+    call venv\Scripts\activate.bat
+    venv\Scripts\python.exe streamdiffusionTD\td_main.py
+) else (
+    call .venv\Scripts\activate.bat
+    .venv\Scripts\python.exe streamdiffusionTD\td_main.py
+)
+pause

--- a/Start_StreamDiffusion.bat
+++ b/Start_StreamDiffusion.bat
@@ -1,23 +1,14 @@
 @echo off
 cd /d %~dp0
 
-:: ─── CUDA / PyTorch Performance Tuning ───
-:: Prevents memory fragmentation from per-frame torch.cat allocations
-set PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:128,expandable_segments:True
-:: Defers CUDA module loading until first use (~1-5s faster startup)
-set CUDA_MODULE_LOADING=LAZY
-:: Enables cuDNN v8 graph API for better conv kernel selection (VAE, preprocessors)
-set TORCH_CUDNN_V8_API_ENABLED=1
-:: Ensures async kernel launches (default=0, but explicit protects against debug leftovers)
-set CUDA_LAUNCH_BLOCKING=0
-:: Caches compiled Triton kernels to disk (eliminates 30-60s JIT warmup on restart)
-set TORCHINDUCTOR_FX_GRAPH_CACHE=1
+:: Load runtime environment variables if set_env.bat exists
+if exist "%~dp0set_env.bat" call "%~dp0set_env.bat"
 
 if exist venv (
     call venv\Scripts\activate.bat
-    venv\Scripts\python.exe streamdiffusionTD\td_main.py
+    venv\Scripts\python.exe StreamDiffusionTD\td_main.py
 ) else (
     call .venv\Scripts\activate.bat
-    .venv\Scripts\python.exe streamdiffusionTD\td_main.py
+    .venv\Scripts\python.exe StreamDiffusionTD\td_main.py
 )
 pause

--- a/Start_StreamDiffusion.bat
+++ b/Start_StreamDiffusion.bat
@@ -1,0 +1,13 @@
+
+            @echo off
+            cd /d %~dp0
+            
+            if exist venv (
+                call venv\Scripts\activate.bat
+                venv\Scripts\python.exe streamdiffusionTD\td_main.py
+            ) else (
+                call .venv\Scripts\activate.bat
+                .venv\Scripts\python.exe streamdiffusionTD\td_main.py
+            )
+            pause
+            

--- a/StreamDiffusionTD/install_tensorrt.py
+++ b/StreamDiffusionTD/install_tensorrt.py
@@ -143,6 +143,11 @@ def install(cu: Optional[str] = None):
         print("Installing pywin32...")
         run_pip("install pywin32==306 --no-cache-dir")
 
+    # Pin onnx to IR 10 — onnxruntime-gpu 1.22 max supported IR version is 10
+    # (onnx 1.18+ exports IR 11/12 which breaks polygraphy constant folding)
+    print("Pinning onnx==1.17.0 (IR 10 for onnxruntime-gpu 1.22 compatibility)...")
+    run_pip("install onnx==1.17.0 --no-cache-dir")
+
     # FP8 quantization dependencies (CUDA 12 only)
     # nvidia-modelopt requires cupy; pin cupy 13.x + numpy<2 for mediapipe compat
     if cuda_major == "12":

--- a/StreamDiffusionTD/install_tensorrt.py
+++ b/StreamDiffusionTD/install_tensorrt.py
@@ -1,12 +1,30 @@
 """
 Standalone TensorRT installation script for StreamDiffusionTD
 This is a self-contained version that doesn't rely on the streamdiffusion package imports
+
+Version pins aligned with sd_installer/tensorrt.py and src/streamdiffusion/tools/install-tensorrt.py
 """
 
 import platform
 import subprocess
 import sys
 from typing import Optional
+
+# Canonical version pins — keep in sync with sd_installer/tensorrt.py
+TENSORRT_PINS = {
+    "cu12": {
+        "cudnn": "nvidia-cudnn-cu12==9.7.1.26",
+        "tensorrt": "tensorrt==10.12.0.36",
+    },
+    "cu11": {
+        "cudnn": "nvidia-cudnn-cu11==8.9.7.29",
+        "tensorrt": "tensorrt==9.0.1.post11.dev4",
+    },
+    "polygraphy": "polygraphy==0.49.26",
+    "onnx_graphsurgeon": "onnx-graphsurgeon==0.5.8",
+    "pywin32": "pywin32==311",
+    "triton_windows": "triton-windows==3.4.0.post21",
+}
 
 
 def run_pip(command: str):
@@ -27,9 +45,8 @@ def version(package_name: str) -> Optional[str]:
     """Get version of installed package"""
     try:
         import importlib.metadata
-
         return importlib.metadata.version(package_name)
-    except:
+    except Exception:
         return None
 
 
@@ -62,86 +79,76 @@ def install(cu: Optional[str] = None):
     cuda_major = cu.split(".")[0] if cu else "12"
     cuda_version_float = float(cu) if cu else 12.0
 
-    # Skip nvidia-pyindex - it's broken with pip 25.3+ and not actually needed
-    # The NVIDIA index is already accessible via pip config or environment variables
-
-    # Uninstall old TensorRT versions
+    # Uninstall old TensorRT versions (anything below 10.8)
     if is_installed("tensorrt"):
         current_version_str = version("tensorrt")
         if current_version_str:
             try:
                 from packaging.version import Version
+                needs_uninstall = Version(current_version_str) < Version("10.8.0")
+            except ImportError:
+                # packaging not available - compare by major version
+                try:
+                    major = int(current_version_str.split(".")[0])
+                    needs_uninstall = major < 10
+                except (ValueError, IndexError):
+                    needs_uninstall = False
+            if needs_uninstall:
+                print("Uninstalling old TensorRT version...")
+                run_pip("uninstall -y tensorrt")
 
-                current_version = Version(current_version_str)
-                if current_version < Version("10.8.0"):
-                    print("Uninstalling old TensorRT version...")
-                    run_pip("uninstall -y tensorrt")
-            except:
-                # If packaging is not available, check version string directly
-                if current_version_str.startswith("9."):
-                    print("Uninstalling old TensorRT version...")
-                    run_pip("uninstall -y tensorrt")
+    if cuda_major == "12":
+        pins = TENSORRT_PINS["cu12"]
+        if cuda_version_float >= 12.8:
+            print("Installing TensorRT 10.12+ for CUDA 12.8+ (Blackwell GPU support)...")
+        else:
+            print("Installing TensorRT for CUDA 12.x...")
 
-    # For CUDA 12.8+ (RTX 5090/Blackwell support), use TensorRT 10.8+
-    if cuda_version_float >= 12.8:
-        print("Installing TensorRT 10.8+ for CUDA 12.8+ (Blackwell GPU support)...")
+        cudnn_name = pins["cudnn"]
+        tensorrt_pkg = pins["tensorrt"]
 
-        # Install cuDNN 9 for CUDA 12
-        cudnn_name = "nvidia-cudnn-cu12"
         print(f"Installing cuDNN: {cudnn_name}")
         run_pip(f"install {cudnn_name} --no-cache-dir")
 
-        # Install TensorRT for CUDA 12 (RTX 5090/Blackwell support)
-        tensorrt_version = "tensorrt-cu12"
-        print(f"Installing TensorRT for CUDA {cu}: {tensorrt_version}")
-        run_pip(f"install {tensorrt_version} --no-cache-dir")
-
-    elif cuda_major == "12":
-        print("Installing TensorRT for CUDA 12.x...")
-
-        # Install cuDNN for CUDA 12
-        cudnn_name = "nvidia-cudnn-cu12"
-        print(f"Installing cuDNN: {cudnn_name}")
-        run_pip(f"install {cudnn_name} --no-cache-dir")
-
-        # Install TensorRT for CUDA 12
-        tensorrt_version = "tensorrt-cu12"
-        print(f"Installing TensorRT for CUDA {cu}: {tensorrt_version}")
-        run_pip(f"install {tensorrt_version} --no-cache-dir")
+        print(f"Installing TensorRT for CUDA {cu}: {tensorrt_pkg}")
+        run_pip(f"install --extra-index-url https://pypi.nvidia.com {tensorrt_pkg} --no-cache-dir")
 
     elif cuda_major == "11":
+        pins = TENSORRT_PINS["cu11"]
         print("Installing TensorRT for CUDA 11.x...")
 
-        # Install cuDNN for CUDA 11
-        cudnn_name = "nvidia-cudnn-cu11==8.9.4.25"
+        cudnn_name = pins["cudnn"]
+        tensorrt_pkg = pins["tensorrt"]
+
         print(f"Installing cuDNN: {cudnn_name}")
         run_pip(f"install {cudnn_name} --no-cache-dir")
 
-        # Install TensorRT for CUDA 11
-        tensorrt_version = "tensorrt==9.0.1.post11.dev4"
-        print(f"Installing TensorRT for CUDA {cu}: {tensorrt_version}")
+        print(f"Installing TensorRT for CUDA {cu}: {tensorrt_pkg}")
         run_pip(
-            f"install --pre --extra-index-url https://pypi.nvidia.com {tensorrt_version} --no-cache-dir"
+            f"install --pre --extra-index-url https://pypi.nvidia.com {tensorrt_pkg} --no-cache-dir"
         )
     else:
         print(f"Unsupported CUDA version: {cu}")
         print("Supported versions: CUDA 11.x, 12.x")
         return
 
-    # Install additional TensorRT tools
+    # Install additional TensorRT tools (pinned versions)
     if not is_installed("polygraphy"):
         print("Installing polygraphy...")
         run_pip(
-            "install polygraphy --extra-index-url https://pypi.ngc.nvidia.com --no-cache-dir"
+            f"install {TENSORRT_PINS['polygraphy']} --extra-index-url https://pypi.ngc.nvidia.com --no-cache-dir"
         )
     if not is_installed("onnx_graphsurgeon"):
         print("Installing onnx-graphsurgeon...")
         run_pip(
-            "install onnx-graphsurgeon --extra-index-url https://pypi.ngc.nvidia.com --no-cache-dir"
+            f"install {TENSORRT_PINS['onnx_graphsurgeon']} --extra-index-url https://pypi.ngc.nvidia.com --no-cache-dir"
         )
     if platform.system() == "Windows" and not is_installed("pywin32"):
         print("Installing pywin32...")
-        run_pip("install pywin32 --no-cache-dir")
+        run_pip(f"install {TENSORRT_PINS['pywin32']} --no-cache-dir")
+    if platform.system() == "Windows" and not is_installed("triton"):
+        print("Installing triton-windows...")
+        run_pip(f"install {TENSORRT_PINS['triton_windows']} --no-cache-dir")
 
     print("TensorRT installation completed successfully!")
 

--- a/StreamDiffusionTD/install_tensorrt.py
+++ b/StreamDiffusionTD/install_tensorrt.py
@@ -1,0 +1,158 @@
+"""
+Standalone TensorRT installation script for StreamDiffusionTD
+This is a self-contained version that doesn't rely on the streamdiffusion package imports
+"""
+
+import platform
+import subprocess
+import sys
+from typing import Optional
+
+
+def run_pip(command: str):
+    """Run pip command with proper error handling"""
+    return subprocess.check_call([sys.executable, "-m", "pip"] + command.split())
+
+
+def is_installed(package_name: str) -> bool:
+    """Check if a package is installed"""
+    try:
+        __import__(package_name.replace("-", "_"))
+        return True
+    except ImportError:
+        return False
+
+
+def version(package_name: str) -> Optional[str]:
+    """Get version of installed package"""
+    try:
+        import importlib.metadata
+
+        return importlib.metadata.version(package_name)
+    except:
+        return None
+
+
+def get_cuda_version_from_torch() -> Optional[str]:
+    try:
+        import torch
+    except ImportError:
+        return None
+
+    cuda_version = torch.version.cuda
+    if cuda_version:
+        # Return full version like "12.8" for better detection
+        major_minor = ".".join(cuda_version.split(".")[:2])
+        return major_minor
+    return None
+
+
+def install(cu: Optional[str] = None):
+    if cu is None:
+        cu = get_cuda_version_from_torch()
+
+    if cu is None:
+        print("Could not detect CUDA version. Please specify manually.")
+        return
+
+    print(f"Detected CUDA version: {cu}")
+    print("Installing TensorRT requirements...")
+
+    # Determine CUDA major version for package selection
+    cuda_major = cu.split(".")[0] if cu else "12"
+    cuda_version_float = float(cu) if cu else 12.0
+
+    # Skip nvidia-pyindex - it's broken with pip 25.3+ and not actually needed
+    # The NVIDIA index is already accessible via pip config or environment variables
+
+    # Uninstall old TensorRT versions
+    if is_installed("tensorrt"):
+        current_version_str = version("tensorrt")
+        if current_version_str:
+            try:
+                from packaging.version import Version
+
+                current_version = Version(current_version_str)
+                if current_version < Version("10.8.0"):
+                    print("Uninstalling old TensorRT version...")
+                    run_pip("uninstall -y tensorrt")
+            except:
+                # If packaging is not available, check version string directly
+                if current_version_str.startswith("9."):
+                    print("Uninstalling old TensorRT version...")
+                    run_pip("uninstall -y tensorrt")
+
+    # For CUDA 12.8+ (RTX 5090/Blackwell support), use TensorRT 10.8+
+    if cuda_version_float >= 12.8:
+        print("Installing TensorRT 10.8+ for CUDA 12.8+ (Blackwell GPU support)...")
+
+        # Install cuDNN 9 for CUDA 12
+        cudnn_name = "nvidia-cudnn-cu12"
+        print(f"Installing cuDNN: {cudnn_name}")
+        run_pip(f"install {cudnn_name} --no-cache-dir")
+
+        # Install TensorRT for CUDA 12 (RTX 5090/Blackwell support)
+        tensorrt_version = "tensorrt-cu12"
+        print(f"Installing TensorRT for CUDA {cu}: {tensorrt_version}")
+        run_pip(f"install {tensorrt_version} --no-cache-dir")
+
+    elif cuda_major == "12":
+        print("Installing TensorRT for CUDA 12.x...")
+
+        # Install cuDNN for CUDA 12
+        cudnn_name = "nvidia-cudnn-cu12"
+        print(f"Installing cuDNN: {cudnn_name}")
+        run_pip(f"install {cudnn_name} --no-cache-dir")
+
+        # Install TensorRT for CUDA 12
+        tensorrt_version = "tensorrt-cu12"
+        print(f"Installing TensorRT for CUDA {cu}: {tensorrt_version}")
+        run_pip(f"install {tensorrt_version} --no-cache-dir")
+
+    elif cuda_major == "11":
+        print("Installing TensorRT for CUDA 11.x...")
+
+        # Install cuDNN for CUDA 11
+        cudnn_name = "nvidia-cudnn-cu11==8.9.4.25"
+        print(f"Installing cuDNN: {cudnn_name}")
+        run_pip(f"install {cudnn_name} --no-cache-dir")
+
+        # Install TensorRT for CUDA 11
+        tensorrt_version = "tensorrt==9.0.1.post11.dev4"
+        print(f"Installing TensorRT for CUDA {cu}: {tensorrt_version}")
+        run_pip(
+            f"install --pre --extra-index-url https://pypi.nvidia.com {tensorrt_version} --no-cache-dir"
+        )
+    else:
+        print(f"Unsupported CUDA version: {cu}")
+        print("Supported versions: CUDA 11.x, 12.x")
+        return
+
+    # Install additional TensorRT tools
+    if not is_installed("polygraphy"):
+        print("Installing polygraphy...")
+        run_pip(
+            "install polygraphy==0.49.24 --extra-index-url https://pypi.ngc.nvidia.com --no-cache-dir"
+        )
+    if not is_installed("onnx_graphsurgeon"):
+        print("Installing onnx-graphsurgeon...")
+        run_pip(
+            "install onnx-graphsurgeon==0.5.8 --extra-index-url https://pypi.ngc.nvidia.com --no-cache-dir"
+        )
+    if platform.system() == "Windows" and not is_installed("pywin32"):
+        print("Installing pywin32...")
+        run_pip("install pywin32==306 --no-cache-dir")
+
+    # FP8 quantization dependencies (CUDA 12 only)
+    # nvidia-modelopt requires cupy; pin cupy 13.x + numpy<2 for mediapipe compat
+    if cuda_major == "12":
+        print("Installing FP8 quantization dependencies (nvidia-modelopt, cupy, numpy)...")
+        run_pip(
+            'install "nvidia-modelopt[onnx]" "cupy-cuda12x==13.6.0" "numpy==1.26.4" --no-cache-dir'
+        )
+
+    print("TensorRT installation completed successfully!")
+
+
+if __name__ == "__main__":
+    install()

--- a/StreamDiffusionTD/install_tensorrt.py
+++ b/StreamDiffusionTD/install_tensorrt.py
@@ -143,10 +143,12 @@ def install(cu: Optional[str] = None):
         print("Installing pywin32...")
         run_pip("install pywin32==306 --no-cache-dir")
 
-    # Pin onnx to IR 10 — onnxruntime-gpu 1.22 max supported IR version is 10
-    # (onnx 1.18+ exports IR 11/12 which breaks polygraphy constant folding)
-    print("Pinning onnx==1.17.0 (IR 10 for onnxruntime-gpu 1.22 compatibility)...")
-    run_pip("install onnx==1.17.0 --no-cache-dir")
+    # Pin onnx 1.18 + onnxruntime-gpu 1.24 together:
+    #   - onnx 1.18 exports IR 11; modelopt needs FLOAT4E2M1 added in 1.18
+    #   - onnx 1.19+ exports IR 12 (ORT 1.24 max) and removes float32_to_bfloat16 (onnx-gs needs it)
+    #   - onnxruntime-gpu 1.24 supports IR 11; never co-install CPU onnxruntime (shared files conflict)
+    print("Pinning onnx==1.18.0 + onnxruntime-gpu==1.24.3...")
+    run_pip("install onnx==1.18.0 onnxruntime-gpu==1.24.3 --no-cache-dir")
 
     # FP8 quantization dependencies (CUDA 12 only)
     # nvidia-modelopt requires cupy; pin cupy 13.x + numpy<2 for mediapipe compat

--- a/StreamDiffusionTD/install_tensorrt.py
+++ b/StreamDiffusionTD/install_tensorrt.py
@@ -132,31 +132,16 @@ def install(cu: Optional[str] = None):
     if not is_installed("polygraphy"):
         print("Installing polygraphy...")
         run_pip(
-            "install polygraphy==0.49.24 --extra-index-url https://pypi.ngc.nvidia.com --no-cache-dir"
+            "install polygraphy --extra-index-url https://pypi.ngc.nvidia.com --no-cache-dir"
         )
     if not is_installed("onnx_graphsurgeon"):
         print("Installing onnx-graphsurgeon...")
         run_pip(
-            "install onnx-graphsurgeon==0.5.8 --extra-index-url https://pypi.ngc.nvidia.com --no-cache-dir"
+            "install onnx-graphsurgeon --extra-index-url https://pypi.ngc.nvidia.com --no-cache-dir"
         )
     if platform.system() == "Windows" and not is_installed("pywin32"):
         print("Installing pywin32...")
-        run_pip("install pywin32==306 --no-cache-dir")
-
-    # Pin onnx 1.18 + onnxruntime-gpu 1.24 together:
-    #   - onnx 1.18 exports IR 11; modelopt needs FLOAT4E2M1 added in 1.18
-    #   - onnx 1.19+ exports IR 12 (ORT 1.24 max) and removes float32_to_bfloat16 (onnx-gs needs it)
-    #   - onnxruntime-gpu 1.24 supports IR 11; never co-install CPU onnxruntime (shared files conflict)
-    print("Pinning onnx==1.18.0 + onnxruntime-gpu==1.24.3...")
-    run_pip("install onnx==1.18.0 onnxruntime-gpu==1.24.3 --no-cache-dir")
-
-    # FP8 quantization dependencies (CUDA 12 only)
-    # nvidia-modelopt requires cupy; pin cupy 13.x + numpy<2 for mediapipe compat
-    if cuda_major == "12":
-        print("Installing FP8 quantization dependencies (nvidia-modelopt, cupy, numpy)...")
-        run_pip(
-            'install "nvidia-modelopt[onnx]" "cupy-cuda12x==13.6.0" "numpy==1.26.4" --no-cache-dir'
-        )
+        run_pip("install pywin32 --no-cache-dir")
 
     print("TensorRT installation completed successfully!")
 

--- a/StreamDiffusionTD/requirements_mac.txt
+++ b/StreamDiffusionTD/requirements_mac.txt
@@ -1,0 +1,13 @@
+git+https://github.com/dotsimulate/StreamDiffusion.git@main#egg=streamdiffusion
+
+huggingface-hub==0.24.6
+numpy==1.24.1
+opencv-python
+Pillow
+fire
+mss
+matplotlib
+python-osc
+einops
+peft==0.12.0
+syphon-python

--- a/StreamDiffusionTD/syphon_utils.py
+++ b/StreamDiffusionTD/syphon_utils.py
@@ -1,0 +1,433 @@
+import numpy as np
+import syphon
+from syphon.server_directory import SyphonServerDirectory
+import Metal
+import objc
+import warnings
+
+# Suppress ObjCPointer warnings
+warnings.filterwarnings("ignore", category=objc.ObjCPointerWarning)
+
+class SyphonClientWrapper:
+    def __init__(self, native_client, width=512, height=512, debug=False):
+        self._client = native_client
+        self.width = width
+        self.height = height
+        self.debug = debug
+        
+        # Create Metal device for texture handling
+        import Metal
+        self.device = Metal.MTLCreateSystemDefaultDevice()
+        self.command_queue = self.device.newCommandQueue()
+        
+        if self.debug:
+            print(f"\nInitialized with Metal device: {self.device}")
+            print(f"Expected dimensions: {width}x{height}")
+        
+        # Get server description
+        desc = self._client.serverDescription()
+        if desc and self.debug:
+            print("\nServer Description:")
+            for key in desc.allKeys():
+                print(f"- {key}: {desc[key]}")
+        
+    @property
+    def has_new_frame(self):
+        try:
+            if self._client is None:
+                return False
+                
+            # Get server description before checking frame
+            desc = self._client.serverDescription()
+            if desc and self.debug:
+                print("\nCurrent Server State:")
+                for key in desc.allKeys():
+                    print(f"- {key}: {desc[key]}")
+            
+            result = self._client.hasNewFrame()
+            if self.debug:
+                print(f"Has new frame: {result}")
+            
+            # Try to get surface info - IMPORTANT: Keep this regardless of debug mode
+            try:
+                surface = self._client.newSurface()
+                if surface and self.debug:
+                    print(f"Surface available: {surface}")
+            except Exception as e:
+                if self.debug:
+                    print(f"Surface check error: {e}")
+            
+            return bool(result)
+        except Exception as e:
+            if self.debug:
+                print(f"Error checking for new frame: {e}")
+            return False
+        
+    @property
+    def new_frame_image(self):
+        """Get new frame as a numpy array directly to avoid texture leaks"""
+        try:
+            if self._client is None:
+                return None
+                
+            import objc
+            pool = objc.autorelease_pool()
+            with pool:
+                if self.debug:
+                    print("\nTrying to get frame via IOSurface...")
+                
+                # Get the IOSurface
+                surface = self._client.newSurface()
+                if surface is None:
+                    if self.debug:
+                        print("No IOSurface available")
+                    return None
+                    
+                if self.debug:
+                    print(f"Got IOSurface: {surface}")
+                
+                # Create a texture descriptor for the known dimensions
+                descriptor = Metal.MTLTextureDescriptor.new()
+                descriptor.setTextureType_(Metal.MTLTextureType2D)
+                descriptor.setPixelFormat_(Metal.MTLPixelFormatBGRA8Unorm)
+                descriptor.setWidth_(self.width)
+                descriptor.setHeight_(self.height)
+                descriptor.setStorageMode_(Metal.MTLStorageModeShared)  # Keep Shared for CPU access
+                descriptor.setUsage_(Metal.MTLTextureUsageShaderRead)
+                
+                # Create a texture from the IOSurface
+                try:
+                    texture = self.device.newTextureWithDescriptor_iosurface_plane_(
+                        descriptor,
+                        surface,
+                        0
+                    )
+                    
+                    if texture is None:
+                        if self.debug:
+                            print("Failed to create texture from IOSurface")
+                        return None
+                        
+                    if self.debug:
+                        print(f"Created texture with dimensions: {texture.width()} x {texture.height()}")
+                    
+                    # Create a command buffer to synchronize the texture
+                    command_buffer = self.command_queue.commandBuffer()
+                    command_buffer.commit()
+                    command_buffer.waitUntilCompleted()
+                    
+                    # Convert texture to numpy array
+                    width = texture.width()
+                    height = texture.height()
+                    bytes_per_row = width * 4
+                    buffer = bytearray(height * bytes_per_row)
+                    
+                    region = Metal.MTLRegionMake2D(0, 0, width, height)
+                    texture.getBytes_bytesPerRow_fromRegion_mipmapLevel_(
+                        buffer,
+                        bytes_per_row,
+                        region,
+                        0
+                    )
+                    
+                    # Release texture immediately
+                    texture.setPurgeableState_(Metal.MTLPurgeableStateEmpty)
+                    
+                    # Return numpy array
+                    frame = np.frombuffer(buffer, dtype=np.uint8).reshape(height, width, 4)
+                    return frame
+                    
+                except Exception as e:
+                    if self.debug:
+                        print(f"Error creating texture from IOSurface: {e}")
+                        import traceback
+                        print(traceback.format_exc())
+                    return None
+                
+        except Exception as e:
+            if self.debug:
+                print(f"Error getting frame image: {e}")
+                import traceback
+                print(traceback.format_exc())
+            return None
+
+    def stop(self):
+        try:
+            if self._client is not None:
+                self._client.stop()
+                self._client = None
+            
+            # Release Metal resources
+            if hasattr(self, 'command_queue'):
+                self.command_queue.release()
+                self.command_queue = None
+        except Exception as e:
+            if self.debug:
+                print(f"Error stopping client: {e}")
+
+class SyphonUtils:
+    def __init__(self, sender_name="StreamDiffusion", input_name=None, control_name=None, width=512, height=512, debug=False):
+        if debug:
+            print(f"\n=== Initializing SyphonUtils ===")
+            print(f"Sender name: {sender_name}")
+            print(f"Input name: {input_name}")
+            print(f"Control name: {control_name}")
+            print(f"Dimensions: {width}x{height}")
+        
+        self.sender_name = sender_name
+        self.input_name = input_name
+        self.control_name = control_name
+        self.width = width
+        self.height = height
+        self.debug = debug
+        
+        self.server = None
+        self.input_client = None
+        self.control_client = None
+        self.directory = SyphonServerDirectory()
+
+    def start(self):
+        try:
+            # List all available Syphon servers
+            servers = self.directory.servers
+            if self.debug:
+                print(f"\n=== Available Syphon Servers ===")
+                for server in servers:
+                    print(f"App Name: {server.app_name}")
+                    print(f"Name: {server.name}")
+                    print(f"UUID: {server.uuid}")
+                    print("---")
+
+            # Initialize server
+            self.server = syphon.SyphonMetalServer(self.sender_name)
+            if self.debug:
+                print(f"=== Syphon Server Initialized ===")
+                print(f"Name: {self.sender_name}")
+                print(f"Device: {self.server.device}")
+
+            if self.input_name:
+                self._connect_client('input')
+            if self.control_name:
+                self._connect_client('control')
+
+        except Exception as e:
+            if self.debug:
+                print(f"Error initializing Syphon: {e}")
+
+    def transmit_frame(self, frame):
+        if self.server is None:
+            return
+
+        try:
+            # Fix frame shape if it's (1, H, W, C)
+            if len(frame.shape) == 4 and frame.shape[0] == 1:
+                frame = frame[0]  # Remove batch dimension
+                if self.debug:
+                    print(f"Removed batch dimension. New shape: {frame.shape}")
+
+            # Ensure frame is contiguous and RGBA
+            frame = np.ascontiguousarray(frame)
+            if frame.shape[2] == 3:
+                alpha = np.full((frame.shape[0], frame.shape[1], 1), 255, dtype=np.uint8)
+                frame = np.concatenate([frame, alpha], axis=2)
+                frame = np.ascontiguousarray(frame)  # Ensure the concatenated array is contiguous
+
+            # Create texture
+            descriptor = Metal.MTLTextureDescriptor.texture2DDescriptorWithPixelFormat_width_height_mipmapped_(
+                Metal.MTLPixelFormatRGBA8Unorm,
+                frame.shape[1],  # width
+                frame.shape[0],  # height
+                False
+            )
+            descriptor.setStorageMode_(Metal.MTLStorageModeShared)
+            descriptor.setUsage_(Metal.MTLTextureUsageShaderRead)
+            
+            texture = self.server.device.newTextureWithDescriptor_(descriptor)
+            
+            # Copy frame data
+            region = Metal.MTLRegionMake2D(0, 0, frame.shape[1], frame.shape[0])
+            frame_bytes = frame.tobytes()
+            bytes_per_row = frame.shape[1] * 4  # RGBA = 4 bytes per pixel
+            
+            texture.replaceRegion_mipmapLevel_withBytes_bytesPerRow_(
+                region,
+                0,
+                frame_bytes,
+                bytes_per_row
+            )
+            
+            # Publish
+            self.server.publish_frame_texture(texture, is_flipped=True)
+            
+            # Mark texture as purgeable to help with memory management
+            texture.setPurgeableState_(Metal.MTLPurgeableStateEmpty)
+            
+            if self.debug:
+                print(f"Transmitted frame via Syphon")
+
+        except Exception as e:
+            if self.debug:
+                print(f"Error transmitting Syphon frame: {e}")
+                import traceback
+                print(traceback.format_exc())
+            
+    def _connect_client(self, client_type='input'):
+        name = self.input_name if client_type == 'input' else self.control_name
+        try:
+            if self.debug:
+                print(f"\n=== Connecting {client_type} Client ===")
+                print(f"Looking for server: {name}")
+            
+            import objc
+            SyphonServerDirectory = objc.lookUpClass('SyphonServerDirectory')
+            directory = SyphonServerDirectory.sharedDirectory()
+            
+            # Get servers directly from Objective-C
+            servers = directory.servers()
+            
+            for server_desc in servers:
+                app_name = str(server_desc.objectForKey_('SyphonServerDescriptionAppNameKey') or '')
+                server_name = str(server_desc.objectForKey_('SyphonServerDescriptionNameKey') or '')
+                
+                if self.debug:
+                    print(f"Checking server: {app_name} - {server_name}")
+                
+                if app_name == name or server_name == name:
+                    if self.debug:
+                        print(f"\nFound Matching Server: {server_name}")
+                    
+                    try:
+                        # Create the client using Objective-C bridge directly
+                        SyphonClient = objc.lookUpClass('SyphonClient')
+                        native_client = SyphonClient.alloc().initWithServerDescription_options_newFrameHandler_(
+                            server_desc,
+                            None,
+                            None
+                        )
+                        
+                        if native_client:
+                            wrapped_client = SyphonClientWrapper(
+                                native_client,
+                                width=self.width,
+                                height=self.height,
+                                debug=self.debug
+                            )
+                            
+                            if client_type == 'input':
+                                if self.input_client is not None:
+                                    self.input_client.stop()
+                                self.input_client = wrapped_client
+                            else:
+                                if self.control_client is not None:
+                                    self.control_client.stop()
+                                self.control_client = wrapped_client
+                                
+                            if self.debug:
+                                print(f"Connected to {client_type} Syphon server: {name}")
+                            return True
+                        else:
+                            if self.debug:
+                                print(f"Failed to create client for: {name}")
+                    
+                    except Exception as e:
+                        if self.debug:
+                            print(f"\n=== Client Creation Error ===")
+                            print(f"Error: {e}")
+                            import traceback
+                            print(traceback.format_exc())
+            
+            if self.debug:
+                print(f"Warning: No matching Syphon server found for name: {name}")
+            return False
+                
+        except Exception as e:
+            if self.debug:
+                print(f"Error connecting to {client_type} Syphon server: {e}")
+                import traceback
+                print(traceback.format_exc())
+            return False
+
+    def capture_input_frame(self):
+        if self.input_client is None:
+            return None
+
+        try:
+            if not self.input_client.has_new_frame:
+                if self.debug:
+                    print("No new input frame available")
+                return None
+
+            if self.debug:
+                print("\n=== Capturing Input Frame ===")
+            
+            # Get frame directly as numpy array to avoid texture leaks
+            frame = self.input_client.new_frame_image
+            if frame is None:
+                return None
+            
+            # Convert RGBA to RGB
+            if frame.shape[2] == 4:
+                frame = frame[:, :, :3]
+                if self.debug:
+                    print(f"Converted to RGB. New shape: {frame.shape}")
+            
+            return frame
+                
+        except Exception as e:
+            if self.debug:
+                print(f"Error capturing input frame: {e}")
+                import traceback
+                print(traceback.format_exc())
+            return None
+
+    def capture_control_frame(self):
+        if self.control_client is None:
+            return None
+
+        try:
+            if not self.control_client.has_new_frame:
+                if self.debug:
+                    print("No new control frame available")
+                return None
+
+            if self.debug:
+                print("\n=== Capturing Control Frame ===")
+            
+            # Get frame directly as numpy array to avoid texture leaks
+            frame = self.control_client.new_frame_image
+            if frame is None:
+                return None
+            
+            # Convert RGBA to RGB
+            if frame.shape[2] == 4:
+                frame = frame[:, :, :3]
+                if self.debug:
+                    print(f"Converted to RGB. New shape: {frame.shape}")
+            
+            return frame
+            
+        except Exception as e:
+            if self.debug:
+                print(f"Error capturing control frame: {e}")
+                import traceback
+                print(traceback.format_exc())
+            return None
+
+    def stop(self):
+        if self.debug:
+            print("\n=== Stopping Syphon ===")
+        if self.server:
+            self.server.stop()
+            self.server = None
+            if self.debug:
+                print("Server stopped")
+        if self.input_client:
+            self.input_client.stop()
+            self.input_client = None
+            if self.debug:
+                print("Input client stopped")
+        if self.control_client:
+            self.control_client.stop()
+            self.control_client = None
+            if self.debug:
+                print("Control client stopped")

--- a/StreamDiffusionTD/td_config.yaml
+++ b/StreamDiffusionTD/td_config.yaml
@@ -1,0 +1,77 @@
+
+model_id: "stabilityai/sdxl-turbo"
+
+# Core StreamDiffusion parameters
+t_index_list: [9, 32]
+width: 512
+height: 512
+device: "cuda"
+dtype: "float16"
+
+# Generation parameters (defaults, can be updated via OSC)
+guidance_scale: 1.0
+num_inference_steps: 50
+seed: 3972332
+delta: 1.0
+
+# Prompt configuration (supports both single and blending)
+prompt: "default fancy banana"
+negative_prompt: "only work with cfg = full"
+
+# Optimization settings
+mode: "img2img"  # Always use img2img engines (mode switching handled at runtime)
+frame_buffer_size: 1
+use_denoising_batch: true
+use_tiny_vae: true
+acceleration: "tensorrt"
+fp8: true
+cfg_type: "self"
+do_add_noise: true
+warmup: 10
+use_safety_checker: false
+skip_diffusion: false
+compile_engines_only: false
+build_engines_if_missing: true
+
+# Scheduler and sampler (TCD/StreamV2V support)
+scheduler: "lcm"
+sampler: "normal"
+
+# StreamV2V Cached Attention (Cattenable enables, Cattmaxframes/Cattinterval tune)
+use_cached_attn: true
+cache_maxframes: 3
+cache_interval: 1
+
+# Image filtering (similar frame skip)
+enable_similar_image_filter: true
+similar_image_filter_threshold: 0.9
+similar_image_filter_max_skip_frame: 0
+
+# HuggingFace cache directory (for model downloads)
+hf_cache: ""
+
+# TensorRT engine directory
+engine_dir: "D:/Users/alexk/FORKNI/STREAM_DIFFUSION/STREAM_DIFFUSION_LIVEPEER/StreamDiffusion/engines/td"
+
+# ControlNet configuration (disabled)
+use_controlnet: false
+
+# IPAdapter configuration (disabled)
+use_ipadapter: false
+
+
+
+
+
+# TouchDesigner specific settings
+td_settings:
+  # OSC communication
+  osc_receive_port: 8569
+  osc_transmit_port: 8578
+  
+  # Memory interface
+  input_mem_name: "StreamDiffusionTD_512-512"
+  output_mem_name: "StreamDiffusionTD_512-512_out"
+  
+  # Debug settings
+  debug_mode: true

--- a/StreamDiffusionTD/td_config.yaml
+++ b/StreamDiffusionTD/td_config.yaml
@@ -2,7 +2,7 @@
 model_id: "stabilityai/sdxl-turbo"
 
 # Core StreamDiffusion parameters
-t_index_list: [9, 32]
+t_index_list: [12, 22]
 width: 512
 height: 512
 device: "cuda"
@@ -23,7 +23,7 @@ mode: "img2img"  # Always use img2img engines (mode switching handled at runtime
 frame_buffer_size: 1
 use_denoising_batch: true
 use_tiny_vae: true
-acceleration: "tensorrt"
+acceleration: "none"
 fp8: true
 cfg_type: "self"
 do_add_noise: true
@@ -39,7 +39,7 @@ sampler: "normal"
 
 # StreamV2V Cached Attention (Cattenable enables, Cattmaxframes/Cattinterval tune)
 use_cached_attn: true
-cache_maxframes: 3
+cache_maxframes: 4
 cache_interval: 1
 
 # Image filtering (similar frame skip)
@@ -53,8 +53,13 @@ hf_cache: ""
 # TensorRT engine directory
 engine_dir: "D:/Users/alexk/FORKNI/STREAM_DIFFUSION/STREAM_DIFFUSION_LIVEPEER/StreamDiffusion/engines/td"
 
-# ControlNet configuration (disabled)
-use_controlnet: false
+# ControlNet configuration
+use_controlnet: true
+controlnets:
+  - model_id: "xinsir/controlnet-canny-sdxl-1.0"
+    conditioning_scale: 0.536
+    preprocessor: "canny"
+    enabled: true
 
 # IPAdapter configuration (disabled)
 use_ipadapter: false

--- a/StreamDiffusionTD/td_main.py
+++ b/StreamDiffusionTD/td_main.py
@@ -1,0 +1,537 @@
+"""
+TouchDesigner StreamDiffusion Main Entry Point
+
+Minimal main script leveraging the full DotSimulate StreamDiffusion fork capabilities.
+Replaces the complex main_sdtd.py with a cleaner, config-driven approach.
+
+Reads configuration from td_config.yaml (single source of truth)
+"""
+
+import logging
+import os
+import sys
+import threading
+import time
+
+import yaml
+from pythonosc import udp_client
+
+
+class OSCReporter:
+    """
+    Lightweight OSC reporter for state, telemetry, and errors.
+    Lives at module level - starts before any heavy imports.
+    No dependencies on torch, diffusers, or StreamDiffusion.
+    """
+
+    def __init__(self, transmit_ip: str, transmit_port: int):
+        self.client = udp_client.SimpleUDPClient(transmit_ip, transmit_port)
+        self._heartbeat_running = False
+        self._heartbeat_thread = None
+        self._current_state = "local_offline"
+        self._vram_monitor_thread = None
+        self._vram_monitor_running = False
+
+    # === Heartbeat ===
+    def start_heartbeat(self) -> None:
+        """Start server heartbeat immediately (Serveractive=True in TD)"""
+        if self._heartbeat_running:
+            return
+        self._heartbeat_running = True
+        self._heartbeat_thread = threading.Thread(
+            target=self._heartbeat_loop, daemon=True
+        )
+        self._heartbeat_thread.start()
+
+    def stop_heartbeat(self) -> None:
+        self._heartbeat_running = False
+
+    def _heartbeat_loop(self) -> None:
+        while self._heartbeat_running:
+            self.client.send_message("/server_active", 1)
+            # Also send current state with heartbeat (every 1-2 seconds during startup)
+            if self._current_state:
+                self.client.send_message("/stream-info/state", self._current_state)
+            time.sleep(1.0)
+
+    # === State Management ===
+    def set_state(self, state: str) -> None:
+        """Set and broadcast connection state"""
+        self._current_state = state
+        self.client.send_message("/stream-info/state", state)
+
+    def send_error(self, error_msg: str, error_time: int = None) -> None:
+        """Send error message with timestamp"""
+        if error_time is None:
+            error_time = int(time.time() * 1000)
+        self.client.send_message("/stream-info/error", error_msg)
+        self.client.send_message("/stream-info/error-time", error_time)
+
+    # === Telemetry (called by manager) ===
+    def send_output_name(self, name: str) -> None:
+        self.client.send_message("/stream-info/output-name", name)
+
+    def send_frame_count(self, count: int) -> None:
+        self.client.send_message("/framecount", count)
+
+    def send_frame_ready(self, count: int) -> None:
+        self.client.send_message("/frame_ready", count)
+
+    def send_fps(self, fps: float) -> None:
+        self.client.send_message("/stream-info/fps", fps)
+
+    def send_controlnet_processed_name(self, name: str) -> None:
+        self.client.send_message("/stream-info/controlnet-processed-name", name)
+
+    # === VRAM Monitoring (Non-Blocking) ===
+    def start_vram_monitoring(self, interval: float = 2.0) -> None:
+        """Start periodic VRAM monitoring (every 2 seconds by default)"""
+        if self._vram_monitor_running:
+            return
+        self._vram_monitor_running = True
+        self._vram_monitor_thread = threading.Thread(
+            target=self._vram_monitor_loop, args=(interval,), daemon=True
+        )
+        self._vram_monitor_thread.start()
+
+    def stop_vram_monitoring(self) -> None:
+        self._vram_monitor_running = False
+
+    def _vram_monitor_loop(self, interval: float) -> None:
+        """Periodic VRAM monitoring using torch.cuda.mem_get_info() for accurate tracking"""
+        import torch
+
+        while self._vram_monitor_running:
+            try:
+                if torch.cuda.is_available():
+                    # Use mem_get_info() to get ACTUAL free/total VRAM (includes TensorRT!)
+                    free_cuda, total_cuda = torch.cuda.mem_get_info(
+                        0
+                    )  # Returns (free, total) in bytes
+                    total = total_cuda / (1024**3)
+                    used = (total_cuda - free_cuda) / (
+                        1024**3
+                    )  # ACTUAL usage including TensorRT
+
+                    # Only send useful metrics (total and used)
+                    self.client.send_message("/vram/total", total)
+                    self.client.send_message("/vram/used", used)
+
+            except Exception:
+                pass  # Silently skip if monitoring fails
+
+            time.sleep(interval)
+
+    # === Engine Building Progress ===
+    def send_engine_progress(self, stage: str, model_name: str = "") -> None:
+        """
+        Send engine building progress.
+        Stages: 'exporting_onnx', 'optimizing_onnx', 'building_engine', 'cached', 'complete'
+        """
+        self.client.send_message("/engine/stage", stage)
+        if model_name:
+            self.client.send_message("/engine/model", model_name)
+
+
+class OSCLoggingHandler(logging.Handler):
+    """
+    Custom logging handler that sends ERROR logs to TouchDesigner via OSC.
+    Also captures engine building progress messages.
+    """
+
+    def __init__(self, osc_reporter: OSCReporter):
+        super().__init__()
+        self.osc_reporter = osc_reporter
+        # Only capture ERROR and CRITICAL
+        self.setLevel(logging.ERROR)
+
+    def emit(self, record: logging.LogRecord):
+        try:
+            # Check if this is a reportable error (from report_error())
+            if hasattr(record, "report_error") and record.report_error:
+                error_msg = self.format(record)
+                self.osc_reporter.send_error(error_msg)
+
+            # Also send all ERROR/CRITICAL logs
+            elif record.levelno >= logging.ERROR:
+                error_msg = self.format(record)
+                self.osc_reporter.send_error(error_msg)
+
+            # Capture engine building progress from log messages
+            msg = record.getMessage()
+            if "Exporting model:" in msg:
+                model_name = msg.split("Exporting model:")[-1].strip()
+                self.osc_reporter.send_engine_progress("exporting_onnx", model_name)
+            elif "Generating optimizing model:" in msg:
+                model_name = msg.split("Generating optimizing model:")[-1].strip()
+                self.osc_reporter.send_engine_progress("optimizing_onnx", model_name)
+            elif "Found cached engine:" in msg:
+                self.osc_reporter.send_engine_progress("cached")
+            elif "Building TensorRT engine" in msg or "Building engine" in msg:
+                self.osc_reporter.send_engine_progress("building_engine")
+
+        except Exception:
+            self.handleError(record)
+
+
+# Read config FIRST
+script_dir = os.path.dirname(os.path.abspath(__file__))
+yaml_config_path = os.path.join(script_dir, "td_config.yaml")
+with open(yaml_config_path, "r") as f:
+    yaml_config = yaml.safe_load(f)
+
+td_settings = yaml_config.get("td_settings", {})
+osc_port = td_settings.get("osc_receive_port", 8567)
+
+# Create reporter and start heartbeat IMMEDIATELY
+osc_reporter = OSCReporter("127.0.0.1", osc_port)
+osc_reporter.start_heartbeat()  # Serveractive=True NOW in TouchDesigner
+osc_reporter.start_vram_monitoring(interval=2.0)  # Monitor VRAM every 2 seconds
+osc_reporter.set_state("local_starting_server")
+
+# Add OSC logging handler to root logger (captures all logs)
+osc_log_handler = OSCLoggingHandler(osc_reporter)
+logging.root.addHandler(osc_log_handler)
+
+
+import signal
+import warnings
+
+
+# Configure warnings to display in dark cyan (low saturation, dark) BEFORE any imports
+def warning_format(message, category, filename, lineno, file=None, line=None):
+    return f"\033[38;5;66m{filename}:{lineno}: {category.__name__}: {message}\033[0m\n"
+
+
+warnings.formatwarning = warning_format
+
+# Loading animation
+print("\033[38;5;80mLoading StreamDiffusionTD", end="", flush=True)
+for _ in range(3):
+    time.sleep(0.33)
+    print(".", end="", flush=True)
+print("\033[0m")
+time.sleep(0.01)
+
+# Clear the loading line and add spacing
+print("\r" + " " * 50 + "\r", end="")  # Clear line
+print("\n")  # One blank line
+
+# ASCII Art Logo
+print("\033[38;5;208m     ┌──────────────────────────────────────┐")
+print("     │ ▶ StreamDiffusionTD                  │")
+print("     │ ▓▓▒▒░░ real-time diffusion           │")
+print("     │ ░░▒▒▓▓ TOX by dotsimulate            │")
+print("     │ ────────────────────────── v0.3.0    │")
+print("     └──────────────────────────────────────┘")
+print("     StreamDiffusion: cumulo-autumn • Daydream\033[0m\n\n")
+
+# Add StreamDiffusion to path
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+# Suppress known third-party deprecation warnings (timm, cuda-python, controlnet_aux)
+import warnings
+
+warnings.filterwarnings(
+    "ignore", message=".*timm.models.layers.*", category=FutureWarning
+)
+warnings.filterwarnings(
+    "ignore", message=".*timm.models.registry.*", category=FutureWarning
+)
+warnings.filterwarnings("ignore", message=".*cuda.cudart.*", category=FutureWarning)
+warnings.filterwarnings("ignore", message=".*not expected and will be ignored.*")
+warnings.filterwarnings(
+    "ignore", message=".*Overwriting tiny_vit.*", category=UserWarning
+)
+
+# Heavy imports with error handling
+try:
+    print("\033[38;5;66mImporting StreamDiffusion modules...\033[0m")
+    from td_manager import TouchDesignerManager
+    from td_osc_handler import OSCParameterHandler
+
+    print("\033[38;5;34m✓ Imports loaded\033[0m\n")
+except ImportError as e:
+    error_msg = f"Import failed: {e}"
+    logging.error(error_msg)  # Also log so it appears in console
+    osc_reporter.send_error(error_msg)
+    osc_reporter.set_state("local_error")
+    raise
+except Exception as e:
+    error_msg = f"Initialization failed: {e}"
+    logging.error(error_msg)  # Also log so it appears in console
+    osc_reporter.send_error(error_msg)
+    osc_reporter.set_state("local_error")
+    raise
+
+# Print YAML config in sections with animated display
+print()  # One blank line before YAML
+script_dir = os.path.dirname(os.path.abspath(__file__))
+yaml_config_path = os.path.join(script_dir, "td_config.yaml")
+
+with open(yaml_config_path, "r") as f:
+    yaml_content = f.read()
+
+# Split into sections based on top-level keys or comment headers
+current_section = []
+lines = yaml_content.split("\n")
+
+for line in lines:
+    stripped = line.lstrip()
+
+    # Check if this is a section break (top-level key or major comment)
+    is_section_break = (
+        (not stripped or stripped.startswith("#"))
+        and current_section
+        and any(l.strip() and not l.strip().startswith("#") for l in current_section)
+    )
+
+    if is_section_break:
+        # Print accumulated section
+        for section_line in current_section:
+            section_stripped = section_line.lstrip()
+            if not section_stripped or section_stripped.startswith("#"):
+                print(f"\033[38;5;66m  {section_line}\033[0m")
+            else:
+                indent = len(section_line) - len(section_stripped)
+                if indent == 0:
+                    print(f"\033[38;5;80m  {section_line}\033[0m")
+                elif indent == 2:
+                    print(f"\033[38;5;75m  {section_line}\033[0m")
+                elif indent == 4:
+                    print(f"\033[38;5;105m  {section_line}\033[0m")
+                else:
+                    print(f"\033[38;5;111m  {section_line}\033[0m")
+        time.sleep(0.05)  # 50ms delay between sections
+        current_section = [line]
+    else:
+        current_section.append(line)
+
+# Print final section
+for section_line in current_section:
+    section_stripped = section_line.lstrip()
+    if not section_stripped or section_stripped.startswith("#"):
+        print(f"\033[38;5;66m  {section_line}\033[0m")
+    else:
+        indent = len(section_line) - len(section_stripped)
+        if indent == 0:
+            print(f"\033[38;5;80m  {section_line}\033[0m")
+        elif indent == 2:
+            print(f"\033[38;5;75m  {section_line}\033[0m")
+        elif indent == 4:
+            print(f"\033[38;5;105m  {section_line}\033[0m")
+        else:
+            print(f"\033[38;5;111m  {section_line}\033[0m")
+
+
+class ColoredFormatter(logging.Formatter):
+    """Custom formatter with ANSI color codes for different log levels"""
+
+    # ANSI color codes
+    GREY = "\033[90m"
+    CYAN = "\033[36m"
+    YELLOW = "\033[33m"
+    RED = "\033[31m"
+    BOLD_RED = "\033[91m"
+    RESET = "\033[0m"
+
+    FORMATS = {
+        logging.DEBUG: GREY
+        + "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        + RESET,
+        logging.INFO: GREY
+        + "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        + RESET,
+        logging.WARNING: YELLOW
+        + "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        + RESET,
+        logging.ERROR: RED
+        + "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        + RESET,
+        logging.CRITICAL: BOLD_RED
+        + "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        + RESET,
+    }
+
+    def format(self, record):
+        log_fmt = self.FORMATS.get(record.levelno)
+        formatter = logging.Formatter(log_fmt, datefmt="%H:%M:%S")
+        return formatter.format(record)
+
+
+class StreamDiffusionTD:
+    """Main application class"""
+
+    def __init__(self, osc_reporter):
+        self.osc_reporter = osc_reporter  # Store reporter reference
+
+        # Load YAML config first to get debug_mode setting
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        yaml_config_path = os.path.join(script_dir, "td_config.yaml")
+
+        from streamdiffusion.config import load_config
+
+        yaml_config = load_config(yaml_config_path)
+
+        # Get TouchDesigner-specific settings from YAML
+        td_settings = yaml_config.get("td_settings", {})
+
+        # Configure logging based on debug_mode from YAML
+        debug_mode = td_settings.get("debug_mode", False)
+        log_level = logging.DEBUG if debug_mode else logging.WARNING
+
+        # Configure root logger with colored formatter
+        root_logger = logging.getLogger()
+        root_logger.setLevel(log_level)
+
+        # Remove existing handlers (except our OSC handler)
+        for handler in root_logger.handlers[:]:
+            if not isinstance(handler, OSCLoggingHandler):
+                root_logger.removeHandler(handler)
+
+        # Add colored console handler
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(log_level)
+        console_handler.setFormatter(ColoredFormatter())
+        root_logger.addHandler(console_handler)
+
+        # Show debug mode status if enabled
+        if debug_mode:
+            print("\033[38;5;208m    [DEBUG MODE ENABLED]\033[0m\n")
+
+        input_mem = td_settings.get("input_mem_name", "input_stream")
+
+        # Make output memory name unique (prevents conflicts & different resolutions)
+        base_output_name = td_settings.get("output_mem_name", "sd_to_td")
+        output_mem = f"{base_output_name}_{int(time.time())}"
+
+        # Get OSC ports from YAML
+        listen_port = td_settings.get("osc_transmit_port", 8247)  # Python listens
+        transmit_port = td_settings.get("osc_receive_port", 8248)  # Python transmits
+
+        # Initialize core manager with clean YAML config, debug flag, AND osc_reporter
+        osc_reporter.set_state("local_loading_models")
+        print("\033[38;5;66mLoading AI models (this may take time)...\033[0m")
+
+        try:
+            self.manager = TouchDesignerManager(
+                yaml_config,
+                input_mem,
+                output_mem,
+                debug_mode=debug_mode,
+                osc_reporter=osc_reporter,  # Pass reporter to manager
+            )
+            print("\033[38;5;34m✓ Models loaded\033[0m")
+            osc_reporter.set_state("local_ready")
+        except Exception as e:
+            error_msg = f"Model loading failed: {e}"
+            logging.error(error_msg, exc_info=True)
+            osc_reporter.send_error(error_msg)
+            osc_reporter.set_state("local_error")
+            raise
+
+        # Initialize OSC handler after manager (parameters only, no heartbeat)
+        self.osc_handler = OSCParameterHandler(
+            manager=self.manager,
+            main_app=self,  # Pass main app for shutdown handling
+            listen_port=listen_port,
+            transmit_port=transmit_port,
+            debug_mode=debug_mode,
+        )
+
+        # Now set OSC handler in manager
+        self.manager.osc_handler = self.osc_handler
+
+        # Application shutdown state
+        self.shutdown_requested = False
+
+        # Setup signal handlers
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+        print()  # Extra blank line before OSC
+        print(
+            f"\033[38;5;80mOSC: \033[37mListen {listen_port} -> Transmit {transmit_port}\033[0m"
+        )
+        print(f"\033[38;5;80mMemory: \033[37m{input_mem} -> {output_mem}\033[0m")
+
+        # Start OSC handler immediately so /stop commands work during model loading
+        self.osc_handler.start()
+
+    def start(self):
+        """Start the application"""
+        try:
+            # OSC handler already started in __init__ so /stop works during loading
+
+            # Send output name via reporter
+            self.osc_reporter.send_output_name(self.manager.output_mem_name)
+
+            # Auto-start streaming (matches your current main_sdtd.py behavior)
+            self.manager.start_streaming()
+
+            # Keep main thread alive
+            self._wait_for_shutdown()
+
+        except KeyboardInterrupt:
+            print("\n👋 Interrupted by user")
+        except Exception as e:
+            print(f"❌ Error: {e}")
+            self.osc_reporter.send_error(f"Application error: {e}")
+            raise
+        finally:
+            self.shutdown()
+
+    def shutdown(self):
+        """Graceful shutdown"""
+        print("\n\nShutting down...")
+
+        try:
+            self.manager.stop_streaming()
+            self.osc_handler.stop()
+            self.osc_reporter.stop_heartbeat()
+            self.osc_reporter.stop_vram_monitoring()
+            print("Shutdown complete")
+        except Exception as e:
+            print(f"Shutdown error: {e}")
+
+    def _signal_handler(self, sig, frame):
+        """Handle shutdown signals"""
+        print(f"\nReceived signal {sig}")
+        self.shutdown()
+        sys.exit(0)
+
+    def request_shutdown(self):
+        """Request application shutdown (called by OSC /stop command)"""
+        print("\n\033[31mStop command received via OSC\033[0m")
+        self.shutdown_requested = True
+
+        # Force immediate exit if stuck in model loading (can't gracefully shutdown)
+        # Use threading to allow OSC response to be sent before exit
+        def force_exit():
+            time.sleep(0.1)  # Give OSC handler time to send response
+            print("Forcing exit...")
+            os._exit(0)  # Hard exit (bypasses cleanup but works when blocked)
+
+        threading.Thread(target=force_exit, daemon=True).start()
+
+    def _wait_for_shutdown(self):
+        """Wait for shutdown signal"""
+        try:
+            # Keep main thread alive
+            while not self.shutdown_requested:
+                time.sleep(0.1)  # Check shutdown flag more frequently
+
+        except KeyboardInterrupt:
+            raise
+
+
+def main():
+    """Main entry point - reads from td_config.yaml"""
+
+    # Create and start application (no longer needs stream_config.json)
+    app = StreamDiffusionTD(osc_reporter)
+    app.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/StreamDiffusionTD/td_main.py
+++ b/StreamDiffusionTD/td_main.py
@@ -205,6 +205,13 @@ def warning_format(message, category, filename, lineno, file=None, line=None):
 
 warnings.formatwarning = warning_format
 
+# ─── CUDA / PyTorch env var defaults (set before any torch import) ───
+# Only set if not already provided by the launch script or environment
+if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
+    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "max_split_size_mb:128,expandable_segments:True"
+if "CUDA_MODULE_LOADING" not in os.environ:
+    os.environ["CUDA_MODULE_LOADING"] = "LAZY"
+
 # Loading animation
 print("\033[38;5;80mLoading StreamDiffusionTD", end="", flush=True)
 for _ in range(3):

--- a/StreamDiffusionTD/td_main.py
+++ b/StreamDiffusionTD/td_main.py
@@ -205,13 +205,6 @@ def warning_format(message, category, filename, lineno, file=None, line=None):
 
 warnings.formatwarning = warning_format
 
-# ─── CUDA / PyTorch env var defaults (set before any torch import) ───
-# Only set if not already provided by the launch script or environment
-if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
-    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "max_split_size_mb:128,expandable_segments:True"
-if "CUDA_MODULE_LOADING" not in os.environ:
-    os.environ["CUDA_MODULE_LOADING"] = "LAZY"
-
 # Loading animation
 print("\033[38;5;80mLoading StreamDiffusionTD", end="", flush=True)
 for _ in range(3):

--- a/StreamDiffusionTD/td_manager.py
+++ b/StreamDiffusionTD/td_manager.py
@@ -125,10 +125,6 @@ class TouchDesignerManager:
         # OSC notification flags
         self._sent_processed_cn_name = False
 
-        # Async GPU→CPU output transfer (eliminates full GPU sync on every output frame)
-        self._pinned_output_buf: Optional[torch.Tensor] = None
-        self._output_copy_event: Optional[torch.cuda.Event] = None
-
         # Mode tracking (img2img or txt2img)
         self.mode = self.config.get("mode", "img2img")
         logger.info(f"Initialized in {self.mode} mode")
@@ -538,11 +534,16 @@ class TouchDesignerManager:
                     instantaneous_fps = (
                         1.0 / frame_interval if frame_interval > 0 else 0.0
                     )
-                    # Smooth the FPS calculation
-                    self.current_fps = (
-                        self.current_fps * self.fps_smoothing
-                        + instantaneous_fps * (1 - self.fps_smoothing)
-                    )
+                    # Smooth the FPS calculation.
+                    # Seed EMA with first measurement so display doesn't slowly
+                    # climb from 0.0 during ramp-up.
+                    if self.current_fps == 0.0:
+                        self.current_fps = instantaneous_fps
+                    else:
+                        self.current_fps = (
+                            self.current_fps * self.fps_smoothing
+                            + instantaneous_fps * (1 - self.fps_smoothing)
+                        )
                 self.last_frame_output_time = frame_output_time
 
                 # Update frame counters
@@ -665,23 +666,7 @@ class TouchDesignerManager:
             if isinstance(output_image, Image.Image):
                 frame_np = np.array(output_image)
             elif isinstance(output_image, torch.Tensor):
-                if output_image.is_cuda:
-                    # Async GPU→CPU via pinned memory: eliminates full stream sync (saves 1-3ms/frame)
-                    if (
-                        self._pinned_output_buf is None
-                        or self._pinned_output_buf.shape != output_image.shape
-                        or self._pinned_output_buf.dtype != output_image.dtype
-                    ):
-                        self._pinned_output_buf = torch.empty(
-                            output_image.shape, dtype=output_image.dtype, pin_memory=True
-                        )
-                        self._output_copy_event = torch.cuda.Event()
-                    self._pinned_output_buf.copy_(output_image, non_blocking=True)
-                    self._output_copy_event.record()
-                    self._output_copy_event.synchronize()  # wait only for this transfer
-                    frame_np = self._pinned_output_buf.numpy()
-                else:
-                    frame_np = output_image.numpy()
+                frame_np = output_image.cpu().numpy()
                 if frame_np.shape[0] == 3:  # CHW -> HWC
                     frame_np = np.transpose(frame_np, (1, 2, 0))
             else:

--- a/StreamDiffusionTD/td_manager.py
+++ b/StreamDiffusionTD/td_manager.py
@@ -1,0 +1,951 @@
+"""
+TouchDesigner StreamDiffusion Manager
+
+Core bridge between TouchDesigner and the LivePeer StreamDiffusion fork.
+Handles configuration, streaming loop, and parameter updates.
+"""
+
+import logging
+import os
+import platform
+import sys
+import threading
+import time
+from multiprocessing import shared_memory
+from typing import Any, Dict, Optional, Union
+
+import numpy as np
+import torch
+from PIL import Image
+
+# Logger will be configured by td_main.py based on debug_mode
+logger = logging.getLogger("TouchDesignerManager")
+
+# Add StreamDiffusion to path
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from streamdiffusion.config import create_wrapper_from_config, load_config
+
+from streamdiffusion import StreamDiffusionWrapper
+
+
+class TouchDesignerManager:
+    """
+    Main manager class that bridges TouchDesigner with StreamDiffusion fork.
+
+    Key differences from your old version:
+    1. Uses new fork's config system and unified parameter updates
+    2. Maintains same SharedMemory/Syphon interface patterns
+    3. Leverages new fork's caching and performance improvements
+    """
+
+    def __init__(
+        self,
+        config: Union[str, Dict[str, Any]],
+        input_mem_name: str,
+        output_mem_name: str,
+        debug_mode: bool = False,
+        osc_reporter=None,
+    ):
+        self.input_mem_name = input_mem_name
+        self.output_mem_name = output_mem_name
+        self.osc_reporter = osc_reporter  # Lightweight telemetry reporter
+        self.osc_handler = None  # Parameter handler (set later)
+        self.debug_mode = debug_mode
+
+        # Handle both config dict (new) and config path (legacy compatibility)
+        if isinstance(config, dict):
+            if debug_mode:
+                print("Using pre-merged configuration dictionary")
+            self.config = config
+            self.config_path = None
+        else:
+            # Legacy: Load configuration using new fork's config system
+            if debug_mode:
+                print(f"Loading configuration from: {config}")
+            self.config = load_config(config)
+            self.config_path = config
+
+        # Extract TD-specific settings
+        self.td_settings = self.config.get("td_settings", {})
+
+        # Platform detection (same as your current version)
+        self.is_macos = platform.system() == "Darwin"
+        self.stream_method = "syphon" if self.is_macos else "shared_mem"
+
+        # Track which seed indices should be randomized every frame
+        self._randomize_seed_indices = []
+
+        # Initialize StreamDiffusion wrapper using new fork
+        logger.debug("Creating StreamDiffusion wrapper...")
+        self.wrapper: StreamDiffusionWrapper = create_wrapper_from_config(self.config)
+
+        # Memory interfaces (will be initialized in start_streaming)
+        self.input_memory: Optional[shared_memory.SharedMemory] = None
+        self.output_memory: Optional[shared_memory.SharedMemory] = None
+        self.control_memory: Optional[shared_memory.SharedMemory] = None
+        self.control_processed_memory: Optional[shared_memory.SharedMemory] = (
+            None  # For pre-processed ControlNet output
+        )
+        self.ipadapter_memory: Optional[shared_memory.SharedMemory] = None
+        self.syphon_handler = None
+
+        # Streaming state
+        self.streaming = False
+        self.stream_thread: Optional[threading.Thread] = None
+        self.paused = False
+        self.process_frame = False
+        self.frame_acknowledged = False
+
+        # State tracking for logging (only log changes)
+        self._last_paused_state = False
+        self._frames_processed_in_pause = 0
+
+        # ControlNet and IPAdapter state
+        self.ipadapter_update_requested = False
+        self.control_mem_name = self.input_mem_name + "-cn"
+        self.control_processed_mem_name = (
+            self.input_mem_name + "-cn-processed"
+        )  # For pre-processed ControlNet output
+        self.ipadapter_mem_name = self.input_mem_name + "-ip"
+
+        # Track live IPAdapter scale from OSC updates
+        self._current_ipadapter_scale = self.config.get("ipadapters", [{}])[0].get(
+            "scale", 1.0
+        )
+
+        # Performance tracking
+        self.frame_count = 0
+        self.total_frame_count = 0  # Total frames processed (for OSC)
+        self.start_time = time.time()
+        self.fps_smoothing = 0.9  # For exponential moving average
+        self.current_fps = 0.0          # Output FPS: includes cached/skipped frames
+        self.inference_fps = 0.0        # Inference FPS: only frames that ran GPU inference
+        self.last_frame_output_time = 0.0   # Wall-clock time of last frame output (any frame)
+        self.last_inference_time = 0.0      # Wall-clock time of last real inference frame
+
+        # OSC notification flags
+        self._sent_processed_cn_name = False
+
+        # Mode tracking (img2img or txt2img)
+        self.mode = self.config.get("mode", "img2img")
+        logger.info(f"Initialized in {self.mode} mode")
+
+        logger.info("TouchDesigner Manager initialized successfully")
+
+    def update_parameters(self, params: Dict[str, Any]) -> None:
+        """
+        Update StreamDiffusion parameters using new fork's unified system.
+
+        This replaces the scattered parameter updates in your old version
+        with a single, atomic update call that handles caching efficiently.
+        """
+        try:
+            # Track IPAdapter scale changes from OSC
+            if "ipadapter_config" in params and "scale" in params["ipadapter_config"]:
+                self._current_ipadapter_scale = params["ipadapter_config"]["scale"]
+                # Removed noisy log: logger.info(f"Updated IPAdapter scale to: {self._current_ipadapter_scale}")
+
+            # Filter out invalid parameters that wrapper doesn't accept
+            valid_params = [
+                "num_inference_steps",
+                "guidance_scale",
+                "delta",
+                "t_index_list",
+                "seed",
+                "prompt_list",
+                "negative_prompt",
+                "prompt_interpolation_method",
+                "normalize_prompt_weights",
+                "seed_list",
+                "seed_interpolation_method",
+                "normalize_seed_weights",
+                "controlnet_config",
+                "ipadapter_config",
+                "image_preprocessing_config",
+                "image_postprocessing_config",
+                "latent_preprocessing_config",
+                "latent_postprocessing_config",
+                "use_safety_checker",
+                "safety_checker_threshold",
+                "cache_maxframes",
+                "cache_interval",
+            ]
+
+            filtered_params = {k: v for k, v in params.items() if k in valid_params}
+
+            # Enforce guidance_scale > 1.0 for cfg_type "full" or "initialize"
+            # (pipeline.py requires this for negative prompt embeddings)
+            if "guidance_scale" in filtered_params:
+                cfg_type = getattr(self.wrapper.stream, "cfg_type", None)
+                if (
+                    cfg_type in ["full", "initialize"]
+                    and filtered_params["guidance_scale"] <= 1.0
+                ):
+                    filtered_params["guidance_scale"] = 1.2
+
+            # Track which seed indices have -1 for continuous per-frame randomization
+            if "seed_list" in filtered_params:
+                import random
+
+                # Clear and rebuild tracking based on this OSC update
+                self._randomize_seed_indices = []
+                new_seed_list = []
+                for idx, (seed, weight) in enumerate(filtered_params["seed_list"]):
+                    if seed == -1:
+                        # Mark this index for continuous randomization
+                        self._randomize_seed_indices.append(idx)
+                        # Generate random seed for this initial update
+                        seed = random.randint(0, 2**32 - 1)
+                    new_seed_list.append((seed, weight))
+                filtered_params["seed_list"] = new_seed_list
+
+            # Use the new fork's unified parameter update system
+            self.wrapper.update_stream_params(**filtered_params)
+        except Exception as e:
+            logger.error(f"Error updating parameters: {e}")
+
+    def start_streaming(self) -> None:
+        """Initialize memory interfaces and start the streaming loop"""
+        if self.streaming:
+            logger.warning("Already streaming!")
+            return
+
+        try:
+            # Send starting state via reporter (not handler - that's for parameters)
+            if self.osc_reporter:
+                self.osc_reporter.set_state("local_starting")
+
+            self._initialize_memory_interfaces()
+            self.streaming = True
+
+            # Start streaming in separate thread (non-blocking)
+            self.stream_thread = threading.Thread(
+                target=self._streaming_loop, daemon=True
+            )
+            self.stream_thread.start()
+
+            # Print styled startup message
+            print("\n\033[32mStream active\033[0m\n")
+
+            logger.info(f"Streaming started - Method: {self.stream_method}")
+
+        except Exception as e:
+            logger.error(f"Failed to start streaming: {e}")
+            raise
+
+    def stop_streaming(self) -> None:
+        """Stop streaming and cleanup resources"""
+        if not self.streaming:
+            return
+
+        logger.info("Stopping streaming...")
+        self.streaming = False
+
+        # Send offline state via reporter
+        if self.osc_reporter:
+            self.osc_reporter.set_state("local_offline")
+
+        # Wait for streaming thread to finish
+        if self.stream_thread and self.stream_thread.is_alive():
+            self.stream_thread.join(timeout=2.0)
+
+        # Cleanup memory interfaces
+        self._cleanup_memory_interfaces()
+
+        logger.info("Streaming stopped")
+
+    def _initialize_memory_interfaces(self) -> None:
+        """Initialize platform-specific memory interfaces"""
+        width = self.config["width"]
+        height = self.config["height"]
+
+        if self.is_macos:
+            # Initialize Syphon (using existing syphon_utils.py)
+            try:
+                from syphon_utils import SyphonUtils
+
+                self.syphon_handler = SyphonUtils(
+                    sender_name=self.output_mem_name,
+                    input_name=self.input_mem_name,
+                    control_name=None,
+                    width=width,
+                    height=height,
+                    debug=False,
+                )
+                self.syphon_handler.start()
+                logger.debug(
+                    f"Syphon initialized - Input: {self.input_mem_name}, Output: {self.output_mem_name}"
+                )
+
+            except Exception as e:
+                logger.error(f"Failed to initialize Syphon: {e}")
+                raise
+        else:
+            # Initialize SharedMemory (same pattern as your current version)
+            try:
+                # Input memory (from TouchDesigner)
+                self.input_memory = shared_memory.SharedMemory(name=self.input_mem_name)
+                logger.debug(f"Connected to input SharedMemory: {self.input_mem_name}")
+
+                # Output memory (to TouchDesigner) - try to connect first, create if not exists
+                frame_size = width * height * 3  # RGB
+                try:
+                    # Try to connect to existing memory first (like main_sdtd.py)
+                    self.output_memory = shared_memory.SharedMemory(
+                        name=self.output_mem_name
+                    )
+                    logger.debug(
+                        f"Connected to existing output SharedMemory: {self.output_mem_name}"
+                    )
+                except FileNotFoundError:
+                    # Create new if doesn't exist
+                    self.output_memory = shared_memory.SharedMemory(
+                        name=self.output_mem_name, create=True, size=frame_size
+                    )
+                    logger.debug(
+                        f"Created new output SharedMemory: {self.output_mem_name}"
+                    )
+
+                # ControlNet memory (per-frame updates)
+                try:
+                    self.control_memory = shared_memory.SharedMemory(
+                        name=self.control_mem_name
+                    )
+                    logger.debug(
+                        f"Connected to ControlNet SharedMemory: {self.control_mem_name}"
+                    )
+                except FileNotFoundError:
+                    logger.debug(
+                        f"ControlNet SharedMemory not found: {self.control_mem_name} (will create if needed)"
+                    )
+                    self.control_memory = None
+
+                # ControlNet processed output memory (to send pre-processed image back to TD)
+                # Create output memory for processed ControlNet with -cn-processed suffix
+                control_processed_mem_name = self.output_mem_name + "-cn-processed"
+                try:
+                    # Try to connect to existing memory first
+                    self.control_processed_memory = shared_memory.SharedMemory(
+                        name=control_processed_mem_name
+                    )
+                    logger.debug(
+                        f"Connected to existing ControlNet processed output SharedMemory: {control_processed_mem_name}"
+                    )
+                except FileNotFoundError:
+                    # Create new if doesn't exist
+                    self.control_processed_memory = shared_memory.SharedMemory(
+                        name=control_processed_mem_name,
+                        create=True,
+                        size=frame_size,  # Same size as main output
+                    )
+                    logger.debug(
+                        f"Created new ControlNet processed output SharedMemory: {control_processed_mem_name}"
+                    )
+
+                # IPAdapter memory (OSC-triggered updates)
+                try:
+                    self.ipadapter_memory = shared_memory.SharedMemory(
+                        name=self.ipadapter_mem_name
+                    )
+                    logger.debug(
+                        f"Connected to IPAdapter SharedMemory: {self.ipadapter_mem_name}"
+                    )
+                except FileNotFoundError:
+                    logger.debug(
+                        f"IPAdapter SharedMemory not found: {self.ipadapter_mem_name} (will create if needed)"
+                    )
+                    self.ipadapter_memory = None
+
+            except Exception as e:
+                logger.error(f"Failed to initialize SharedMemory: {e}")
+                raise
+
+    def _cleanup_memory_interfaces(self) -> None:
+        """Cleanup memory interfaces"""
+        try:
+            if self.syphon_handler:
+                self.syphon_handler.stop()
+                self.syphon_handler = None
+
+            if self.input_memory:
+                self.input_memory.close()
+                self.input_memory = None
+
+            if self.output_memory:
+                self.output_memory.close()
+                self.output_memory.unlink()  # Delete the shared memory
+                self.output_memory = None
+
+            if self.control_memory:
+                self.control_memory.close()
+                self.control_memory = None
+
+            if self.control_processed_memory:
+                self.control_processed_memory.close()
+                self.control_processed_memory.unlink()  # Delete the shared memory
+                self.control_processed_memory = None
+
+            if self.ipadapter_memory:
+                self.ipadapter_memory.close()
+                self.ipadapter_memory = None
+
+        except Exception as e:
+            logger.error(f"Error during cleanup: {e}")
+
+    def _streaming_loop(self) -> None:
+        """
+        Main streaming loop - processes frames as fast as possible.
+
+        Key insight: The wrapper.img2img() call runs as fast as it can.
+        You don't manually control the speed - the wrapper handles timing internally.
+        """
+        logger.info("Starting streaming loop...")
+
+        frame_time_accumulator = 0.0
+        fps_report_interval = 1.0  # Report FPS every second
+
+        while self.streaming:
+            try:
+                # CRITICAL: Check pause state FIRST before any processing
+                if self.paused:
+                    if not self.process_frame:
+                        time.sleep(
+                            0.001
+                        )  # Brief sleep if paused and no frame requested
+                        continue
+                    else:
+                        # Reset acknowledgment flag when starting frame processing
+                        self.frame_acknowledged = False
+                        self._frames_processed_in_pause += 1
+
+                        # Log useful info every 10th frame
+                        if self._frames_processed_in_pause % 10 == 0:
+                            logger.info(
+                                f"PAUSE: Frame {self._frames_processed_in_pause} | FPS: {self.current_fps:.1f}"
+                            )
+
+                        # CRITICAL: Reset process_frame IMMEDIATELY after confirming we're processing
+                        # This must happen INSIDE the pause block, not outside
+                        self.process_frame = False
+                else:
+                    # In continuous mode, we don't need to reset process_frame
+                    pass
+
+                loop_start = time.time()
+
+                # Process through StreamDiffusion - mode determines which method to call
+                if self.mode == "txt2img":
+                    # txt2img mode: generate from prepared noise (respects seed)
+                    # Use init_noise instead of random noise to respect seed parameter
+                    stream = self.wrapper.stream
+                    batch_size = 1
+
+                    # Check if seed is -1 (randomize every frame)
+                    # Get current seed from config (updated via OSC)
+                    current_seed = self.config.get("seed", -1)
+
+                    if current_seed == -1:
+                        # Generate fresh random noise every frame (random seed)
+                        adjusted_noise = torch.randn(
+                            (batch_size, 4, stream.latent_height, stream.latent_width),
+                            device=stream.device,
+                            dtype=stream.dtype,
+                        )
+                    else:
+                        # Generate noise from seed (consistent image every frame)
+                        generator = torch.Generator(device=stream.device)
+                        generator.manual_seed(current_seed)
+                        adjusted_noise = torch.randn(
+                            (batch_size, 4, stream.latent_height, stream.latent_width),
+                            device=stream.device,
+                            dtype=stream.dtype,
+                            generator=generator,
+                        )
+
+                    # Apply latent preprocessing hooks before prediction
+                    adjusted_noise = stream._apply_latent_preprocessing_hooks(
+                        adjusted_noise
+                    )
+
+                    # Call predict_x0_batch with prepared noise
+                    x_0_pred_out = stream.predict_x0_batch(adjusted_noise)
+
+                    # Apply latent postprocessing hooks
+                    x_0_pred_out = stream._apply_latent_postprocessing_hooks(
+                        x_0_pred_out
+                    )
+
+                    # Store for latent feedback processors
+                    stream.prev_latent_result = x_0_pred_out.detach().clone()
+
+                    # Decode to image
+                    x_output = stream.decode_image(x_0_pred_out).detach().clone()
+
+                    # Apply image postprocessing hooks
+                    x_output = stream._apply_image_postprocessing_hooks(x_output)
+
+                    # Postprocess to desired output format
+                    output_image = self.wrapper.postprocess_image(
+                        x_output, output_type=self.wrapper.output_type
+                    )
+                else:
+                    # img2img mode: get input frame and process
+                    input_image = self._get_input_frame()
+                    if input_image is None:
+                        time.sleep(0.001)  # Brief sleep if no input
+                        continue
+
+                    # Convert input for pipeline
+                    if input_image.dtype == np.uint8:
+                        input_image = input_image.astype(np.float32) / 255.0
+
+                    # Process ControlNet frame (per-frame if enabled)
+                    self._process_controlnet_frame()
+
+                    # Process IPAdapter frame (only on OSC request)
+                    self._process_ipadapter_frame()
+
+                    # Randomize tracked seed indices every frame (indices marked as -1 via OSC)
+                    if self._randomize_seed_indices:
+                        import random
+
+                        # Make a copy of current seed_list and randomize tracked indices
+                        current_seed_list = (
+                            self.wrapper.stream._param_updater._current_seed_list.copy()
+                        )
+                        for idx in self._randomize_seed_indices:
+                            _, weight = current_seed_list[idx]
+                            current_seed_list[idx] = (
+                                random.randint(0, 2**32 - 1),
+                                weight,
+                            )
+                        # Apply the randomized seed_list to the stream
+                        self.wrapper.update_stream_params(seed_list=current_seed_list)
+
+                    # Transform input image
+                    output_image = self.wrapper.img2img(input_image)
+
+                # Send output frame to TouchDesigner
+                self._send_output_frame(output_image)
+
+                # Output FPS: wall-clock rate of all frames sent to TD (includes cached skips)
+                frame_output_time = time.time()
+                if self.last_frame_output_time > 0:
+                    frame_interval = frame_output_time - self.last_frame_output_time
+                    instantaneous_fps = (
+                        1.0 / frame_interval if frame_interval > 0 else 0.0
+                    )
+                    self.current_fps = (
+                        self.current_fps * self.fps_smoothing
+                        + instantaneous_fps * (1 - self.fps_smoothing)
+                    )
+                self.last_frame_output_time = frame_output_time
+
+                # Inference FPS: only frames that actually ran GPU inference (similar filter skips excluded)
+                was_skipped = getattr(self.wrapper.stream, 'last_frame_was_skipped', False)
+                if not was_skipped:
+                    if self.last_inference_time > 0:
+                        inf_interval = frame_output_time - self.last_inference_time
+                        instantaneous_inf_fps = (
+                            1.0 / inf_interval if inf_interval > 0 else 0.0
+                        )
+                        self.inference_fps = (
+                            self.inference_fps * self.fps_smoothing
+                            + instantaneous_inf_fps * (1 - self.fps_smoothing)
+                        )
+                    self.last_inference_time = frame_output_time
+
+                # Update frame counters
+                self.frame_count += 1
+                self.total_frame_count += 1
+
+                # Update performance metrics for display
+                loop_end = time.time()
+                loop_time = loop_end - loop_start
+                frame_time_accumulator += loop_time
+
+                # Send OSC messages EVERY FRAME via reporter (like main_sdtd.py - critical for TD connection!)
+                if self.osc_reporter:
+                    self.osc_reporter.send_frame_count(self.total_frame_count)
+                    # Only send frame_ready in continuous mode, NOT in pause mode
+                    if not self.paused:
+                        self.osc_reporter.send_frame_ready(self.total_frame_count)
+
+                    # Send connection state update (transition to streaming after 30 frames)
+                    if self.total_frame_count == 30:
+                        self.osc_reporter.set_state("local_streaming")
+
+                    # Send processed ControlNet memory name (only once at startup or when needed)
+                    if (
+                        not self._sent_processed_cn_name
+                        and self.control_processed_memory
+                    ):
+                        processed_cn_name = self.output_mem_name + "-cn-processed"
+                        self.osc_reporter.send_controlnet_processed_name(
+                            processed_cn_name
+                        )
+                        self._sent_processed_cn_name = True
+
+                # Report FPS periodically using the correct frame output FPS (ALWAYS show)
+                if frame_time_accumulator >= fps_report_interval:
+                    # Calculate uptime
+                    uptime_seconds = int(time.time() - self.start_time)
+                    uptime_mins = uptime_seconds // 60
+                    uptime_secs = uptime_seconds % 60
+                    uptime_str = f"{uptime_mins:02d}:{uptime_secs:02d}"
+
+                    # Clear the line properly and write new status with color
+                    status_line = f"\033[38;5;208mStreaming | FPS: {self.inference_fps:.1f} (out: {self.current_fps:.1f}) | Uptime: {uptime_str}\033[0m"
+                    print(f"\r{' ' * 80}\r{status_line}", end="", flush=True)
+
+                    # Reset counters
+                    frame_time_accumulator = 0.0
+                    self.frame_count = 0
+
+                # Send FPS EVERY FRAME via reporter — use inference FPS (excludes similar-filter skips)
+                if self.osc_reporter:
+                    reported_fps = self.inference_fps if self.inference_fps > 0 else self.current_fps
+                    if reported_fps > 0:
+                        self.osc_reporter.send_fps(reported_fps)
+
+                # Handle frame acknowledgment for pause mode synchronization
+                if self.paused:
+                    # Send frame completion signal to TouchDesigner
+                    if self.osc_handler:
+                        self.osc_handler.send_message(
+                            "/frame_ready", self.total_frame_count
+                        )
+
+                    # Wait for TouchDesigner to acknowledge it has processed the frame
+                    acknowledgment_timeout = time.time() + 5.0  # 5 second timeout
+                    while (
+                        not self.frame_acknowledged
+                        and time.time() < acknowledgment_timeout
+                    ):
+                        time.sleep(0.001)  # Small sleep to prevent busy waiting
+
+                    if not self.frame_acknowledged:
+                        logger.warning(
+                            f"TIMEOUT: No /frame_ack after 5s (frame {self._frames_processed_in_pause})"
+                        )
+
+                    # Reset for next frame
+                    self.frame_acknowledged = False
+
+            except Exception as e:
+                logger.error(f"Error in streaming loop: {e}")
+                # Continue streaming unless explicitly stopped
+                if self.streaming:
+                    time.sleep(0.1)  # Brief pause before retrying
+                else:
+                    break
+
+        logger.info("Streaming loop ended")
+
+    def _get_input_frame(self) -> Optional[np.ndarray]:
+        """Get input frame from TouchDesigner (platform-specific)"""
+        try:
+            if self.is_macos and self.syphon_handler:
+                # Get frame from Syphon
+                frame = self.syphon_handler.capture_input_frame()
+                return frame
+
+            elif self.input_memory:
+                # Get frame from SharedMemory
+                width = self.config["width"]
+                height = self.config["height"]
+
+                # Create numpy array view of shared memory
+                frame = np.ndarray(
+                    (height, width, 3), dtype=np.uint8, buffer=self.input_memory.buf
+                )
+
+                return frame.copy()  # Copy to avoid memory issues
+
+            return None
+
+        except Exception as e:
+            logger.error(f"Error getting input frame: {e}")
+            return None
+
+    def _send_output_frame(
+        self, output_image: Union[Image.Image, np.ndarray]
+    ) -> None:
+        """Send output frame to TouchDesigner (platform-specific)"""
+        try:
+            # Convert output to numpy array if needed
+            if isinstance(output_image, Image.Image):
+                frame_np = np.array(output_image)
+            elif isinstance(output_image, torch.Tensor):
+                frame_np = output_image.cpu().numpy()
+                if frame_np.shape[0] == 3:  # CHW -> HWC
+                    frame_np = np.transpose(frame_np, (1, 2, 0))
+            else:
+                frame_np = output_image
+
+            # Ensure proper scaling like main_sdtd.py (line 916)
+            if frame_np.max() <= 1.0:
+                frame_np = (frame_np * 255).astype(np.uint8)
+            elif frame_np.dtype != np.uint8:
+                frame_np = frame_np.astype(np.uint8)
+
+            if self.is_macos and self.syphon_handler:
+                # Send via Syphon
+                self.syphon_handler.send_frame(frame_np)
+
+            elif self.output_memory:
+                # Send via SharedMemory
+                output_array = np.ndarray(
+                    frame_np.shape, dtype=np.uint8, buffer=self.output_memory.buf
+                )
+                np.copyto(output_array, frame_np)
+
+                # Diagnostic: confirm first frame write
+                if self.total_frame_count == 0:
+                    print(
+                        f"[SharedMem] First frame written: shape={frame_np.shape}, "
+                        f"dtype={frame_np.dtype}, mem_name={self.output_mem_name}, "
+                        f"buf_size={self.output_memory.size}"
+                    )
+
+        except Exception as e:
+            logger.error(f"Error sending output frame: {e}")
+            import traceback; traceback.print_exc()  # TEMP diagnostic
+
+    def _send_processed_controlnet_frame(
+        self, processed_tensor: Optional[torch.Tensor]
+    ) -> None:
+        """Send processed ControlNet frame to TouchDesigner via shared memory"""
+        if not self.control_processed_memory or processed_tensor is None:
+            return
+
+        try:
+            # Convert tensor to numpy array (similar to _send_output_frame)
+            if isinstance(processed_tensor, torch.Tensor):
+                frame_np = processed_tensor.cpu().numpy()
+
+                # Handle tensor format: CHW -> HWC
+                if frame_np.ndim == 4 and frame_np.shape[0] == 1:
+                    frame_np = frame_np.squeeze(0)  # Remove batch dimension
+                if frame_np.ndim == 3 and frame_np.shape[0] == 3:
+                    frame_np = np.transpose(frame_np, (1, 2, 0))  # CHW -> HWC
+            else:
+                frame_np = processed_tensor
+
+            # Ensure proper scaling (0-1 range to 0-255)
+            if frame_np.max() <= 1.0:
+                frame_np = (frame_np * 255).astype(np.uint8)
+            elif frame_np.dtype != np.uint8:
+                frame_np = frame_np.astype(np.uint8)
+
+            # Send via SharedMemory
+            if self.control_processed_memory:
+                output_array = np.ndarray(
+                    frame_np.shape,
+                    dtype=np.uint8,
+                    buffer=self.control_processed_memory.buf,
+                )
+                np.copyto(output_array, frame_np)
+
+        except Exception as e:
+            logger.error(f"Error sending processed ControlNet frame: {e}")
+
+    def pause_streaming(self) -> None:
+        """Pause streaming (frame processing continues only on process_frame requests)"""
+        if not self.paused:  # Only log state changes
+            self.paused = True
+            self._frames_processed_in_pause = 0  # Reset counter
+
+            logger.info("STREAMING PAUSED - waiting for /process_frame commands")
+
+    def resume_streaming(self) -> None:
+        """Resume streaming (continuous frame processing)"""
+        if self.paused:  # Only log state changes
+            self.paused = False
+            logger.info(
+                f"STREAMING RESUMED - processed {self._frames_processed_in_pause} frames while paused"
+            )
+
+    def process_single_frame(self) -> None:
+        """Process a single frame when paused"""
+        if self.paused:
+            self.process_frame = True
+            # Only log occasionally to reduce spam
+        else:
+            logger.warning("process_single_frame called but streaming is not paused")
+
+    def acknowledge_frame(self) -> None:
+        """Acknowledge frame processing completion (called by TouchDesigner)"""
+        self.frame_acknowledged = True
+
+    def _process_controlnet_frame(self) -> None:
+        """Process ControlNet frame data (per-frame updates)"""
+        if not self.control_memory or not self.config.get("use_controlnet", False):
+            return
+
+        try:
+            width = self.config["width"]
+            height = self.config["height"]
+
+            # Read ControlNet frame from shared memory
+            control_frame = np.ndarray(
+                (height, width, 3), dtype=np.uint8, buffer=self.control_memory.buf
+            )
+
+            # Convert to float [0,1] and pass to wrapper
+            if control_frame.dtype == np.uint8:
+                control_frame = control_frame.astype(np.float32) / 255.0
+
+            # Update ControlNet image in wrapper (index 0 for first ControlNet)
+            self.wrapper.update_control_image(0, control_frame)
+
+            # IMPORTANT: After processing, extract the pre-processed image and send it back to TD
+            # The processed image is now available in the controlnet module
+            try:
+                if (
+                    hasattr(self.wrapper, "stream")
+                    and hasattr(self.wrapper.stream, "_controlnet_module")
+                    and self.wrapper.stream._controlnet_module is not None
+                ):
+                    controlnet_module = self.wrapper.stream._controlnet_module
+
+                    # Check if we have processed images available
+                    if (
+                        hasattr(controlnet_module, "controlnet_images")
+                        and len(controlnet_module.controlnet_images) > 0
+                        and controlnet_module.controlnet_images[0] is not None
+                    ):
+                        processed_tensor = controlnet_module.controlnet_images[0]
+
+                        # Send the processed ControlNet image back to TouchDesigner
+                        self._send_processed_controlnet_frame(processed_tensor)
+
+            except Exception as processed_error:
+                logger.debug(
+                    f"Could not extract processed ControlNet image: {processed_error}"
+                )
+
+        except Exception as e:
+            logger.error(f"Error processing ControlNet frame: {e}")
+
+    def _process_ipadapter_frame(self) -> None:
+        """Process IPAdapter frame data (OSC-triggered updates only)"""
+        if not self.config.get("use_ipadapter", False):
+            return
+        if not self.ipadapter_memory:
+            logger.debug(
+                f"IPAdapter SharedMemory not connected: {self.ipadapter_mem_name}"
+            )
+            return
+
+        if not self.ipadapter_update_requested:
+            return
+
+        try:
+            width = self.config["width"]
+            height = self.config["height"]
+
+            # Read IPAdapter frame from shared memory
+            ipadapter_frame = np.ndarray(
+                (height, width, 3), dtype=np.uint8, buffer=self.ipadapter_memory.buf
+            )
+
+            # Convert to float [0,1] and pass to wrapper
+            if ipadapter_frame.dtype == np.uint8:
+                ipadapter_frame = ipadapter_frame.astype(np.float32) / 255.0
+
+            # Update IPAdapter config FIRST (like img2img example)
+            # Use live scale value updated by OSC, not static config
+            current_scale = self._current_ipadapter_scale
+            logger.info(f"Using live IPAdapter scale: {current_scale}")
+            self.wrapper.update_stream_params(ipadapter_config={"scale": current_scale})
+
+            # THEN update the style image (following img2img pattern)
+            self.wrapper.update_style_image(ipadapter_frame)
+
+            # CRITICAL FIX: Trigger prompt re-blending to apply the new IPAdapter embeddings
+            # The embedding hooks only run during _apply_prompt_blending, so we must trigger it
+            # after updating the IPAdapter image to concatenate the new embeddings with prompts
+            if (
+                hasattr(self.wrapper.stream._param_updater, "_current_prompt_list")
+                and self.wrapper.stream._param_updater._current_prompt_list
+            ):
+                # Get current interpolation method or use default
+                interpolation_method = getattr(
+                    self.wrapper.stream._param_updater,
+                    "_last_prompt_interpolation_method",
+                    "slerp",
+                )
+                # Re-apply prompt blending to trigger embedding hooks
+                self.wrapper.stream._param_updater._apply_prompt_blending(
+                    interpolation_method
+                )
+                logger.info(
+                    "Re-applied prompt blending to incorporate new IPAdapter embeddings"
+                )
+
+            # Debug: Check if embeddings were cached
+            cached_embeddings = (
+                self.wrapper.stream._param_updater.get_cached_embeddings(
+                    "ipadapter_main"
+                )
+            )
+            if cached_embeddings is not None:
+                logger.info(
+                    f"IPAdapter config+image updated! Scale: {current_scale}, Embeddings: {cached_embeddings[0].shape}"
+                )
+            else:
+                logger.error("IPAdapter embeddings NOT cached!")
+
+            # Reset the update flag
+            self.ipadapter_update_requested = False
+            logger.info("IPAdapter config and image updated from SharedMemory")
+
+        except Exception as e:
+            logger.error(f"Error processing IPAdapter frame: {e}")
+
+    def request_ipadapter_update(self) -> None:
+        """Request IPAdapter image update on next frame (called via OSC)"""
+        self.ipadapter_update_requested = True
+        logger.info("IPAdapter update requested")
+
+    def set_mode(self, mode: str) -> None:
+        """
+        Switch between txt2img and img2img modes.
+
+        Args:
+            mode: Either "txt2img" or "img2img"
+        """
+        if mode not in ["txt2img", "img2img"]:
+            logger.error(f"Invalid mode: {mode}. Must be 'txt2img' or 'img2img'")
+            return
+
+        if mode == self.mode:
+            logger.info(f"Already in {mode} mode")
+            return
+
+        logger.info(f"Switching from {self.mode} to {mode} mode")
+        self.mode = mode
+
+        # txt2img mode requirements
+        if mode == "txt2img":
+            logger.warning(
+                "txt2img mode requires cfg_type='none' - verify your config!"
+            )
+
+    def get_stream_state(self) -> Dict[str, Any]:
+        """Get current streaming state and parameters"""
+        return {
+            "streaming": self.streaming,
+            "paused": self.paused,
+            "fps": self.current_fps,
+            "frame_count": self.frame_count,
+            "stream_method": self.stream_method,
+            "wrapper_state": self.wrapper.get_stream_state()
+            if hasattr(self.wrapper, "get_stream_state")
+            else {},
+            "controlnet_connected": self.control_memory is not None,
+            "controlnet_processed_connected": self.control_processed_memory is not None,
+            "ipadapter_connected": self.ipadapter_memory is not None,
+        }

--- a/StreamDiffusionTD/td_manager.py
+++ b/StreamDiffusionTD/td_manager.py
@@ -534,16 +534,11 @@ class TouchDesignerManager:
                     instantaneous_fps = (
                         1.0 / frame_interval if frame_interval > 0 else 0.0
                     )
-                    # Smooth the FPS calculation.
-                    # Seed EMA with first measurement so display doesn't slowly
-                    # climb from 0.0 during ramp-up.
-                    if self.current_fps == 0.0:
-                        self.current_fps = instantaneous_fps
-                    else:
-                        self.current_fps = (
-                            self.current_fps * self.fps_smoothing
-                            + instantaneous_fps * (1 - self.fps_smoothing)
-                        )
+                    # Smooth the FPS calculation
+                    self.current_fps = (
+                        self.current_fps * self.fps_smoothing
+                        + instantaneous_fps * (1 - self.fps_smoothing)
+                    )
                 self.last_frame_output_time = frame_output_time
 
                 # Update frame counters

--- a/StreamDiffusionTD/td_manager.py
+++ b/StreamDiffusionTD/td_manager.py
@@ -119,10 +119,8 @@ class TouchDesignerManager:
         self.total_frame_count = 0  # Total frames processed (for OSC)
         self.start_time = time.time()
         self.fps_smoothing = 0.9  # For exponential moving average
-        self.current_fps = 0.0          # Output FPS: includes cached/skipped frames
-        self.inference_fps = 0.0        # Inference FPS: only frames that ran GPU inference
-        self.last_frame_output_time = 0.0   # Wall-clock time of last frame output (any frame)
-        self.last_inference_time = 0.0      # Wall-clock time of last real inference frame
+        self.current_fps = 0.0
+        self.last_frame_output_time = 0.0  # Track actual frame output timing
 
         # OSC notification flags
         self._sent_processed_cn_name = False
@@ -529,32 +527,19 @@ class TouchDesignerManager:
                 # Send output frame to TouchDesigner
                 self._send_output_frame(output_image)
 
-                # Output FPS: wall-clock rate of all frames sent to TD (includes cached skips)
+                # Calculate FPS based on actual frame output timing (not loop timing)
                 frame_output_time = time.time()
                 if self.last_frame_output_time > 0:
                     frame_interval = frame_output_time - self.last_frame_output_time
                     instantaneous_fps = (
                         1.0 / frame_interval if frame_interval > 0 else 0.0
                     )
+                    # Smooth the FPS calculation
                     self.current_fps = (
                         self.current_fps * self.fps_smoothing
                         + instantaneous_fps * (1 - self.fps_smoothing)
                     )
                 self.last_frame_output_time = frame_output_time
-
-                # Inference FPS: only frames that actually ran GPU inference (similar filter skips excluded)
-                was_skipped = getattr(self.wrapper.stream, 'last_frame_was_skipped', False)
-                if not was_skipped:
-                    if self.last_inference_time > 0:
-                        inf_interval = frame_output_time - self.last_inference_time
-                        instantaneous_inf_fps = (
-                            1.0 / inf_interval if inf_interval > 0 else 0.0
-                        )
-                        self.inference_fps = (
-                            self.inference_fps * self.fps_smoothing
-                            + instantaneous_inf_fps * (1 - self.fps_smoothing)
-                        )
-                    self.last_inference_time = frame_output_time
 
                 # Update frame counters
                 self.frame_count += 1
@@ -596,18 +581,16 @@ class TouchDesignerManager:
                     uptime_str = f"{uptime_mins:02d}:{uptime_secs:02d}"
 
                     # Clear the line properly and write new status with color
-                    status_line = f"\033[38;5;208mStreaming | FPS: {self.inference_fps:.1f} (out: {self.current_fps:.1f}) | Uptime: {uptime_str}\033[0m"
+                    status_line = f"\033[38;5;208mStreaming | FPS: {self.current_fps:.1f} | Uptime: {uptime_str}\033[0m"
                     print(f"\r{' ' * 80}\r{status_line}", end="", flush=True)
 
                     # Reset counters
                     frame_time_accumulator = 0.0
                     self.frame_count = 0
 
-                # Send FPS EVERY FRAME via reporter — use inference FPS (excludes similar-filter skips)
-                if self.osc_reporter:
-                    reported_fps = self.inference_fps if self.inference_fps > 0 else self.current_fps
-                    if reported_fps > 0:
-                        self.osc_reporter.send_fps(reported_fps)
+                # Send FPS EVERY FRAME via reporter (like main_sdtd.py) - report actual measured FPS
+                if self.osc_reporter and self.current_fps > 0:
+                    self.osc_reporter.send_fps(self.current_fps)
 
                 # Handle frame acknowledgment for pause mode synchronization
                 if self.paused:

--- a/StreamDiffusionTD/td_manager.py
+++ b/StreamDiffusionTD/td_manager.py
@@ -125,6 +125,10 @@ class TouchDesignerManager:
         # OSC notification flags
         self._sent_processed_cn_name = False
 
+        # Async GPU→CPU output transfer (eliminates full GPU sync on every output frame)
+        self._pinned_output_buf: Optional[torch.Tensor] = None
+        self._output_copy_event: Optional[torch.cuda.Event] = None
+
         # Mode tracking (img2img or txt2img)
         self.mode = self.config.get("mode", "img2img")
         logger.info(f"Initialized in {self.mode} mode")
@@ -661,7 +665,23 @@ class TouchDesignerManager:
             if isinstance(output_image, Image.Image):
                 frame_np = np.array(output_image)
             elif isinstance(output_image, torch.Tensor):
-                frame_np = output_image.cpu().numpy()
+                if output_image.is_cuda:
+                    # Async GPU→CPU via pinned memory: eliminates full stream sync (saves 1-3ms/frame)
+                    if (
+                        self._pinned_output_buf is None
+                        or self._pinned_output_buf.shape != output_image.shape
+                        or self._pinned_output_buf.dtype != output_image.dtype
+                    ):
+                        self._pinned_output_buf = torch.empty(
+                            output_image.shape, dtype=output_image.dtype, pin_memory=True
+                        )
+                        self._output_copy_event = torch.cuda.Event()
+                    self._pinned_output_buf.copy_(output_image, non_blocking=True)
+                    self._output_copy_event.record()
+                    self._output_copy_event.synchronize()  # wait only for this transfer
+                    frame_np = self._pinned_output_buf.numpy()
+                else:
+                    frame_np = output_image.numpy()
                 if frame_np.shape[0] == 3:  # CHW -> HWC
                     frame_np = np.transpose(frame_np, (1, 2, 0))
             else:

--- a/StreamDiffusionTD/td_osc_handler.py
+++ b/StreamDiffusionTD/td_osc_handler.py
@@ -1,0 +1,565 @@
+"""
+OSC Parameter Handler for TouchDesigner StreamDiffusion
+
+Maps OSC addresses to the new fork's unified parameter system.
+Maintains compatibility with existing TouchDesigner OSC patterns.
+"""
+
+import json
+import logging
+import threading
+import time
+from typing import Any, Dict
+
+from pythonosc import udp_client
+from pythonosc.dispatcher import Dispatcher
+from pythonosc.osc_server import BlockingOSCUDPServer
+
+# Logger will be configured by td_main.py based on debug_mode
+logger = logging.getLogger("OSCHandler")
+
+
+class OSCParameterHandler:
+    """
+    Handles OSC communication with TouchDesigner and maps parameters
+    to the new StreamDiffusion fork's unified parameter system.
+    """
+
+    def __init__(
+        self,
+        manager,
+        main_app=None,
+        listen_port: int = 8247,
+        transmit_port: int = 8248,
+        transmit_ip: str = "127.0.0.1",
+        debug_mode: bool = False,
+    ):
+        self.manager = manager
+        self.main_app = main_app  # Reference to main application for shutdown
+        self.listen_port = listen_port
+        self.transmit_port = transmit_port
+        self.transmit_ip = transmit_ip
+        self.debug_mode = debug_mode
+
+        # OSC communication
+        self.server = None
+        self.client = udp_client.SimpleUDPClient(transmit_ip, transmit_port)
+        self.server_thread = None
+        self.running = False
+
+        # Parameter batching for efficiency
+        self.parameter_batch: Dict[str, Any] = {}
+        self.batch_lock = threading.Lock()
+        self.last_batch_time = time.time()
+        self.batch_interval = 0.016  # ~60Hz parameter updates
+
+        # OSC dispatcher setup
+        self.dispatcher = Dispatcher()
+        self._setup_osc_handlers()
+
+        logger.info(
+            f"OSC Handler initialized - Listen: {listen_port}, Transmit: {transmit_port}"
+        )
+
+    def start(self) -> None:
+        """Start OSC server in separate thread"""
+        if self.running:
+            return
+
+        self.running = True
+
+        try:
+            self.server = BlockingOSCUDPServer(
+                (self.transmit_ip, self.listen_port), self.dispatcher
+            )
+            self.server_thread = threading.Thread(target=self._server_loop, daemon=True)
+            self.server_thread.start()
+
+            # Start parameter batch processing
+            batch_thread = threading.Thread(
+                target=self._parameter_batch_loop, daemon=True
+            )
+            batch_thread.start()
+
+            logger.info(f"OSC server started on {self.transmit_ip}:{self.listen_port}")
+
+        except Exception as e:
+            logger.error(f"Failed to start OSC server: {e}")
+            self.running = False
+            raise
+
+    def stop(self) -> None:
+        """Stop OSC server"""
+        if not self.running:
+            return
+
+        logger.info("Stopping OSC server...")
+        self.running = False
+
+        if self.server:
+            self.server.shutdown()
+
+        if self.server_thread and self.server_thread.is_alive():
+            self.server_thread.join(timeout=2.0)
+
+        logger.info("OSC server stopped")
+
+    def send_message(self, address: str, value: Any) -> None:
+        """Send OSC message to TouchDesigner"""
+        try:
+            self.client.send_message(address, value)
+        except Exception as e:
+            logger.error(f"Error sending OSC message {address}: {e}")
+
+    def _server_loop(self) -> None:
+        """OSC server loop"""
+        try:
+            self.server.serve_forever()
+        except Exception as e:
+            if self.running:
+                logger.error(f"OSC server error: {e}")
+
+    def _parameter_batch_loop(self) -> None:
+        """
+        Process parameter updates in batches for efficiency.
+        This prevents overwhelming the StreamDiffusion wrapper with rapid updates.
+        """
+        while self.running:
+            try:
+                current_time = time.time()
+
+                if current_time - self.last_batch_time >= self.batch_interval:
+                    with self.batch_lock:
+                        if self.parameter_batch:
+                            # Send batched parameters to manager
+                            self.manager.update_parameters(self.parameter_batch.copy())
+                            self.parameter_batch.clear()
+                            self.last_batch_time = current_time
+
+                time.sleep(0.001)  # Small sleep to prevent busy waiting
+
+            except Exception as e:
+                logger.error(f"Error in parameter batch loop: {e}")
+                time.sleep(0.1)
+
+    def _queue_parameter_update(self, param_name: str, value: Any) -> None:
+        """Queue a parameter for batched update"""
+        with self.batch_lock:
+            self.parameter_batch[param_name] = value
+
+    def _setup_osc_handlers(self) -> None:
+        """Setup OSC message handlers mapping to new fork's parameter system"""
+
+        # === Core Generation Parameters ===
+        self.dispatcher.map(
+            "/guidance_scale",
+            lambda addr, *args: self._queue_parameter_update(
+                "guidance_scale", float(args[0])
+            ),
+        )
+
+        self.dispatcher.map(
+            "/delta",
+            lambda addr, *args: self._queue_parameter_update("delta", float(args[0])),
+        )
+
+        self.dispatcher.map(
+            "/num_inference_steps",
+            lambda addr, *args: self._queue_parameter_update(
+                "num_inference_steps", int(args[0])
+            ),
+        )
+
+        self.dispatcher.map(
+            "/seed",
+            lambda addr, *args: self._queue_parameter_update("seed", int(args[0])),
+        )
+
+        # === T-Index List ===
+        self.dispatcher.map(
+            "/t_list",
+            lambda addr, *args: self._queue_parameter_update(
+                "t_index_list", list(args)
+            ),
+        )
+
+        # === Prompt Handling (NEW: supports both single and blending) ===
+        self.dispatcher.map("/prompt", self._handle_single_prompt)
+        self.dispatcher.map(
+            "/negative_prompt",
+            lambda addr, *args: self._queue_parameter_update(
+                "negative_prompt", str(args[0])
+            ),
+        )
+
+        # NEW: Prompt blending support
+        self.dispatcher.map("/prompt_list", self._handle_prompt_list)
+        self.dispatcher.map(
+            "/prompt_interpolation_method",
+            lambda addr, *args: self._queue_parameter_update(
+                "prompt_interpolation_method", str(args[0])
+            ),
+        )
+
+        # === Seed Blending (NEW) ===
+        self.dispatcher.map("/seed_list", self._handle_seed_list)
+        self.dispatcher.map(
+            "/seed_interpolation_method",
+            lambda addr, *args: self._queue_parameter_update(
+                "seed_interpolation_method", str(args[0])
+            ),
+        )
+
+        # === ControlNet Support (NEW: Multi-ControlNet) ===
+        self.dispatcher.map("/controlnets", self._handle_controlnet_config)
+
+        # Only keep use_controlnet for enabling/disabling (sets conditioning scale to 0)
+        self.dispatcher.map("/use_controlnet", self._handle_controlnet_enable)
+
+        # === IPAdapter Support (NEW) ===
+        self.dispatcher.map("/ipadapter_config", self._handle_ipadapter_config)
+        self.dispatcher.map(
+            "/ipadapter_scale",
+            lambda addr, *args: self._queue_parameter_update(
+                "ipadapter_config", {"scale": float(args[0])}
+            ),
+        )
+        self.dispatcher.map("/ipadapter_enable", self._handle_ipadapter_enable)
+        self.dispatcher.map("/ipadapter_update", self._handle_ipadapter_update)
+
+        # === Cached Attention / StreamV2V (live-updateable) ===
+        self.dispatcher.map("/cached_attention", self._handle_cached_attention_config)
+
+        # === Mode Switching (txt2img/img2img) ===
+        self.dispatcher.map("/sdmode", self._handle_mode_switch)
+
+        # === Latent Preprocessing (Latent Feedback) ===
+        self.dispatcher.map(
+            "/latent_feedback_strength", self._handle_latent_feedback_strength
+        )
+
+        # === FX Dynamic Parameters (Latent-domain processors) ===
+        # Generic handler for all FX processor parameters
+        self.dispatcher.map("/fx/*", self._handle_fx_parameter)
+
+        # === System Commands ===
+        self.dispatcher.map("/start_streaming", self._handle_start_streaming)
+        self.dispatcher.map("/stop_streaming", self._handle_stop_streaming)
+        self.dispatcher.map(
+            "/stop", self._handle_stop_application
+        )  # Main application stop (like main_sdtd.py)
+        self.dispatcher.map("/pause", self._handle_pause_streaming)
+        self.dispatcher.map("/play", self._handle_resume_streaming)
+        self.dispatcher.map("/process_frame", self._handle_process_frame)
+        self.dispatcher.map("/frame_ack", self._handle_frame_acknowledgment)
+        self.dispatcher.map("/get_status", self._handle_get_status)
+
+        # === Heartbeat removed - now handled by OSCReporter in td_main.py ===
+        # This handler now focuses solely on parameter updates
+
+    # === Handler Methods ===
+
+    def _handle_single_prompt(self, address, *args):
+        """Handle single prompt (maintains compatibility)"""
+        prompt_text = str(args[0])
+        # Convert single prompt to prompt_list format for unified handling
+        prompt_list = [(prompt_text, 1.0)]
+        self._queue_parameter_update("prompt_list", prompt_list)
+
+    def _handle_prompt_list(self, address, *args):
+        """Handle prompt list for blending - expects JSON string"""
+        try:
+            prompt_data = json.loads(args[0])
+            # Convert to list of tuples: [(text, weight), ...]
+            prompt_list = [(item[0], float(item[1])) for item in prompt_data]
+            self._queue_parameter_update("prompt_list", prompt_list)
+        except Exception as e:
+            logger.error(f"Error parsing prompt_list: {e}")
+
+    def _handle_seed_list(self, address, *args):
+        """Handle seed list for blending - expects JSON string"""
+        try:
+            seed_data = json.loads(args[0])
+            # Convert to list of tuples: [(seed, weight), ...]
+            seed_list = [(int(item[0]), float(item[1])) for item in seed_data]
+            self._queue_parameter_update("seed_list", seed_list)
+        except Exception as e:
+            logger.error(f"Error parsing seed_list: {e}")
+
+    def _handle_controlnet_config(self, address, *args):
+        """Handle full ControlNet configuration array"""
+        try:
+            controlnet_data = json.loads(args[0])
+            self._queue_parameter_update("controlnet_config", controlnet_data)
+        except Exception as e:
+            logger.error(f"Error parsing controlnet config: {e}")
+
+    def _handle_controlnet_enable(self, address, *args):
+        """Enable/disable ControlNet by setting conditioning scale to 0"""
+        enabled = bool(args[0])
+        if enabled:
+            # Enable: Let extension handle proper config via /controlnets
+            logger.info("ControlNet enabled via OSC")
+        else:
+            # Disable: Set conditioning scale to 0 for all ControlNets
+            controlnet_config = [{"enabled": False, "conditioning_scale": 0.0}]
+            self._queue_parameter_update("controlnet_config", controlnet_config)
+            logger.info("ControlNet disabled via OSC (conditioning scale set to 0)")
+
+    def _handle_ipadapter_config(self, address, *args):
+        """Handle IPAdapter configuration"""
+        try:
+            ipadapter_data = json.loads(args[0])
+            self._queue_parameter_update("ipadapter_config", ipadapter_data)
+        except Exception as e:
+            logger.error(f"Error parsing ipadapter config: {e}")
+
+    def _handle_ipadapter_enable(self, address, *args):
+        """Handle IPAdapter enable/disable"""
+        enabled = bool(args[0])
+        self._queue_parameter_update("use_ipadapter", enabled)
+        logger.info(f"IPAdapter {'enabled' if enabled else 'disabled'}")
+
+    def _handle_ipadapter_update(self, address, *args):
+        """Handle IPAdapter update request (triggers image loading from SharedMemory)"""
+        logger.info(f"OSC: Received {address}")
+        try:
+            if self.manager:
+                self.manager.request_ipadapter_update()
+            else:
+                logger.warning("No manager reference - cannot trigger IPAdapter update")
+        except Exception as e:
+            logger.error(f"Error handling IPAdapter update: {e}")
+
+    def _handle_cached_attention_config(self, address, *args):
+        """Handle Cached Attention (StreamV2V) configuration - live updateable"""
+        try:
+            config = json.loads(args[0])
+            # Queue both cache params for batched update
+            if "cache_maxframes" in config:
+                self._queue_parameter_update(
+                    "cache_maxframes", int(config["cache_maxframes"])
+                )
+            if "cache_interval" in config:
+                self._queue_parameter_update(
+                    "cache_interval", int(config["cache_interval"])
+                )
+        except Exception as e:
+            logger.error(f"Error parsing cached_attention config: {e}")
+
+    def _handle_mode_switch(self, address, *args):
+        """Handle mode switching between txt2img and img2img"""
+        mode = str(args[0])
+        logger.info(f"OSC: Received /sdmode = {mode}")
+        if mode in ["txt2img", "img2img"]:
+            try:
+                if self.manager:
+                    self.manager.set_mode(mode)
+                    self.send_message("/mode_status", mode)
+                else:
+                    logger.warning("No manager reference - cannot switch mode")
+            except Exception as e:
+                logger.error(f"Error switching mode: {e}")
+        else:
+            logger.warning(f"Invalid mode: {mode} (must be 'txt2img' or 'img2img')")
+
+    def _handle_latent_feedback_strength(self, address, *args):
+        """Handle latent feedback strength updates for temporal consistency"""
+        feedback_strength = float(args[0])
+
+        try:
+            if hasattr(self.manager, "wrapper") and self.manager.wrapper:
+                stream = self.manager.wrapper.stream
+
+                if hasattr(stream, "_latent_preprocessing_module"):
+                    module = stream._latent_preprocessing_module
+                    for processor in module.processors:
+                        if processor.__class__.__name__ == "LatentFeedbackPreprocessor":
+                            processor.feedback_strength = feedback_strength
+                            return
+
+                logger.warning("LatentFeedbackPreprocessor not found")
+        except Exception as e:
+            logger.error(f"Error updating latent feedback strength: {e}")
+
+    def _handle_fx_parameter(self, address, *args):
+        """
+        DYNAMIC handler for FX processor parameters.
+
+        Format: /fx/{processor_type}/{param_name}
+        Example:
+            /fx/latent_transform/zoom 1.05
+            /fx/feedback_transform/feedback_strength 0.8
+            /fx/any_new_processor/any_param value
+
+        Works with ANY processor in ANY module - no hardcoding needed!
+        Automatically discovers processors across all preprocessing/postprocessing modules:
+        - _image_preprocessing_module
+        - _latent_preprocessing_module
+        - _latent_postprocessing_module
+        - _image_postprocessing_module
+
+        Just ensure StreamDiffusionExt.py generates matching OSC addresses!
+        """
+        # Removed noisy log: logger.debug(f"FX OSC received: {address} = {args}")
+
+        try:
+            # Parse address: /fx/processor_type/param_name
+            parts = address.split("/")[2:]  # Skip empty string and 'fx'
+            if len(parts) != 2:
+                logger.warning(
+                    f"Invalid FX parameter address: {address} (expected /fx/processor/param)"
+                )
+                return
+
+            processor_type = parts[0]  # e.g., 'feedback_transform', 'latent_transform'
+            param_name = parts[1]  # e.g., 'zoom', 'feedback_strength'
+            param_value = args[0]
+
+            # Removed noisy log: logger.debug(f"Parsed FX: processor={processor_type}, param={param_name}, value={param_value}")
+
+            if not (hasattr(self.manager, "wrapper") and self.manager.wrapper):
+                logger.warning("Manager or wrapper not available")
+                return
+
+            stream = self.manager.wrapper.stream
+            # Removed noisy log: logger.debug(f"Scanning all modules for processor type '{processor_type}'...")
+
+            # DYNAMIC: Search all preprocessing/postprocessing modules
+            module_names = [
+                "_image_preprocessing_module",
+                "_latent_preprocessing_module",
+                "_latent_postprocessing_module",
+                "_image_postprocessing_module",
+            ]
+
+            # Convert processor_type to expected class name pattern
+            # Examples:
+            #   'feedback_transform' -> 'FeedbackTransformPreprocessor'
+            #   'latent_transform' -> 'LatentTransformPreprocessor'
+            #   'latent_feedback' -> 'LatentFeedbackPreprocessor'
+            #   'custom_effect' -> 'CustomEffectPreprocessor' or 'CustomEffectPostprocessor'
+
+            # Try both Preprocessor and Postprocessor suffixes
+            processor_type_title = "".join(
+                word.capitalize() for word in processor_type.split("_")
+            )
+            possible_class_names = [
+                f"{processor_type_title}Preprocessor",
+                f"{processor_type_title}Postprocessor",
+                processor_type_title,  # In case class name exactly matches (no suffix)
+            ]
+
+            # Removed noisy log: logger.debug(f"Looking for class names: {possible_class_names}")
+
+            # Search all modules
+            for module_name in module_names:
+                if not hasattr(stream, module_name):
+                    continue
+
+                module = getattr(stream, module_name)
+                if not hasattr(module, "processors"):
+                    continue
+
+                # Removed noisy log: logger.debug(f"Checking {module_name} ({len(module.processors)} processors)")
+
+                # Search processors in this module
+                for processor in module.processors:
+                    class_name = processor.__class__.__name__
+
+                    # Check if this processor matches our target
+                    if class_name in possible_class_names:
+                        # Removed noisy log: logger.debug(f"Found matching processor: {class_name} in {module_name}")
+
+                        # Verify attribute exists
+                        if hasattr(processor, param_name):
+                            setattr(processor, param_name, param_value)
+                            # Successfully updated parameter (noisy logs removed)
+                            return
+                        else:
+                            logger.warning(
+                                f"{class_name} has no attribute '{param_name}' (available: {dir(processor)})"
+                            )
+                            return
+
+            # Not found in any module
+            logger.warning(
+                f"Processor '{processor_type}' (looking for {possible_class_names}) not found in any module"
+            )
+            logger.debug(
+                f"Available modules: {[name for name in module_names if hasattr(stream, name)]}"
+            )
+
+        except Exception as e:
+            logger.error(f"Error updating FX parameter {address}: {e}", exc_info=True)
+
+    def _handle_start_streaming(self, address, *args):
+        """Handle start streaming command"""
+        try:
+            self.manager.start_streaming()
+            self.send_message("/streaming_status", "started")
+        except Exception as e:
+            logger.error(f"Error starting streaming: {e}")
+            self.send_message("/streaming_status", f"error: {e}")
+
+    def _handle_stop_streaming(self, address, *args):
+        """Handle stop streaming command"""
+        try:
+            self.manager.stop_streaming()
+            self.send_message("/streaming_status", "stopped")
+        except Exception as e:
+            logger.error(f"Error stopping streaming: {e}")
+
+    def _handle_stop_application(self, address, *args):
+        """Handle stop application command (shuts down entire app like main_sdtd.py)"""
+        logger.info(f"OSC: Received {address}")
+        try:
+            if self.main_app:
+                self.main_app.request_shutdown()
+                self.send_message("/application_status", "stopping")
+            else:
+                logger.warning("No main app reference - cannot stop application")
+        except Exception as e:
+            logger.error(f"Error stopping application: {e}")
+
+    def _handle_pause_streaming(self, address, *args):
+        """Handle pause streaming command"""
+        logger.info(f"OSC: Received {address}")
+        try:
+            self.manager.pause_streaming()
+            self.send_message("/streaming_status", "paused")
+        except Exception as e:
+            logger.error(f"Error pausing streaming: {e}")
+
+    def _handle_resume_streaming(self, address, *args):
+        """Handle resume streaming command"""
+        logger.info(f"OSC: Received {address}")
+        try:
+            self.manager.resume_streaming()
+            self.send_message("/streaming_status", "resumed")
+        except Exception as e:
+            logger.error(f"Error resuming streaming: {e}")
+
+    def _handle_process_frame(self, address, *args):
+        """Handle process single frame command (when paused)"""
+        # Don't log every process_frame - too noisy
+        try:
+            self.manager.process_single_frame()
+        except Exception as e:
+            logger.error(f"Error processing frame: {e}")
+
+    def _handle_frame_acknowledgment(self, address, *args):
+        """Handle frame acknowledgment from TouchDesigner"""
+        # Don't log frame acks - too frequent
+        try:
+            self.manager.acknowledge_frame()
+        except Exception as e:
+            logger.error(f"Error handling frame acknowledgment: {e}")
+
+    def _handle_get_status(self, address, *args):
+        """Handle status request"""
+        try:
+            status = self.manager.get_stream_state()
+            self.send_message("/status", json.dumps(status))
+        except Exception as e:
+            logger.error(f"Error getting status: {e}")

--- a/StreamDiffusionTD/working_models.json
+++ b/StreamDiffusionTD/working_models.json
@@ -1,0 +1,5 @@
+[
+    "stabilityai/sd-turbo",
+    "prompthero/openjourney-v4",
+    "stabilityai/sdxl-turbo"
+]

--- a/demo/realtime-img2img/app_config.py
+++ b/demo/realtime-img2img/app_config.py
@@ -1,46 +1,51 @@
 """
 Application configuration and settings for realtime-img2img
 """
-import yaml
+
 import logging
 from pathlib import Path
+
+import yaml
+
 
 def load_controlnet_registry():
     """Load ControlNet registry from config file"""
     try:
         registry_path = Path(__file__).parent / "controlnet_registry.yaml"
-        with open(registry_path, 'r') as f:
+        with open(registry_path, "r") as f:
             config_data = yaml.safe_load(f)
-        
+
         # Extract the available_controlnets section
-        return config_data.get('available_controlnets', {})
+        return config_data.get("available_controlnets", {})
     except Exception as e:
         logging.exception(f"load_controlnet_registry: Failed to load ControlNet registry: {e}")
         # Fallback to empty registry
         return {}
 
+
 def load_default_settings():
     """Load default settings from YAML config file"""
     try:
         registry_path = Path(__file__).parent / "controlnet_registry.yaml"
-        with open(registry_path, 'r') as f:
+        with open(registry_path, "r") as f:
             config_data = yaml.safe_load(f)
-        
-        return config_data.get('defaults', {})
+
+        return config_data.get("defaults", {})
     except Exception as e:
         logging.exception(f"load_default_settings: Failed to load default settings: {e}")
         # Fallback to hardcoded defaults
         return {
-            'guidance_scale': 1.1,
-            'delta': 0.7,
-            'num_inference_steps': 50,
-            'seed': 2,
-            't_index_list': [35, 45],
-            'ipadapter_scale': 1.0,
-            'normalize_prompt_weights': True,
-            'normalize_seed_weights': True,
-            'prompt': "Portrait of The Joker halloween costume, face painting, with , glare pose, detailed, intricate, full of colour, cinematic lighting, trending on artstation, 8k, hyperrealistic, focused, extreme details, unreal engine 5 cinematic, masterpiece"
+            "guidance_scale": 1.1,
+            "delta": 0.7,
+            "num_inference_steps": 50,
+            "seed": 2,
+            "t_index_list": [35, 45],
+            "ipadapter_scale": 1.0,
+            "normalize_prompt_weights": True,
+            "normalize_seed_weights": True,
+            "prompt": "Portrait of The Joker halloween costume, face painting, with , glare pose, detailed, intricate, full of colour, cinematic lighting, trending on artstation, 8k, hyperrealistic, focused, extreme details, unreal engine 5 cinematic, masterpiece",
         }
+
 
 # Load configuration at module level
 AVAILABLE_CONTROLNETS = load_controlnet_registry()

--- a/demo/realtime-img2img/config.py
+++ b/demo/realtime-img2img/config.py
@@ -1,6 +1,6 @@
-from typing import NamedTuple
 import argparse
 import os
+from typing import NamedTuple
 
 
 class Args(NamedTuple):
@@ -45,9 +45,7 @@ parser = argparse.ArgumentParser(description="Run the app")
 parser.add_argument("--host", type=str, default=default_host, help="Host address")
 parser.add_argument("--port", type=int, default=default_port, help="Port number")
 parser.add_argument("--reload", action="store_true", help="Reload code on change")
-parser.add_argument(
-    "--mode", type=str, default=default_mode, help="App Inferece Mode: txt2img, img2img"
-)
+parser.add_argument("--mode", type=str, default=default_mode, help="App Inferece Mode: txt2img, img2img")
 parser.add_argument(
     "--max-queue-size",
     dest="max_queue_size",

--- a/demo/realtime-img2img/connection_manager.py
+++ b/demo/realtime-img2img/connection_manager.py
@@ -1,10 +1,12 @@
-from typing import Dict, Union
-from uuid import UUID
 import asyncio
-from fastapi import WebSocket
-from starlette.websockets import WebSocketState
 import logging
 from types import SimpleNamespace
+from typing import Dict, Union
+from uuid import UUID
+
+from fastapi import WebSocket
+from starlette.websockets import WebSocketState
+
 
 Connections = Dict[UUID, Dict[str, Union[WebSocket, asyncio.Queue]]]
 
@@ -20,9 +22,7 @@ class ConnectionManager:
         self.active_connections: Connections = {}
         self.latest_data: Dict[UUID, SimpleNamespace] = {}  # Store latest parameters for HTTP streaming
 
-    async def connect(
-        self, user_id: UUID, websocket: WebSocket, max_queue_size: int = 0
-    ):
+    async def connect(self, user_id: UUID, websocket: WebSocket, max_queue_size: int = 0):
         await websocket.accept()
         user_count = self.get_user_count()
         print(f"User count: {user_count}")
@@ -61,7 +61,7 @@ class ConnectionManager:
                 return await queue.get()
             except asyncio.QueueEmpty:
                 return None
-                
+
     def get_latest_data_sync(self, user_id: UUID) -> SimpleNamespace:
         """Get the latest data without consuming it from the queue (for HTTP streaming)"""
         return self.latest_data.get(user_id)

--- a/demo/realtime-img2img/img2img.py
+++ b/demo/realtime-img2img/img2img.py
@@ -1,6 +1,7 @@
-import sys
-import os
 import logging
+import os
+import sys
+
 
 sys.path.append(
     os.path.join(
@@ -12,10 +13,11 @@ sys.path.append(
 
 # Config system functions are now used only in main.py
 
+
 import torch
-from pydantic import BaseModel, Field
 from PIL import Image
-from typing import Optional
+from pydantic import BaseModel, Field
+
 
 # Default values for pipeline parameters
 default_negative_prompt = "black and white, blurry, low resolution, pixelated,  pixel art, low quality, low fidelity"
@@ -78,26 +80,22 @@ class Pipeline:
                 "768x512 (3:2)",
                 "896x640 (7:5)",
                 "1024x768 (4:3)",
-                "1024x576 (16:9)"
-            ]
+                "1024x576 (16:9)",
+            ],
         )
-        width: int = Field(
-            512, min=2, max=15, title="Width", disabled=True, hide=True, id="width"
-        )
-        height: int = Field(
-            512, min=2, max=15, title="Height", disabled=True, hide=True, id="height"
-        )
+        width: int = Field(512, min=2, max=15, title="Width", disabled=True, hide=True, id="width")
+        height: int = Field(512, min=2, max=15, title="Height", disabled=True, hide=True, id="height")
 
-#TODO update naming convention to reflect the controlnet agnostic nature of the config system (pipeline_config instead of controlnet_config for example)
+    # TODO update naming convention to reflect the controlnet agnostic nature of the config system (pipeline_config instead of controlnet_config for example)
     def __init__(self, wrapper, config):
         """
         Initialize Pipeline with pre-created wrapper and config.
-        
+
         Args:
             wrapper: Pre-created StreamDiffusionWrapper instance
             config: Configuration dictionary used to create the wrapper
         """
-        
+
         # IPAdapter state tracking for optimization
         self._last_ipadapter_source_type = None
         self._last_ipadapter_source_data = None
@@ -106,16 +104,16 @@ class Pipeline:
         self.stream = wrapper
         self.config = config
         self.use_config = True
-        
+
         # Extract pipeline configuration from config
-        self.pipeline_mode = self.config.get('mode', 'img2img')
-        self.has_controlnet = 'controlnets' in self.config and len(self.config['controlnets']) > 0
-        self.has_ipadapter = 'ipadapters' in self.config and len(self.config['ipadapters']) > 0
-        
+        self.pipeline_mode = self.config.get("mode", "img2img")
+        self.has_controlnet = "controlnets" in self.config and len(self.config["controlnets"]) > 0
+        self.has_ipadapter = "ipadapters" in self.config and len(self.config["ipadapters"]) > 0
+
         # Store config values for later use
-        self.negative_prompt = self.config.get('negative_prompt', default_negative_prompt)
-        self.guidance_scale = self.config.get('guidance_scale', 1.2)
-        self.num_inference_steps = self.config.get('num_inference_steps', 50)
+        self.negative_prompt = self.config.get("negative_prompt", default_negative_prompt)
+        self.guidance_scale = self.config.get("guidance_scale", 1.2)
+        self.num_inference_steps = self.config.get("num_inference_steps", 50)
 
         # Update input_mode based on pipeline mode
         self.info = self.Info()
@@ -129,23 +127,23 @@ class Pipeline:
         self.guidance_scale = 1.1
         self.num_inference_steps = 50
         self.negative_prompt = default_negative_prompt
-        
+
         # Store output type for frame conversion - always force "pt" for optimal performance
         self.output_type = "pt"
 
     def predict(self, params: "Pipeline.InputParams") -> Image.Image:
         # Get input manager if available (passed from websocket handler)
-        input_manager = getattr(params, 'input_manager', None)
-        
+        input_manager = getattr(params, "input_manager", None)
+
         # Handle different modes
         if self.pipeline_mode == "txt2img":
             # Text-to-image mode
-            
+
             # Handle ControlNet updates if enabled
             if self.has_controlnet:
                 try:
                     stream_state = self.stream.get_stream_state()
-                    current_cfg = stream_state.get('controlnet_config', [])
+                    current_cfg = stream_state.get("controlnet_config", [])
                 except Exception:
                     current_cfg = []
                 if current_cfg:
@@ -154,11 +152,11 @@ class Pipeline:
                         control_image = self._get_controlnet_input(input_manager, i, params.image)
                         if control_image is not None:
                             self.stream.update_control_image(index=i, image=control_image)
-            
+
             # Handle IPAdapter updates if enabled
             if self.has_ipadapter:
                 self._update_ipadapter_style_image(input_manager)
-            
+
             # Generate output based on what's enabled
             if self.has_controlnet and not self.has_ipadapter:
                 # ControlNet only: use base input for generation
@@ -176,12 +174,12 @@ class Pipeline:
                 output_image = self.stream()
         else:
             # Image-to-image mode: use original logic
-            
+
             # Handle ControlNet updates if enabled
             if self.has_controlnet:
                 try:
                     stream_state = self.stream.get_stream_state()
-                    current_cfg = stream_state.get('controlnet_config', [])
+                    current_cfg = stream_state.get("controlnet_config", [])
                 except Exception:
                     current_cfg = []
                 if current_cfg:
@@ -190,11 +188,11 @@ class Pipeline:
                         control_image = self._get_controlnet_input(input_manager, i, params.image)
                         if control_image is not None:
                             self.stream.update_control_image(index=i, image=control_image)
-            
+
             # Handle IPAdapter updates if enabled
             if self.has_ipadapter:
                 self._update_ipadapter_style_image(input_manager)
-            
+
             # Generate output based on what's enabled
             if self.has_controlnet or self.has_ipadapter:
                 # ControlNet and/or IPAdapter: use base input for img2img
@@ -216,150 +214,153 @@ class Pipeline:
     def _get_controlnet_input(self, input_manager, index: int, fallback_image):
         """
         Get input image for a specific ControlNet index.
-        
+
         Args:
             input_manager: InputSourceManager instance (can be None)
             index: ControlNet index
             fallback_image: Fallback image if no specific source is configured
-            
+
         Returns:
             Input image for the ControlNet or fallback
         """
         if input_manager:
-            frame = input_manager.get_frame('controlnet', index)
+            frame = input_manager.get_frame("controlnet", index)
             if frame is not None:
                 return frame
-        
+
         # Fallback to main image input
         return fallback_image
-    
+
     def _get_ipadapter_input(self, input_manager):
         """
         Get input image for IPAdapter.
-        
+
         Args:
             input_manager: InputSourceManager instance (can be None)
-            
+
         Returns:
             Input image for IPAdapter or None
         """
         if input_manager:
-            return input_manager.get_frame('ipadapter')
+            return input_manager.get_frame("ipadapter")
         return None
-    
+
     def _update_ipadapter_style_image(self, input_manager):
         """
         Update IPAdapter style image from InputSourceManager.
         Only updates when source actually changes to avoid unnecessary processing.
-        
+
         Args:
             input_manager: InputSourceManager instance (can be None)
         """
         if not input_manager or not self.has_ipadapter:
             return
-            
+
         try:
             # Get current source info to check if it changed
-            source_info = input_manager.get_source_info('ipadapter')
-            current_source_type = source_info.get('source_type')
-            current_source_data = source_info.get('source_data')
-            is_stream = source_info.get('is_stream', False)
-            
+            source_info = input_manager.get_source_info("ipadapter")
+            current_source_type = source_info.get("source_type")
+            current_source_data = source_info.get("source_data")
+            is_stream = source_info.get("is_stream", False)
+
             # Check if source changed (for static images, only update when source changes)
             source_changed = (
-                current_source_type != self._last_ipadapter_source_type or
-                current_source_data != self._last_ipadapter_source_data
+                current_source_type != self._last_ipadapter_source_type
+                or current_source_data != self._last_ipadapter_source_data
             )
-            
+
             # For streaming sources (webcam/video), always get fresh frame
             # For static sources (uploaded image), only update when source changes
             should_update = is_stream or source_changed
-            
+
             if not should_update:
                 return  # No update needed - static source unchanged
-            
+
             # Get IPAdapter style image from input source manager
-            ipadapter_frame = input_manager.get_frame('ipadapter')
-            
+            ipadapter_frame = input_manager.get_frame("ipadapter")
+
             if ipadapter_frame is not None:
                 import torch
-                
+
                 # Use tensor directly - update_style_image expects torch tensor
                 if isinstance(ipadapter_frame, torch.Tensor):
                     try:
                         # Update IPAdapter with tensor and stream configuration
                         self.stream.update_style_image(ipadapter_frame, is_stream=is_stream)
-                        self.stream.update_stream_params(ipadapter_config={'is_stream': is_stream})
-                        
+                        self.stream.update_stream_params(ipadapter_config={"is_stream": is_stream})
+
                         # Force prompt re-encoding to apply new style image embeddings
                         # This is critical because IPAdapter embedding hook only runs during prompt encoding
                         try:
                             state = self.stream.get_stream_state()
-                            current_prompts = state.get('prompt_list', [])
+                            current_prompts = state.get("prompt_list", [])
                             if current_prompts:
                                 self.stream.update_prompt(current_prompts, prompt_interpolation_method="slerp")
                         except Exception as e:
-                            logging.exception(f"_update_ipadapter_style_image: Failed to force prompt re-encoding: {e}")
-                        
-                        
+                            logging.exception(
+                                f"_update_ipadapter_style_image: Failed to force prompt re-encoding: {e}"
+                            )
+
                         # Update tracking variables only on successful update
                         self._last_ipadapter_source_type = current_source_type
                         self._last_ipadapter_source_data = current_source_data
-                        
+
                     except Exception as e:
                         logging.exception(f"_update_ipadapter_style_image: Failed to update IPAdapter: {e}")
                 else:
-                    logging.warning("_update_ipadapter_style_image: IPAdapter frame is not a tensor, skipping style image update")
+                    logging.warning(
+                        "_update_ipadapter_style_image: IPAdapter frame is not a tensor, skipping style image update"
+                    )
         except Exception as e:
             logging.exception(f"_update_ipadapter_style_image: Error updating IPAdapter style image: {e}")
-    
+
     def _get_base_input(self, input_manager, fallback_image):
         """
         Get input image for base pipeline.
-        
+
         Args:
             input_manager: InputSourceManager instance (can be None)
             fallback_image: Fallback image if no specific source is configured
-            
+
         Returns:
             Input image for base pipeline or fallback
         """
         if input_manager:
-            frame = input_manager.get_frame('base')
+            frame = input_manager.get_frame("base")
             if frame is not None:
                 return frame
-        
+
         # Fallback to main image input
         return fallback_image
 
     def update_ipadapter_config(self, scale: float = None, style_image: Image.Image = None) -> bool:
         """
         Update IPAdapter configuration in real-time using direct methods
-        
+
         Args:
             scale: New IPAdapter scale value (optional)
             style_image: New style image (PIL Image, optional)
-            
+
         Returns:
             bool: True if successful, False otherwise
         """
         if not self.has_ipadapter:
             return False
-            
+
         if scale is None and style_image is None:
             return False  # Nothing to update
-            
+
         try:
             # Update scale via unified config system (no direct method needed)
             if scale is not None:
-                self.stream.update_stream_params(ipadapter_config={'scale': scale})
-            
+                self.stream.update_stream_params(ipadapter_config={"scale": scale})
+
             # Update style image via direct method
             if style_image is not None:
                 self.stream.update_style_image(style_image)
-                
+
             return True
-        except Exception as e:
+        except Exception:
             return False
 
     def update_ipadapter_scale(self, scale: float) -> bool:
@@ -374,21 +375,21 @@ class Pipeline:
         """Update IPAdapter weight type in real-time"""
         if not self.has_ipadapter:
             return False
-            
+
         try:
             # Use unified updater on wrapper
-            if hasattr(self.stream, 'update_stream_params'):
-                self.stream.update_stream_params(ipadapter_config={ 'weight_type': weight_type })
+            if hasattr(self.stream, "update_stream_params"):
+                self.stream.update_stream_params(ipadapter_config={"weight_type": weight_type})
                 return True
             # Should not reach here in normal operation
             return False
-        except Exception as e:
+        except Exception:
             return False
 
     def get_ipadapter_info(self) -> dict:
         """
         Get current IPAdapter information
-        
+
         Returns:
             dict: IPAdapter information including scale, model info, etc.
         """
@@ -397,35 +398,37 @@ class Pipeline:
             "scale": 1.0,
             "weight_type": "linear",
             "model_path": None,
-            "style_image_set": False
+            "style_image_set": False,
         }
-        
-        if self.has_ipadapter and self.config and 'ipadapters' in self.config:
+
+        if self.has_ipadapter and self.config and "ipadapters" in self.config:
             # Get info from first IPAdapter config
-            if len(self.config['ipadapters']) > 0:
-                ipadapter_config = self.config['ipadapters'][0]
-                info["scale"] = ipadapter_config.get('scale', 1.0)
-                info["weight_type"] = ipadapter_config.get('weight_type', 'linear')
-                info["model_path"] = ipadapter_config.get('ipadapter_model_path')
-                info["style_image_set"] = 'style_image' in ipadapter_config
-                
+            if len(self.config["ipadapters"]) > 0:
+                ipadapter_config = self.config["ipadapters"][0]
+                info["scale"] = ipadapter_config.get("scale", 1.0)
+                info["weight_type"] = ipadapter_config.get("weight_type", "linear")
+                info["model_path"] = ipadapter_config.get("ipadapter_model_path")
+                info["style_image_set"] = "style_image" in ipadapter_config
+
         # Get current runtime state from wrapper's public API
         try:
-            if hasattr(self.stream, 'get_stream_state'):
+            if hasattr(self.stream, "get_stream_state"):
                 stream_state = self.stream.get_stream_state()
-                ipadapter_runtime_config = stream_state.get('ipadapter_config', {})
+                ipadapter_runtime_config = stream_state.get("ipadapter_config", {})
                 if ipadapter_runtime_config:
-                    info["scale"] = ipadapter_runtime_config.get('scale', info.get("scale", 1.0))
-                    info["weight_type"] = ipadapter_runtime_config.get('weight_type', info.get("weight_type", 'linear'))
+                    info["scale"] = ipadapter_runtime_config.get("scale", info.get("scale", 1.0))
+                    info["weight_type"] = ipadapter_runtime_config.get(
+                        "weight_type", info.get("weight_type", "linear")
+                    )
         except Exception:
             pass  # Use defaults from config if wrapper method fails
-            
+
         return info
 
     def update_stream_params(self, **kwargs):
         """
         Update streaming parameters using the consolidated API
-        
+
         Args:
             **kwargs: All parameters supported by StreamDiffusionWrapper.update_stream_params()
                      including controlnet_config, guidance_scale, delta, etc.

--- a/demo/realtime-img2img/input_control.py
+++ b/demo/realtime-img2img/input_control.py
@@ -1,48 +1,48 @@
-from abc import ABC, abstractmethod
-from typing import Dict, Any, Callable, Optional
 import asyncio
+import logging
 import threading
 import time
-import logging
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, Optional
 
 
 class InputControl(ABC):
     """Generic interface for input controls that can modify parameters"""
-    
+
     def __init__(self, parameter_name: str, min_value: float = 0.0, max_value: float = 1.0):
         self.parameter_name = parameter_name
         self.min_value = min_value
         self.max_value = max_value
         self.is_active = False
         self.update_callback: Optional[Callable[[str, float], None]] = None
-    
+
     @abstractmethod
     async def start(self) -> None:
         """Start the input control"""
         pass
-    
+
     @abstractmethod
     async def stop(self) -> None:
         """Stop the input control"""
         pass
-    
+
     @abstractmethod
     def get_current_value(self) -> float:
         """Get the current normalized value (0.0 to 1.0)"""
         pass
-    
+
     def set_update_callback(self, callback: Callable[[str, float], None]) -> None:
         """Set callback for parameter updates"""
         self.update_callback = callback
-    
+
     def normalize_value(self, raw_value: float) -> float:
         """Normalize raw input value to 0.0-1.0 range"""
         return max(0.0, min(1.0, raw_value))
-    
+
     def scale_to_parameter(self, normalized_value: float) -> float:
         """Scale normalized value to parameter range"""
         return self.min_value + (normalized_value * (self.max_value - self.min_value))
-    
+
     def _trigger_update(self, normalized_value: float) -> None:
         """Trigger parameter update if callback is set"""
         if self.update_callback:
@@ -52,9 +52,16 @@ class InputControl(ABC):
 
 class GamepadInput(InputControl):
     """Gamepad input control for parameter modification"""
-    
-    def __init__(self, parameter_name: str, min_value: float = 0.0, max_value: float = 1.0, 
-                 gamepad_index: int = 0, axis_index: int = 0, deadzone: float = 0.1):
+
+    def __init__(
+        self,
+        parameter_name: str,
+        min_value: float = 0.0,
+        max_value: float = 1.0,
+        gamepad_index: int = 0,
+        axis_index: int = 0,
+        deadzone: float = 0.1,
+    ):
         super().__init__(parameter_name, min_value, max_value)
         self.gamepad_index = gamepad_index
         self.axis_index = axis_index
@@ -62,78 +69,78 @@ class GamepadInput(InputControl):
         self.current_value = 0.0
         self._stop_event = threading.Event()
         self._thread = None
-    
+
     async def start(self) -> None:
         """Start gamepad monitoring"""
         if self.is_active:
             return
-        
+
         self.is_active = True
         self._stop_event.clear()
         self._thread = threading.Thread(target=self._monitor_gamepad, daemon=True)
         self._thread.start()
         logging.info(f"GamepadInput: Started monitoring gamepad {self.gamepad_index}, axis {self.axis_index}")
-    
+
     async def stop(self) -> None:
         """Stop gamepad monitoring"""
         if not self.is_active:
             return
-        
+
         self.is_active = False
         self._stop_event.set()
-        
+
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=1.0)
-        
+
         logging.info(f"GamepadInput: Stopped monitoring gamepad {self.gamepad_index}, axis {self.axis_index}")
-    
+
     def get_current_value(self) -> float:
         """Get current normalized value"""
         return self.current_value
-    
+
     def _monitor_gamepad(self) -> None:
         """Monitor gamepad input in background thread"""
         try:
             import pygame
-            
+
             # Initialize pygame for gamepad support
             pygame.init()
             pygame.joystick.init()
-            
+
             # Check if gamepad is available
             if pygame.joystick.get_count() <= self.gamepad_index:
                 logging.error(f"GamepadInput: Gamepad {self.gamepad_index} not found")
                 return
-            
+
             # Initialize the gamepad
             joystick = pygame.joystick.Joystick(self.gamepad_index)
             joystick.init()
-            
+
             logging.info(f"GamepadInput: Connected to {joystick.get_name()}")
-            
+
             # Monitor gamepad input
             while not self._stop_event.is_set():
                 pygame.event.pump()
-                
+
                 # Get axis value
                 if self.axis_index < joystick.get_numaxes():
                     raw_value = joystick.get_axis(self.axis_index)
-                    
+
                     # Apply deadzone
                     if abs(raw_value) < self.deadzone:
                         raw_value = 0.0
-                    
+
                     # Convert from [-1, 1] to [0, 1] range
                     normalized_value = (raw_value + 1.0) / 2.0
-                    
+
                     # Update current value
                     self.current_value = normalized_value
-                    
+
                     # Trigger update callback
                     self._trigger_update(normalized_value)
-                
+
                 time.sleep(0.016)  # ~60 FPS polling
-                
+
         except ImportError:
             logging.error("GamepadInput: pygame not installed. Install with: pip install pygame")
         except Exception as e:
@@ -150,48 +157,48 @@ class GamepadInput(InputControl):
 
 class InputManager:
     """Manages multiple input controls"""
-    
+
     def __init__(self):
         self.inputs: Dict[str, InputControl] = {}
         self.parameter_update_callback: Optional[Callable[[str, float], None]] = None
-    
+
     def add_input(self, input_id: str, input_control: InputControl) -> None:
         """Add an input control"""
         input_control.set_update_callback(self._handle_parameter_update)
         self.inputs[input_id] = input_control
         logging.info(f"InputManager: Added input control {input_id} for parameter {input_control.parameter_name}")
-    
+
     def remove_input(self, input_id: str) -> None:
         """Remove an input control"""
         if input_id in self.inputs:
             asyncio.create_task(self.inputs[input_id].stop())
             del self.inputs[input_id]
             logging.info(f"InputManager: Removed input control {input_id}")
-    
+
     async def start_input(self, input_id: str) -> None:
         """Start a specific input control"""
         if input_id in self.inputs:
             await self.inputs[input_id].start()
-    
+
     async def stop_input(self, input_id: str) -> None:
         """Stop a specific input control"""
         if input_id in self.inputs:
             await self.inputs[input_id].stop()
-    
+
     async def start_all(self) -> None:
         """Start all input controls"""
         for input_control in self.inputs.values():
             await input_control.start()
-    
+
     async def stop_all(self) -> None:
         """Stop all input controls"""
         for input_control in self.inputs.values():
             await input_control.stop()
-    
+
     def set_parameter_update_callback(self, callback: Callable[[str, float], None]) -> None:
         """Set callback for parameter updates from any input"""
         self.parameter_update_callback = callback
-    
+
     def get_input_status(self) -> Dict[str, Dict[str, Any]]:
         """Get status of all inputs"""
         status = {}
@@ -201,10 +208,10 @@ class InputManager:
                 "is_active": input_control.is_active,
                 "current_value": input_control.get_current_value(),
                 "min_value": input_control.min_value,
-                "max_value": input_control.max_value
+                "max_value": input_control.max_value,
             }
         return status
-    
+
     def _handle_parameter_update(self, parameter_name: str, value: float) -> None:
         """Handle parameter update from input controls"""
         if self.parameter_update_callback:

--- a/demo/realtime-img2img/input_sources.py
+++ b/demo/realtime-img2img/input_sources.py
@@ -8,19 +8,19 @@ This module provides a flexible input routing system for different components
 
 import logging
 from enum import Enum
-from typing import Dict, Optional, Union, Any
 from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+import numpy as np
 import torch
 from PIL import Image
-import cv2
-import numpy as np
-
 from util import bytes_to_pt
 from utils.video_utils import VideoFrameExtractor
 
 
 class InputSourceType(Enum):
     """Types of input sources available."""
+
     WEBCAM = "webcam"
     UPLOADED_IMAGE = "uploaded_image"
     UPLOADED_VIDEO = "uploaded_video"
@@ -29,15 +29,15 @@ class InputSourceType(Enum):
 class InputSource:
     """
     Represents an input source for a component.
-    
+
     Handles different types of inputs (webcam, image, video) and provides
     a unified interface to get the current frame as a tensor.
     """
-    
+
     def __init__(self, source_type: InputSourceType, source_data: Any = None):
         """
         Initialize an input source.
-        
+
         Args:
             source_type: Type of input source
             source_data: Data for the source (PIL Image, video path, or None for webcam)
@@ -48,11 +48,11 @@ class InputSource:
         self._current_frame = None
         self._video_extractor = None
         self._logger = logging.getLogger(f"InputSource.{source_type.value}")
-        
+
         # Initialize video extractor if needed
         if source_type == InputSourceType.UPLOADED_VIDEO and source_data:
             self._init_video_extractor()
-    
+
     def _init_video_extractor(self):
         """Initialize video extractor for video input sources."""
         if self.source_data and Path(self.source_data).exists():
@@ -64,11 +64,11 @@ class InputSource:
                 self._video_extractor = None
         else:
             self._logger.error(f"Video file not found: {self.source_data}")
-    
+
     def get_frame(self) -> Optional[torch.Tensor]:
         """
         Get the current frame as a PyTorch tensor.
-        
+
         Returns:
             torch.Tensor: Current frame with shape (C, H, W), values in [0, 1], dtype float32
             None: If no frame is available
@@ -77,7 +77,7 @@ class InputSource:
             if self.source_type == InputSourceType.WEBCAM:
                 # For webcam, return cached frame (will be updated externally)
                 return self._current_frame
-            
+
             elif self.source_type == InputSourceType.UPLOADED_IMAGE:
                 # For static image, convert to tensor if not already done
                 if self._current_frame is None and self.source_data:
@@ -91,35 +91,35 @@ class InputSource:
                     elif isinstance(self.source_data, bytes):
                         # Convert bytes to tensor using existing utility
                         self._current_frame = bytes_to_pt(self.source_data)
-                
+
                 return self._current_frame
-            
+
             elif self.source_type == InputSourceType.UPLOADED_VIDEO:
                 # For video, get next frame
                 return self._get_video_frame()
-            
+
         except Exception as e:
             self._logger.error(f"Error getting frame from {self.source_type.value}: {e}")
-            
+
         return None
-    
+
     def _get_video_frame(self) -> Optional[torch.Tensor]:
         """Get the next frame from video source."""
         if not self._video_extractor:
             return None
-        
+
         return self._video_extractor.get_frame()
-    
+
     def update_webcam_frame(self, frame_data: Union[bytes, torch.Tensor]):
         """
         Update the current frame for webcam sources.
-        
+
         Args:
             frame_data: Frame data as bytes or tensor
         """
         if self.source_type != InputSourceType.WEBCAM:
             return
-        
+
         try:
             if isinstance(frame_data, bytes):
                 self._current_frame = bytes_to_pt(frame_data)
@@ -127,7 +127,7 @@ class InputSource:
                 self._current_frame = frame_data
         except Exception as e:
             self._logger.error(f"Error updating webcam frame: {e}")
-    
+
     def cleanup(self):
         """Clean up resources."""
         if self._video_extractor:
@@ -138,211 +138,224 @@ class InputSource:
 class InputSourceManager:
     """
     Manages input sources for different components in the pipeline.
-    
+
     Provides a centralized way to set and get input sources for:
     - ControlNet instances (indexed)
-    - IPAdapter 
+    - IPAdapter
     - Base pipeline
     """
-    
+
     def __init__(self):
         """Initialize the input source manager."""
         self.sources = {
-            'controlnet': {},  # {index: InputSource}
-            'ipadapter': None,  # Single InputSource
-            'base': None       # Single InputSource for main pipeline
+            "controlnet": {},  # {index: InputSource}
+            "ipadapter": None,  # Single InputSource
+            "base": None,  # Single InputSource for main pipeline
         }
         self._logger = logging.getLogger("InputSourceManager")
-        
+
         # Default to webcam for base pipeline
-        self.sources['base'] = InputSource(InputSourceType.WEBCAM)
-        
+        self.sources["base"] = InputSource(InputSourceType.WEBCAM)
+
         # Default IPAdapter to uploaded_image with default image
         self._init_default_ipadapter_source()
-    
+
     def set_source(self, component: str, source: InputSource, index: Optional[int] = None):
         """
         Set input source for a component.
-        
+
         Args:
             component: Component name ('controlnet', 'ipadapter', 'base')
             source: InputSource instance
             index: Index for ControlNet instances (required for 'controlnet')
         """
         try:
-            if component == 'controlnet':
+            if component == "controlnet":
                 if index is None:
                     raise ValueError("Index is required for ControlNet components")
-                
+
                 # Clean up existing source if any
-                if index in self.sources['controlnet']:
-                    self.sources['controlnet'][index].cleanup()
-                
-                self.sources['controlnet'][index] = source
+                if index in self.sources["controlnet"]:
+                    self.sources["controlnet"][index].cleanup()
+
+                self.sources["controlnet"][index] = source
                 self._logger.info(f"Set ControlNet {index} input source to {source.source_type.value}")
-                
-            elif component in ['ipadapter', 'base']:
+
+            elif component in ["ipadapter", "base"]:
                 # Clean up existing source if any
                 if self.sources[component]:
                     self.sources[component].cleanup()
-                
+
                 self.sources[component] = source
                 self._logger.info(f"Set {component} input source to {source.source_type.value}")
-                
+
             else:
                 raise ValueError(f"Unknown component: {component}")
-                
+
         except Exception as e:
             self._logger.error(f"Error setting source for {component}: {e}")
-    
+
     def get_frame(self, component: str, index: Optional[int] = None) -> Optional[torch.Tensor]:
         """
         Get current frame for a component.
-        
+
         Args:
             component: Component name ('controlnet', 'ipadapter', 'base')
             index: Index for ControlNet instances (required for 'controlnet')
-            
+
         Returns:
             torch.Tensor: Current frame or None if not available
         """
         try:
-            if component == 'controlnet':
+            if component == "controlnet":
                 if index is None:
                     raise ValueError("Index is required for ControlNet components")
-                
+
                 # Ensure ControlNet is initialized with default webcam source
                 self._ensure_controlnet_initialized(index)
-                source = self.sources['controlnet'][index]
-                
+                source = self.sources["controlnet"][index]
+
                 frame = source.get_frame()
                 if frame is not None:
                     return frame
-                
+
                 # If webcam source has no frame yet, fallback to base pipeline input
                 self._logger.debug(f"ControlNet {index} webcam has no frame yet, falling back to base")
                 return self._get_fallback_frame()
-                
-            elif component in ['ipadapter', 'base']:
+
+            elif component in ["ipadapter", "base"]:
                 source = self.sources[component]
                 if source:
                     frame = source.get_frame()
                     if frame is not None:
                         return frame
-                
+
                 # Fallback to base pipeline input if not base itself
-                if component != 'base':
+                if component != "base":
                     self._logger.debug(f"{component} has no input, falling back to base")
                     return self._get_fallback_frame()
-                
+
         except Exception as e:
             self._logger.error(f"Error getting frame for {component}: {e}")
-        
+
         return None
-    
+
     def _get_fallback_frame(self) -> Optional[torch.Tensor]:
         """Get frame from base pipeline as fallback."""
-        base_source = self.sources['base']
+        base_source = self.sources["base"]
         if base_source:
             return base_source.get_frame()
         return None
-    
+
     def update_webcam_frame(self, frame_data: Union[bytes, torch.Tensor]):
         """
         Update webcam frame for all webcam sources.
-        
+
         Args:
             frame_data: Frame data as bytes or tensor
         """
         # Update base pipeline if it's webcam
-        if (self.sources['base'] and 
-            self.sources['base'].source_type == InputSourceType.WEBCAM):
-            self.sources['base'].update_webcam_frame(frame_data)
-        
+        if self.sources["base"] and self.sources["base"].source_type == InputSourceType.WEBCAM:
+            self.sources["base"].update_webcam_frame(frame_data)
+
         # Update ControlNet webcam sources
-        for source in self.sources['controlnet'].values():
+        for source in self.sources["controlnet"].values():
             if source.source_type == InputSourceType.WEBCAM:
                 source.update_webcam_frame(frame_data)
-        
+
         # Update IPAdapter if it's webcam
-        if (self.sources['ipadapter'] and 
-            self.sources['ipadapter'].source_type == InputSourceType.WEBCAM):
-            self.sources['ipadapter'].update_webcam_frame(frame_data)
-    
+        if self.sources["ipadapter"] and self.sources["ipadapter"].source_type == InputSourceType.WEBCAM:
+            self.sources["ipadapter"].update_webcam_frame(frame_data)
+
     def _ensure_controlnet_initialized(self, index: int):
         """
         Ensure a ControlNet has a default webcam source if not already set.
-        
+
         Args:
             index: ControlNet index
         """
-        if index not in self.sources['controlnet']:
-            self.sources['controlnet'][index] = InputSource(InputSourceType.WEBCAM)
+        if index not in self.sources["controlnet"]:
+            self.sources["controlnet"][index] = InputSource(InputSourceType.WEBCAM)
             self._logger.info(f"_ensure_controlnet_initialized: Initialized ControlNet {index} with webcam source")
 
     def get_source_info(self, component: str, index: Optional[int] = None) -> Dict[str, Any]:
         """
         Get information about a component's input source.
-        
+
         Returns:
             Dictionary with source type and metadata
         """
         try:
-            if component == 'controlnet':
+            if component == "controlnet":
                 if index is None:
-                    return {'source_type': 'error', 'source_data': 'index_required', 'is_stream': False, 'has_data': False}
-                
+                    return {
+                        "source_type": "error",
+                        "source_data": "index_required",
+                        "is_stream": False,
+                        "has_data": False,
+                    }
+
                 # Ensure ControlNet is initialized with default webcam source
                 self._ensure_controlnet_initialized(index)
-                source = self.sources['controlnet'][index]
-                
-            elif component in ['ipadapter', 'base']:
+                source = self.sources["controlnet"][index]
+
+            elif component in ["ipadapter", "base"]:
                 source = self.sources[component]
                 if not source:
-                    return {'source_type': 'none', 'source_data': None, 'is_stream': False, 'has_data': False}
+                    return {"source_type": "none", "source_data": None, "is_stream": False, "has_data": False}
             else:
-                return {'source_type': 'unknown', 'source_data': None, 'is_stream': False, 'has_data': False}
-            
+                return {"source_type": "unknown", "source_data": None, "is_stream": False, "has_data": False}
+
             return {
-                'source_type': source.source_type.value,
-                'source_data': source.source_data,
-                'is_stream': source.is_stream,
-                'has_data': source.source_data is not None
+                "source_type": source.source_type.value,
+                "source_data": source.source_data,
+                "is_stream": source.is_stream,
+                "has_data": source.source_data is not None,
             }
-            
+
         except Exception as e:
             self._logger.error(f"Error getting source info for {component}: {e}")
-            return {'source_type': 'error', 'source_data': None, 'is_stream': False, 'has_data': False, 'error': str(e)}
-    
+            return {
+                "source_type": "error",
+                "source_data": None,
+                "is_stream": False,
+                "has_data": False,
+                "error": str(e),
+            }
+
     def _init_default_ipadapter_source(self):
         """Initialize IPAdapter with default image source."""
         try:
             import os
+
             from PIL import Image
-            
+
             # Try to load default image
             default_image_path = os.path.join(os.path.dirname(__file__), "..", "..", "images", "inputs", "input.png")
             if os.path.exists(default_image_path):
                 default_image = Image.open(default_image_path).convert("RGB")
-                self.sources['ipadapter'] = InputSource(InputSourceType.UPLOADED_IMAGE, default_image)
+                self.sources["ipadapter"] = InputSource(InputSourceType.UPLOADED_IMAGE, default_image)
                 self._logger.info("_init_default_ipadapter_source: Initialized IPAdapter with default image")
             else:
-                self._logger.warning("_init_default_ipadapter_source: Default image not found, IPAdapter will have no source")
+                self._logger.warning(
+                    "_init_default_ipadapter_source: Default image not found, IPAdapter will have no source"
+                )
         except Exception as e:
             self._logger.error(f"_init_default_ipadapter_source: Error loading default image: {e}")
-    
+
     def load_config_style_image(self, style_image_path: str, base_config_path: str = None):
         """
         Load IPAdapter style image from config file path.
-        
+
         Args:
             style_image_path: Path to style image (can be relative)
             base_config_path: Base path for resolving relative paths
         """
         try:
             import os
+
             from PIL import Image
-            
+
             # Handle relative paths
             if not os.path.isabs(style_image_path):
                 if base_config_path:
@@ -355,17 +368,19 @@ class InputSourceManager:
                     if not os.path.exists(style_image_path):
                         self._logger.warning(f"load_config_style_image: Style image not found: {style_image_path}")
                         return
-            
+
             if os.path.exists(style_image_path):
                 style_image = Image.open(style_image_path).convert("RGB")
                 input_source = InputSource(InputSourceType.UPLOADED_IMAGE, style_image)
-                self.set_source('ipadapter', input_source)
-                self._logger.info(f"load_config_style_image: Loaded IPAdapter style image from config: {style_image_path}")
+                self.set_source("ipadapter", input_source)
+                self._logger.info(
+                    f"load_config_style_image: Loaded IPAdapter style image from config: {style_image_path}"
+                )
             else:
                 self._logger.warning(f"load_config_style_image: IPAdapter style image not found: {style_image_path}")
         except Exception as e:
             self._logger.exception(f"load_config_style_image: Error loading config style image: {e}")
-    
+
     def reset_to_defaults(self):
         """
         Reset all input sources to their default states.
@@ -374,30 +389,30 @@ class InputSourceManager:
         try:
             # Clean up existing sources first
             self.cleanup()
-            
+
             # Reset to default states
             self.sources = {
-                'controlnet': {},  # Empty - ControlNets will use fallback to base
-                'ipadapter': None,  # Will be re-initialized
-                'base': None       # Will be re-initialized
+                "controlnet": {},  # Empty - ControlNets will use fallback to base
+                "ipadapter": None,  # Will be re-initialized
+                "base": None,  # Will be re-initialized
             }
-            
+
             # Re-initialize defaults
-            self.sources['base'] = InputSource(InputSourceType.WEBCAM)
+            self.sources["base"] = InputSource(InputSourceType.WEBCAM)
             self._init_default_ipadapter_source()
-            
+
             self._logger.info("reset_to_defaults: Reset all input sources to defaults")
-            
+
         except Exception as e:
             self._logger.error(f"reset_to_defaults: Error resetting input sources: {e}")
-    
+
     def cleanup(self):
         """Clean up all sources."""
-        for source in self.sources['controlnet'].values():
+        for source in self.sources["controlnet"].values():
             source.cleanup()
-        
-        if self.sources['ipadapter']:
-            self.sources['ipadapter'].cleanup()
-        
-        if self.sources['base']:
-            self.sources['base'].cleanup()
+
+        if self.sources["ipadapter"]:
+            self.sources["ipadapter"].cleanup()
+
+        if self.sources["base"]:
+            self.sources["base"].cleanup()

--- a/demo/realtime-img2img/main.py
+++ b/demo/realtime-img2img/main.py
@@ -1,29 +1,16 @@
-from fastapi import FastAPI, WebSocket, HTTPException, WebSocketDisconnect, UploadFile, File, Response
-from fastapi.responses import StreamingResponse, JSONResponse
+import logging
+import mimetypes
+import time
+
+import torch
+from config import Args, config
+from connection_manager import ConnectionManager
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from fastapi import Request
-
-import markdown2
-
-import logging
-import uuid
-import time
-from types import SimpleNamespace
-import asyncio
-import os
-import time
-import mimetypes
-import torch
-import tempfile
-from pathlib import Path
-import yaml
-
-from config import config, Args
-from util import pil_to_frame, pt_to_frame, bytes_to_pil, bytes_to_pt
-from connection_manager import ConnectionManager, ServerFullException
 from img2img import Pipeline
-from input_control import InputManager, GamepadInput
+from input_control import InputManager
+
 
 # fix mime error on windows
 mimetypes.add_type("application/javascript", ".js")
@@ -33,87 +20,79 @@ THROTTLE = 1.0 / 120
 # Import configuration from separate file to avoid circular imports
 from app_config import AVAILABLE_CONTROLNETS, DEFAULT_SETTINGS
 
+
 # Configure logging
 def setup_logging(log_level: str = "INFO"):
     """Setup logging configuration for the application"""
     # Convert string to logging level
     numeric_level = getattr(logging, log_level.upper(), logging.INFO)
-    
+
     # Configure root logger
     logging.basicConfig(
-        level=numeric_level,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
+        level=numeric_level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
     )
-    
+
     # Set up logger for streamdiffusion modules
-    streamdiffusion_logger = logging.getLogger('streamdiffusion')
+    streamdiffusion_logger = logging.getLogger("streamdiffusion")
     streamdiffusion_logger.setLevel(numeric_level)
-    
+
     # Set up logger for this application
-    app_logger = logging.getLogger('realtime_img2img')
+    app_logger = logging.getLogger("realtime_img2img")
     app_logger.setLevel(numeric_level)
-    
+
     return app_logger
+
 
 # Initialize logger
 logger = setup_logging(config.log_level)
 
 # Suppress uvicorn INFO messages
 if config.quiet:
-    uvicorn_logger = logging.getLogger('uvicorn')
+    uvicorn_logger = logging.getLogger("uvicorn")
     uvicorn_logger.setLevel(logging.WARNING)
-    uvicorn_access_logger = logging.getLogger('uvicorn.access')
+    uvicorn_access_logger = logging.getLogger("uvicorn.access")
     uvicorn_access_logger.setLevel(logging.WARNING)
 
 
 class AppState:
     """Centralized application state management - SINGLE SOURCE OF TRUTH"""
-    
+
     def __init__(self):
         # Pipeline state
         self.pipeline_lifecycle = "stopped"  # stopped, starting, running, error
         self.pipeline_active = False
-        
-        # Configuration state  
+
+        # Configuration state
         self.uploaded_config = None  # Raw uploaded config
-        self.runtime_config = None   # Runtime modifications to config
+        self.runtime_config = None  # Runtime modifications to config
         self.config_needs_reload = False
-        
+
         # Resolution state
         self.current_resolution = {"width": 512, "height": 512}
-        
+
         # Parameter state (consolidates scattered vars from frontend)
         self.pipeline_params = {}
-        
+
         # ControlNet state - AUTHORITATIVE SOURCE
-        self.controlnet_info = {
-            "enabled": False,
-            "controlnets": []
-        }
-        
-        # IPAdapter state - AUTHORITATIVE SOURCE  
-        self.ipadapter_info = {
-            "enabled": False,
-            "has_style_image": False,
-            "scale": 1.0,
-            "weight_type": "linear"
-        }
-        
+        self.controlnet_info = {"enabled": False, "controlnets": []}
+
+        # IPAdapter state - AUTHORITATIVE SOURCE
+        self.ipadapter_info = {"enabled": False, "has_style_image": False, "scale": 1.0, "weight_type": "linear"}
+
         # Pipeline hooks state - AUTHORITATIVE SOURCE
         self.pipeline_hooks = {
             "image_preprocessing": {"enabled": False, "processors": []},
             "image_postprocessing": {"enabled": False, "processors": []},
             "latent_preprocessing": {"enabled": False, "processors": []},
-            "latent_postprocessing": {"enabled": False, "processors": []}
+            "latent_postprocessing": {"enabled": False, "processors": []},
         }
-        
+
         # Blending configurations
         self.prompt_blending = None
         self.seed_blending = None
         self.normalize_prompt_weights = True
         self.normalize_seed_weights = True
-        
+
         # Core pipeline parameters
         self.guidance_scale = 1.1
         self.delta = 0.7
@@ -122,98 +101,92 @@ class AppState:
         self.t_index_list = [35, 45]
         self.negative_prompt = ""
         self.skip_diffusion = False
-        
+
         # UI state
         self.fps = 0
         self.queue_size = 0
         self.model_id = ""
         self.page_content = ""
-        
+
         # Input source state
         self.input_sources = {
-            'controlnet': {},  # {index: source_info}
-            'ipadapter': None,
-            'base': None
+            "controlnet": {},  # {index: source_info}
+            "ipadapter": None,
+            "base": None,
         }
-        
+
         # Debug mode state
         self.debug_mode = False
         self.debug_pending_frame = False  # True when a frame step is requested
-        
+
     def populate_from_config(self, config_data):
         """Populate AppState from uploaded config - SINGLE SOURCE OF TRUTH"""
         if not config_data:
             return
-            
+
         logger.info("populate_from_config: Populating AppState from config as single source of truth")
-        
+
         # Store the complete uploaded config to preserve ALL parameters
         self.uploaded_config = config_data
-        
+
         # Core parameters
-        self.guidance_scale = config_data.get('guidance_scale', self.guidance_scale)
-        self.delta = config_data.get('delta', self.delta)
-        self.num_inference_steps = config_data.get('num_inference_steps', self.num_inference_steps)
-        self.seed = config_data.get('seed', self.seed)
-        self.t_index_list = config_data.get('t_index_list', self.t_index_list)
-        self.negative_prompt = config_data.get('negative_prompt', self.negative_prompt)
-        self.skip_diffusion = config_data.get('skip_diffusion', self.skip_diffusion)
-        self.model_id = config_data.get('model_id_or_path', self.model_id)
-        
+        self.guidance_scale = config_data.get("guidance_scale", self.guidance_scale)
+        self.delta = config_data.get("delta", self.delta)
+        self.num_inference_steps = config_data.get("num_inference_steps", self.num_inference_steps)
+        self.seed = config_data.get("seed", self.seed)
+        self.t_index_list = config_data.get("t_index_list", self.t_index_list)
+        self.negative_prompt = config_data.get("negative_prompt", self.negative_prompt)
+        self.skip_diffusion = config_data.get("skip_diffusion", self.skip_diffusion)
+        self.model_id = config_data.get("model_id_or_path", self.model_id)
+
         # Resolution parameters
-        if 'width' in config_data or 'height' in config_data:
+        if "width" in config_data or "height" in config_data:
             self.current_resolution = {
-                "width": config_data.get('width', self.current_resolution["width"]),
-                "height": config_data.get('height', self.current_resolution["height"])
+                "width": config_data.get("width", self.current_resolution["width"]),
+                "height": config_data.get("height", self.current_resolution["height"]),
             }
-        
+
         # Normalization settings
-        self.normalize_prompt_weights = config_data.get('normalize_weights', self.normalize_prompt_weights)
-        self.normalize_seed_weights = config_data.get('normalize_weights', self.normalize_seed_weights)
-        
+        self.normalize_prompt_weights = config_data.get("normalize_weights", self.normalize_prompt_weights)
+        self.normalize_seed_weights = config_data.get("normalize_weights", self.normalize_seed_weights)
+
         # ControlNet configuration
-        if 'controlnets' in config_data:
-            self.controlnet_info = {
-                "enabled": True,
-                "controlnets": []
-            }
-            for i, controlnet in enumerate(config_data['controlnets']):
+        if "controlnets" in config_data:
+            self.controlnet_info = {"enabled": True, "controlnets": []}
+            for i, controlnet in enumerate(config_data["controlnets"]):
                 processed = dict(controlnet)
-                processed['index'] = i
-                processed['name'] = controlnet.get('model_id', '')
-                processed['strength'] = controlnet.get('conditioning_scale', 0.0)
+                processed["index"] = i
+                processed["name"] = controlnet.get("model_id", "")
+                processed["strength"] = controlnet.get("conditioning_scale", 0.0)
                 self.controlnet_info["controlnets"].append(processed)
         else:
             self.controlnet_info = {"enabled": False, "controlnets": []}
-            
+
         # IPAdapter configuration
-        if config_data.get('use_ipadapter', False):
+        if config_data.get("use_ipadapter", False):
             self.ipadapter_info["enabled"] = True
-            ipadapters = config_data.get('ipadapters', [])
+            ipadapters = config_data.get("ipadapters", [])
             if ipadapters:
                 first = ipadapters[0]
-                self.ipadapter_info["scale"] = first.get('scale', 1.0)
-                self.ipadapter_info["weight_type"] = first.get('weight_type', 'linear')
+                self.ipadapter_info["scale"] = first.get("scale", 1.0)
+                self.ipadapter_info["weight_type"] = first.get("weight_type", "linear")
                 # Store required model paths
-                self.ipadapter_info["ipadapter_model_path"] = first.get('ipadapter_model_path')
-                self.ipadapter_info["image_encoder_path"] = first.get('image_encoder_path')
-                self.ipadapter_info["type"] = first.get('type', 'regular')
-                self.ipadapter_info["insightface_model_name"] = first.get('insightface_model_name')
-                if first.get('style_image'):
+                self.ipadapter_info["ipadapter_model_path"] = first.get("ipadapter_model_path")
+                self.ipadapter_info["image_encoder_path"] = first.get("image_encoder_path")
+                self.ipadapter_info["type"] = first.get("type", "regular")
+                self.ipadapter_info["insightface_model_name"] = first.get("insightface_model_name")
+                if first.get("style_image"):
                     self.ipadapter_info["has_style_image"] = True
-                    self.ipadapter_info["style_image_path"] = first['style_image']
+                    self.ipadapter_info["style_image_path"] = first["style_image"]
         else:
             self.ipadapter_info = {"enabled": False, "has_style_image": False, "scale": 1.0, "weight_type": "linear"}
-            
+
         # Pipeline hooks configuration
         for hook_type in self.pipeline_hooks.keys():
             if hook_type in config_data:
                 hook_config = config_data[hook_type]
                 if isinstance(hook_config, dict):
-                    self.pipeline_hooks[hook_type] = {
-                        "enabled": hook_config.get("enabled", False),
-                        "processors": []
-                    }
+                    self.pipeline_hooks[hook_type] = {"enabled": hook_config.get("enabled", False), "processors": []}
                     # Process processors with proper indexing
                     for index, processor in enumerate(hook_config.get("processors", [])):
                         if isinstance(processor, dict):
@@ -223,74 +196,74 @@ class AppState:
                                 "type": processor.get("type", "unknown"),
                                 "enabled": processor.get("enabled", False),
                                 "order": processor.get("order", index + 1),
-                                "params": processor.get("params", {})
+                                "params": processor.get("params", {}),
                             }
                             self.pipeline_hooks[hook_type]["processors"].append(processed_processor)
             else:
                 self.pipeline_hooks[hook_type] = {"enabled": False, "processors": []}
-        
+
         # Blending configurations
         self.prompt_blending = self._normalize_prompt_config(config_data)
         self.seed_blending = self._normalize_seed_config(config_data)
-        
+
         logger.info("populate_from_config: AppState populated successfully from config")
 
     def _normalize_prompt_config(self, config_data):
         """Normalize prompt configuration to always return a list format"""
         if not config_data:
             return None
-            
+
         # Check for explicit prompt_blending first
-        if 'prompt_blending' in config_data:
-            prompt_blending = config_data['prompt_blending']
-            if isinstance(prompt_blending, dict) and 'prompt_list' in prompt_blending:
-                prompt_list = prompt_blending['prompt_list']
+        if "prompt_blending" in config_data:
+            prompt_blending = config_data["prompt_blending"]
+            if isinstance(prompt_blending, dict) and "prompt_list" in prompt_blending:
+                prompt_list = prompt_blending["prompt_list"]
                 if isinstance(prompt_list, list) and len(prompt_list) > 0:
                     return prompt_list
             elif isinstance(prompt_blending, list) and len(prompt_blending) > 0:
                 return prompt_blending
-        
-        # Check for direct prompt_list key  
-        if 'prompt_list' in config_data:
-            prompt_list = config_data['prompt_list']
+
+        # Check for direct prompt_list key
+        if "prompt_list" in config_data:
+            prompt_list = config_data["prompt_list"]
             if isinstance(prompt_list, list) and len(prompt_list) > 0:
                 return prompt_list
-        
+
         # Check for simple prompt key and convert to list format
-        if 'prompt' in config_data:
-            prompt = config_data['prompt']
+        if "prompt" in config_data:
+            prompt = config_data["prompt"]
             if prompt and isinstance(prompt, str):
                 return [(prompt, 1.0)]
-        
+
         return None
 
     def _normalize_seed_config(self, config_data):
         """Normalize seed configuration to always return a list format"""
         if not config_data:
             return None
-            
+
         # Check for explicit seed_blending first
-        if 'seed_blending' in config_data:
-            seed_blending = config_data['seed_blending']
-            if isinstance(seed_blending, dict) and 'seed_list' in seed_blending:
-                seed_list = seed_blending['seed_list']
+        if "seed_blending" in config_data:
+            seed_blending = config_data["seed_blending"]
+            if isinstance(seed_blending, dict) and "seed_list" in seed_blending:
+                seed_list = seed_blending["seed_list"]
                 if isinstance(seed_list, list) and len(seed_list) > 0:
                     return seed_list
             elif isinstance(seed_blending, list) and len(seed_blending) > 0:
                 return seed_blending
-        
-        # Check for direct seed_list key  
-        if 'seed_list' in config_data:
-            seed_list = config_data['seed_list']
+
+        # Check for direct seed_list key
+        if "seed_list" in config_data:
+            seed_list = config_data["seed_list"]
             if isinstance(seed_list, list) and len(seed_list) > 0:
                 return seed_list
-        
+
         # Check for simple seed key and convert to list format
-        if 'seed' in config_data:
-            seed = config_data['seed']
+        if "seed" in config_data:
+            seed = config_data["seed"]
             if seed is not None and isinstance(seed, (int, float)):
                 return [(int(seed), 1.0)]
-        
+
         return None
 
     def get_complete_state(self):
@@ -299,13 +272,10 @@ class AppState:
             # Pipeline state
             "pipeline_active": self.pipeline_active,
             "pipeline_lifecycle": self.pipeline_lifecycle,
-            
             # Configuration
             "config_needs_reload": self.config_needs_reload,
-            
             # Resolution
             "current_resolution": self.current_resolution,
-            
             # Parameters
             "pipeline_params": self.pipeline_params,
             "controlnet": self.controlnet_info,
@@ -314,7 +284,6 @@ class AppState:
             "seed_blending": self.seed_blending,
             "normalize_prompt_weights": self.normalize_prompt_weights,
             "normalize_seed_weights": self.normalize_seed_weights,
-            
             # Core parameters
             "guidance_scale": self.guidance_scale,
             "delta": self.delta,
@@ -323,27 +292,23 @@ class AppState:
             "t_index_list": self.t_index_list,
             "negative_prompt": self.negative_prompt,
             "skip_diffusion": self.skip_diffusion,
-            
             # UI state
             "fps": self.fps,
             "queue_size": self.queue_size,
             "model_id": self.model_id,
             "page_content": self.page_content,
-            
             # Input sources
             "input_sources": self.input_sources,
-            
             # Debug mode state
             "debug_mode": self.debug_mode,
             "debug_pending_frame": self.debug_pending_frame,
-            
             # Pipeline hooks - AUTHORITATIVE SOURCE
             "image_preprocessing": self.pipeline_hooks["image_preprocessing"],
             "image_postprocessing": self.pipeline_hooks["image_postprocessing"],
             "latent_preprocessing": self.pipeline_hooks["latent_preprocessing"],
             "latent_postprocessing": self.pipeline_hooks["latent_postprocessing"],
         }
-    
+
     def update_controlnet_strength(self, index: int, strength: float):
         """Update ControlNet strength in AppState - SINGLE SOURCE OF TRUTH"""
         if index < len(self.controlnet_info["controlnets"]):
@@ -352,32 +317,32 @@ class AppState:
             logger.debug(f"update_controlnet_strength: Updated ControlNet {index} strength to {strength}")
         else:
             logger.warning(f"update_controlnet_strength: ControlNet index {index} out of range")
-    
+
     def add_controlnet(self, controlnet_config: dict):
         """Add ControlNet to AppState - SINGLE SOURCE OF TRUTH"""
         index = len(self.controlnet_info["controlnets"])
         processed = dict(controlnet_config)
-        processed['index'] = index
-        processed['name'] = controlnet_config.get('model_id', '')
-        processed['strength'] = controlnet_config.get('conditioning_scale', 0.0)
-        
+        processed["index"] = index
+        processed["name"] = controlnet_config.get("model_id", "")
+        processed["strength"] = controlnet_config.get("conditioning_scale", 0.0)
+
         self.controlnet_info["controlnets"].append(processed)
         self.controlnet_info["enabled"] = True
         logger.debug(f"add_controlnet: Added ControlNet at index {index}")
-        
+
     def remove_controlnet(self, index: int):
         """Remove ControlNet from AppState - SINGLE SOURCE OF TRUTH"""
         if index < len(self.controlnet_info["controlnets"]):
             removed = self.controlnet_info["controlnets"].pop(index)
             # Re-index remaining controlnets
             for i, controlnet in enumerate(self.controlnet_info["controlnets"]):
-                controlnet['index'] = i
+                controlnet["index"] = i
             if not self.controlnet_info["controlnets"]:
                 self.controlnet_info["enabled"] = False
             logger.debug(f"remove_controlnet: Removed ControlNet at index {index}")
         else:
             logger.warning(f"remove_controlnet: ControlNet index {index} out of range")
-    
+
     def update_hook_processor(self, hook_type: str, processor_index: int, updates: dict):
         """Update pipeline hook processor in AppState - SINGLE SOURCE OF TRUTH"""
         if hook_type in self.pipeline_hooks:
@@ -386,10 +351,12 @@ class AppState:
                 processors[processor_index].update(updates)
                 logger.debug(f"update_hook_processor: Updated {hook_type} processor {processor_index}")
             else:
-                logger.warning(f"update_hook_processor: Processor index {processor_index} out of range for {hook_type}")
+                logger.warning(
+                    f"update_hook_processor: Processor index {processor_index} out of range for {hook_type}"
+                )
         else:
             logger.warning(f"update_hook_processor: Unknown hook type {hook_type}")
-    
+
     def add_hook_processor(self, hook_type: str, processor_config: dict):
         """Add pipeline hook processor to AppState - SINGLE SOURCE OF TRUTH"""
         if hook_type in self.pipeline_hooks:
@@ -400,14 +367,14 @@ class AppState:
                 "type": processor_config.get("type", "unknown"),
                 "enabled": processor_config.get("enabled", True),
                 "order": processor_config.get("order", index + 1),
-                "params": processor_config.get("params", {})
+                "params": processor_config.get("params", {}),
             }
             self.pipeline_hooks[hook_type]["processors"].append(processed)
             self.pipeline_hooks[hook_type]["enabled"] = True
             logger.debug(f"add_hook_processor: Added {hook_type} processor at index {index}")
         else:
             logger.warning(f"add_hook_processor: Unknown hook type {hook_type}")
-    
+
     def remove_hook_processor(self, hook_type: str, processor_index: int):
         """Remove pipeline hook processor from AppState - SINGLE SOURCE OF TRUTH"""
         if hook_type in self.pipeline_hooks:
@@ -416,191 +383,204 @@ class AppState:
                 removed = processors.pop(processor_index)
                 # Re-index remaining processors
                 for i, processor in enumerate(processors):
-                    processor['index'] = i
+                    processor["index"] = i
                 if not processors:
                     self.pipeline_hooks[hook_type]["enabled"] = False
                 logger.debug(f"remove_hook_processor: Removed {hook_type} processor at index {processor_index}")
             else:
-                logger.warning(f"remove_hook_processor: Processor index {processor_index} out of range for {hook_type}")
+                logger.warning(
+                    f"remove_hook_processor: Processor index {processor_index} out of range for {hook_type}"
+                )
         else:
             logger.warning(f"remove_hook_processor: Unknown hook type {hook_type}")
 
     def update_parameter(self, parameter_name: str, value: float):
         """Update a single parameter in AppState - UNIFIED PARAMETER UPDATE"""
         logger.debug(f"update_parameter: Updating {parameter_name} = {value}")
-        
+
         # Core pipeline parameters
-        if parameter_name == 'guidance_scale':
+        if parameter_name == "guidance_scale":
             self.guidance_scale = float(value)
-        elif parameter_name == 'delta':
+        elif parameter_name == "delta":
             self.delta = float(value)
-        elif parameter_name == 'num_inference_steps':
+        elif parameter_name == "num_inference_steps":
             self.num_inference_steps = int(value)
-        elif parameter_name == 'seed':
+        elif parameter_name == "seed":
             self.seed = int(value)
-        elif parameter_name == 'negative_prompt':
+        elif parameter_name == "negative_prompt":
             self.negative_prompt = str(value)
-        elif parameter_name == 'skip_diffusion':
+        elif parameter_name == "skip_diffusion":
             self.skip_diffusion = bool(value)
-        elif parameter_name == 't_index_list':
+        elif parameter_name == "t_index_list":
             if isinstance(value, list):
                 self.t_index_list = value
             else:
                 logger.warning(f"update_parameter: t_index_list must be a list, got {type(value)}")
-        
+
         # IPAdapter parameters
-        elif parameter_name == 'ipadapter_scale':
+        elif parameter_name == "ipadapter_scale":
             self.ipadapter_info["scale"] = float(value)
-        elif parameter_name == 'ipadapter_weight_type':
+        elif parameter_name == "ipadapter_weight_type":
             # Convert numeric value to weight type string
-            weight_types = ["linear", "ease in", "ease out", "ease in-out", "reverse in-out", 
-                           "weak input", "weak output", "weak middle", "strong middle", 
-                           "style transfer", "composition", "strong style transfer", 
-                           "style and composition", "style transfer precise", "composition precise"]
+            weight_types = [
+                "linear",
+                "ease in",
+                "ease out",
+                "ease in-out",
+                "reverse in-out",
+                "weak input",
+                "weak output",
+                "weak middle",
+                "strong middle",
+                "style transfer",
+                "composition",
+                "strong style transfer",
+                "style and composition",
+                "style transfer precise",
+                "composition precise",
+            ]
             index = int(value) % len(weight_types)
             self.ipadapter_info["weight_type"] = weight_types[index]
-        
+
         # ControlNet strength parameters
-        elif parameter_name.startswith('controlnet_') and parameter_name.endswith('_strength'):
+        elif parameter_name.startswith("controlnet_") and parameter_name.endswith("_strength"):
             import re
-            match = re.match(r'controlnet_(\d+)_strength', parameter_name)
+
+            match = re.match(r"controlnet_(\d+)_strength", parameter_name)
             if match:
                 index = int(match.group(1))
                 self.update_controlnet_strength(index, float(value))
-        
+
         # ControlNet preprocessor parameters
-        elif parameter_name.startswith('controlnet_') and '_preprocessor_' in parameter_name:
+        elif parameter_name.startswith("controlnet_") and "_preprocessor_" in parameter_name:
             import re
-            match = re.match(r'controlnet_(\d+)_preprocessor_(.+)', parameter_name)
+
+            match = re.match(r"controlnet_(\d+)_preprocessor_(.+)", parameter_name)
             if match:
                 controlnet_index = int(match.group(1))
                 param_name = match.group(2)
                 if controlnet_index < len(self.controlnet_info["controlnets"]):
                     controlnet = self.controlnet_info["controlnets"][controlnet_index]
-                    if 'preprocessor_params' not in controlnet:
-                        controlnet['preprocessor_params'] = {}
-                    controlnet['preprocessor_params'][param_name] = value
-        
+                    if "preprocessor_params" not in controlnet:
+                        controlnet["preprocessor_params"] = {}
+                    controlnet["preprocessor_params"][param_name] = value
+
         # Prompt blending weights
-        elif parameter_name.startswith('prompt_weight_'):
+        elif parameter_name.startswith("prompt_weight_"):
             import re
-            match = re.match(r'prompt_weight_(\d+)', parameter_name)
+
+            match = re.match(r"prompt_weight_(\d+)", parameter_name)
             if match:
                 index = int(match.group(1))
                 if self.prompt_blending and index < len(self.prompt_blending):
                     # Update weight in prompt blending list
                     prompt_text = self.prompt_blending[index][0]
                     self.prompt_blending[index] = (prompt_text, float(value))
-        
+
         # Seed blending weights
-        elif parameter_name.startswith('seed_weight_'):
+        elif parameter_name.startswith("seed_weight_"):
             import re
-            match = re.match(r'seed_weight_(\d+)', parameter_name)
+
+            match = re.match(r"seed_weight_(\d+)", parameter_name)
             if match:
                 index = int(match.group(1))
                 if self.seed_blending and index < len(self.seed_blending):
                     # Update weight in seed blending list
                     seed_value = self.seed_blending[index][0]
                     self.seed_blending[index] = (seed_value, float(value))
-        
+
         else:
             logger.warning(f"update_parameter: Unknown parameter {parameter_name}")
             return
-        
+
         logger.debug(f"update_parameter: Successfully updated {parameter_name} in AppState")
 
     def generate_pipeline_config(self):
         """Generate pipeline configuration from AppState - PRESERVES ALL ORIGINAL CONFIG"""
-        logger.info("generate_pipeline_config: Generating pipeline config from AppState, preserving all original config")
-        
+        logger.info(
+            "generate_pipeline_config: Generating pipeline config from AppState, preserving all original config"
+        )
+
         # Start with complete original config to preserve ALL parameters
         config = {}
         if self.uploaded_config:
             config = dict(self.uploaded_config)
-        
+
         # Only override runtime-changeable parameters from AppState
-        config.update({
-            'guidance_scale': self.guidance_scale,
-            'delta': self.delta,
-            'num_inference_steps': self.num_inference_steps,
-            'seed': self.seed,
-            't_index_list': self.t_index_list,
-            'negative_prompt': self.negative_prompt,
-            'skip_diffusion': self.skip_diffusion,
-            'width': self.current_resolution["width"],
-            'height': self.current_resolution["height"],
-            'output_type': 'pt',  # Force optimal tensor performance
-        })
-        
+        config.update(
+            {
+                "guidance_scale": self.guidance_scale,
+                "delta": self.delta,
+                "num_inference_steps": self.num_inference_steps,
+                "seed": self.seed,
+                "t_index_list": self.t_index_list,
+                "negative_prompt": self.negative_prompt,
+                "skip_diffusion": self.skip_diffusion,
+                "width": self.current_resolution["width"],
+                "height": self.current_resolution["height"],
+                "output_type": "pt",  # Force optimal tensor performance
+            }
+        )
+
         # Update ControlNet configurations with current AppState values
         if self.controlnet_info["enabled"] and self.controlnet_info["controlnets"]:
-            config['controlnets'] = []
+            config["controlnets"] = []
             for controlnet in self.controlnet_info["controlnets"]:
                 cn_config = dict(controlnet)
                 # Ensure conditioning_scale reflects current strength
-                cn_config['conditioning_scale'] = controlnet.get('strength', controlnet.get('conditioning_scale', 0.0))
-                config['controlnets'].append(cn_config)
-        elif 'controlnets' in config:
+                cn_config["conditioning_scale"] = controlnet.get("strength", controlnet.get("conditioning_scale", 0.0))
+                config["controlnets"].append(cn_config)
+        elif "controlnets" in config:
             # Remove controlnets if disabled
-            del config['controlnets']
-        
+            del config["controlnets"]
+
         # Update IPAdapter configurations with current AppState values
         if self.ipadapter_info["enabled"]:
-            config['use_ipadapter'] = True
+            config["use_ipadapter"] = True
             # Preserve original ipadapters config but update runtime values
-            if 'ipadapters' in config and config['ipadapters']:
+            if "ipadapters" in config and config["ipadapters"]:
                 # Update existing config with current values
-                config['ipadapters'][0].update({
-                    'scale': self.ipadapter_info["scale"],
-                    'weight_type': self.ipadapter_info["weight_type"]
-                })
+                config["ipadapters"][0].update(
+                    {"scale": self.ipadapter_info["scale"], "weight_type": self.ipadapter_info["weight_type"]}
+                )
                 # Add style image if available
                 if self.ipadapter_info.get("has_style_image") and self.ipadapter_info.get("style_image_path"):
-                    config['ipadapters'][0]['style_image'] = self.ipadapter_info["style_image_path"]
-        elif 'use_ipadapter' in config:
+                    config["ipadapters"][0]["style_image"] = self.ipadapter_info["style_image_path"]
+        elif "use_ipadapter" in config:
             # Disable IPAdapter if not enabled in AppState
-            config['use_ipadapter'] = False
-        
+            config["use_ipadapter"] = False
+
         # Update pipeline hooks with current AppState values
         for hook_type, hook_config in self.pipeline_hooks.items():
             if hook_config["enabled"] and hook_config["processors"]:
-                config[hook_type] = {
-                    "enabled": True,
-                    "processors": []
-                }
+                config[hook_type] = {"enabled": True, "processors": []}
                 for processor in hook_config["processors"]:
                     proc_config = {
                         "type": processor["type"],
                         "enabled": processor["enabled"],
                         "order": processor["order"],
-                        "params": processor["params"]
+                        "params": processor["params"],
                     }
                     config[hook_type]["processors"].append(proc_config)
             elif hook_type in config:
                 # Disable hook if not enabled in AppState
                 config[hook_type] = {"enabled": False, "processors": []}
-        
+
         # Update blending configurations with current AppState values
         if self.prompt_blending:
-            config['prompt_blending'] = {
-                'prompt_list': self.prompt_blending,
-                'interpolation_method': 'slerp'
-            }
-            config['normalize_weights'] = self.normalize_prompt_weights
-        elif 'prompt_blending' in config:
-            del config['prompt_blending']
-        
+            config["prompt_blending"] = {"prompt_list": self.prompt_blending, "interpolation_method": "slerp"}
+            config["normalize_weights"] = self.normalize_prompt_weights
+        elif "prompt_blending" in config:
+            del config["prompt_blending"]
+
         if self.seed_blending:
-            config['seed_blending'] = {
-                'seed_list': self.seed_blending,
-                'interpolation_method': 'linear'
-            }
+            config["seed_blending"] = {"seed_list": self.seed_blending, "interpolation_method": "linear"}
             # Note: seed normalization uses same normalize_weights key
             if not self.prompt_blending:  # Only set if not already set by prompt blending
-                config['normalize_weights'] = self.normalize_seed_weights
-        elif 'seed_blending' in config:
-            del config['seed_blending']
-        
+                config["normalize_weights"] = self.normalize_seed_weights
+        elif "seed_blending" in config:
+            del config["seed_blending"]
+
         logger.info("generate_pipeline_config: Generated pipeline config preserving all original parameters")
         return config
 
@@ -612,7 +592,6 @@ class AppState:
                 logger.debug(f"AppState update_state: Updated {key} = {value}")
             else:
                 logger.warning(f"AppState update_state: Unknown state key: {key}")
-    
 
 
 class App:
@@ -623,46 +602,50 @@ class App:
         self.conn_manager = ConnectionManager()
         self.fps_counter = []
         self.last_fps_update = time.time()
-        
+
         # Centralized state management
         self.app_state = AppState()
-        
+
         # Initialize input manager for controller support
         self.input_manager = InputManager()
         # Initialize input source manager for modular input routing
         from input_sources import InputSourceManager
+
         self.input_source_manager = InputSourceManager()
-        
+
         # Preemptively initialize input sources to avoid config upload delay
         self._preload_input_sources()
-        
+
         self.init_app()
 
     def _preload_input_sources(self):
         """Preemptively initialize input sources and preprocessors to avoid delays during config upload"""
         try:
-            logger.info("_preload_input_sources: Preemptively initializing input sources and preprocessors to avoid config upload delay")
-            
+            logger.info(
+                "_preload_input_sources: Preemptively initializing input sources and preprocessors to avoid config upload delay"
+            )
+
             # Preload base input source
-            self.input_source_manager.get_source_info('base')
-            
+            self.input_source_manager.get_source_info("base")
+
             # Preload IPAdapter input source
-            self.input_source_manager.get_source_info('ipadapter')
-            
+            self.input_source_manager.get_source_info("ipadapter")
+
             # Preload potential ControlNet input sources (up to 5)
             for i in range(5):
-                self.input_source_manager.get_source_info('controlnet', index=i)
-            
+                self.input_source_manager.get_source_info("controlnet", index=i)
+
             # Preload preprocessors to trigger controlnet_aux imports
             # This is what causes the delay - the first time a preprocessor is accessed,
             # all the controlnet_aux modules get imported
             logger.info("_preload_input_sources: Triggering preprocessor imports...")
             try:
-                from streamdiffusion.preprocessing.processors import list_preprocessors, get_preprocessor_class
+                from streamdiffusion.preprocessing.processors import get_preprocessor_class, list_preprocessors
+
                 # List all available preprocessors - this triggers the lazy imports
                 available = list_preprocessors()
                 logger.info(f"_preload_input_sources: Found {len(available)} preprocessors, loading metadata...")
-                
+
                 # Access at least one preprocessor class to ensure all imports complete
                 if available:
                     for processor_name in available[:3]:  # Load first 3 to trigger most imports
@@ -670,15 +653,15 @@ class App:
                             _ = get_preprocessor_class(processor_name)
                         except Exception as e:
                             logger.debug(f"_preload_input_sources: Could not load {processor_name}: {e}")
-                
+
                 logger.info("_preload_input_sources: Preprocessor imports completed")
             except Exception as prep_error:
                 logger.warning(f"_preload_input_sources: Could not preload preprocessors: {prep_error}")
-            
+
             logger.info("_preload_input_sources: Input sources and preprocessors preloaded successfully")
         except Exception as e:
             logger.error(f"_preload_input_sources: Error during preload: {e}")
-    
+
     def cleanup(self):
         """Cleanup resources when app is shutting down"""
         logger.info("App cleanup: Starting application cleanup...")
@@ -687,7 +670,7 @@ class App:
             self._cleanup_pipeline(self.pipeline)
             self.pipeline = None
             self.app_state.pipeline_lifecycle = "stopped"
-        if hasattr(self, 'input_source_manager'):
+        if hasattr(self, "input_source_manager"):
             self.input_source_manager.cleanup()
         self._cleanup_temp_files()
         logger.info("App cleanup: Completed application cleanup")
@@ -696,15 +679,17 @@ class App:
         """Handle parameter updates from input controls - UNIFIED THROUGH APPSTATE"""
         try:
             logger.debug(f"_handle_input_parameter_update: Updating {parameter_name} = {value} via AppState")
-            
+
             # Update AppState as single source of truth
             self.app_state.update_parameter(parameter_name, value)
-            
+
             # Sync to pipeline if active (for real-time updates)
-            if self.pipeline and hasattr(self.pipeline, 'stream'):
+            if self.pipeline and hasattr(self.pipeline, "stream"):
                 self._sync_appstate_to_pipeline()
             else:
-                logger.debug(f"_handle_input_parameter_update: No active pipeline, parameter stored in AppState for next pipeline creation")
+                logger.debug(
+                    "_handle_input_parameter_update: No active pipeline, parameter stored in AppState for next pipeline creation"
+                )
 
         except Exception as e:
             logger.exception(f"_handle_input_parameter_update: Failed to update {parameter_name}: {e}")
@@ -712,36 +697,36 @@ class App:
     def _update_resolution(self, width: int, height: int) -> None:
         """Update resolution by recreating pipeline with new dimensions"""
         logger.info(f"_update_resolution: Updating resolution to {width}x{height}")
-        
+
         # Update AppState first
         self.app_state.current_resolution = {"width": width, "height": height}
-        
+
         # If no pipeline exists, just update state (will be used when pipeline is created)
         if not self.pipeline:
             logger.info("_update_resolution: No pipeline exists, resolution will apply on next pipeline creation")
             return
-        
+
         # Set pipeline lifecycle state
         self.app_state.pipeline_lifecycle = "restarting"
-        
+
         # Store reference to old pipeline for cleanup
         old_pipeline = self.pipeline
-        
+
         # Clear current pipeline reference before cleanup
         self.pipeline = None
-        
+
         # Cleanup old pipeline and free VRAM
         if old_pipeline:
             self._cleanup_pipeline(old_pipeline)
             old_pipeline = None
-        
+
         # Create new pipeline with new resolution
         # No state restoration needed - _create_pipeline() uses AppState as single source of truth
         try:
             self.pipeline = self._create_pipeline()
             self.app_state.pipeline_lifecycle = "running"
             logger.info(f"_update_resolution: Pipeline successfully recreated with resolution {width}x{height}")
-            
+
         except Exception as e:
             self.app_state.pipeline_lifecycle = "error"
             logger.error(f"_update_resolution: Failed to recreate pipeline: {e}")
@@ -750,9 +735,9 @@ class App:
     def _sync_appstate_to_pipeline(self):
         """Sync AppState parameters to active pipeline for real-time updates"""
         try:
-            if not self.pipeline or not hasattr(self.pipeline, 'stream'):
+            if not self.pipeline or not hasattr(self.pipeline, "stream"):
                 return
-            
+
             # Core parameters
             self.pipeline.update_stream_params(
                 guidance_scale=self.app_state.guidance_scale,
@@ -760,63 +745,56 @@ class App:
                 num_inference_steps=self.app_state.num_inference_steps,
                 seed=self.app_state.seed,
                 negative_prompt=self.app_state.negative_prompt,
-                t_index_list=self.app_state.t_index_list
+                t_index_list=self.app_state.t_index_list,
             )
-            
+
             # IPAdapter parameters
             if self.app_state.ipadapter_info["enabled"]:
-                self.pipeline.update_stream_params(ipadapter_config={
-                    'scale': self.app_state.ipadapter_info["scale"]
-                })
-                if hasattr(self.pipeline, 'update_ipadapter_weight_type'):
+                self.pipeline.update_stream_params(ipadapter_config={"scale": self.app_state.ipadapter_info["scale"]})
+                if hasattr(self.pipeline, "update_ipadapter_weight_type"):
                     self.pipeline.update_ipadapter_weight_type(self.app_state.ipadapter_info["weight_type"])
-            
+
             # ControlNet parameters
             if self.app_state.controlnet_info["enabled"] and self.app_state.controlnet_info["controlnets"]:
                 controlnet_config = []
                 for cn in self.app_state.controlnet_info["controlnets"]:
                     config_entry = dict(cn)
-                    config_entry['conditioning_scale'] = cn['strength']
+                    config_entry["conditioning_scale"] = cn["strength"]
                     controlnet_config.append(config_entry)
                 self.pipeline.update_stream_params(controlnet_config=controlnet_config)
-            
+
             # Prompt blending
             if self.app_state.prompt_blending:
                 self.pipeline.update_stream_params(prompt_list=self.app_state.prompt_blending)
-            
+
             # Seed blending
             if self.app_state.seed_blending:
                 self.pipeline.update_stream_params(seed_list=self.app_state.seed_blending)
-            
+
             logger.debug("_sync_appstate_to_pipeline: Successfully synced AppState to pipeline")
-            
+
         except Exception as e:
             logger.exception(f"_sync_appstate_to_pipeline: Failed to sync AppState to pipeline: {e}")
-
-
-    
-
 
     def _get_controlnet_pipeline(self):
         """Get the ControlNet pipeline from the main pipeline structure"""
         if not self.pipeline:
             return None
-            
+
         stream = self.pipeline.stream
-        
+
         # Module-aware: module installs expose preprocessors on stream
-        if hasattr(stream, 'preprocessors'):
+        if hasattr(stream, "preprocessors"):
             return stream
-            
+
         # Check if stream has nested stream (IPAdapter wrapper)
-        if hasattr(stream, 'stream') and hasattr(stream.stream, 'preprocessors'):
+        if hasattr(stream, "stream") and hasattr(stream.stream, "preprocessors"):
             return stream.stream
-            
+
         # New module path on stream
-        if hasattr(stream, '_controlnet_module'):
+        if hasattr(stream, "_controlnet_module"):
             return stream._controlnet_module
         return None
-
 
     def init_app(self):
         # Enhanced CORS for API-only development mode
@@ -844,74 +822,95 @@ class App:
 
         # Register route modules
         self._register_routes()
-    
+
     def _register_routes(self):
         """Register all route modules with dependency injection"""
-        from routes import parameters, controlnet, ipadapter, inference, pipeline_hooks, websocket, input_sources, debug
-        from routes.common.dependencies import get_app_instance as shared_get_app_instance, get_pipeline_class as shared_get_pipeline_class, get_default_settings as shared_get_default_settings, get_available_controlnets as shared_get_available_controlnets
-        
+        from routes import (
+            controlnet,
+            debug,
+            inference,
+            input_sources,
+            ipadapter,
+            parameters,
+            pipeline_hooks,
+            websocket,
+        )
+        from routes.common.dependencies import get_app_instance as shared_get_app_instance
+        from routes.common.dependencies import get_available_controlnets as shared_get_available_controlnets
+        from routes.common.dependencies import get_default_settings as shared_get_default_settings
+        from routes.common.dependencies import get_pipeline_class as shared_get_pipeline_class
+
         # Create dependency overrides to inject app instance and other dependencies
         def get_app_instance():
             return self
-            
+
         def get_pipeline_class():
             return Pipeline
-            
+
         def get_default_settings():
             return DEFAULT_SETTINGS
-            
+
         def get_available_controlnets():
             return AVAILABLE_CONTROLNETS
-        
+
         # Include routers and set up dependency overrides on the main app
-        for router_module in [parameters, controlnet, ipadapter, inference, pipeline_hooks, websocket, input_sources, debug]:
+        for router_module in [
+            parameters,
+            controlnet,
+            ipadapter,
+            inference,
+            pipeline_hooks,
+            websocket,
+            input_sources,
+            debug,
+        ]:
             # Include the router
             self.app.include_router(router_module.router)
-        
+
         # Set up dependency overrides on the main app (not individual routers)
         self.app.dependency_overrides[shared_get_app_instance] = get_app_instance
         self.app.dependency_overrides[shared_get_pipeline_class] = get_pipeline_class
         self.app.dependency_overrides[shared_get_default_settings] = get_default_settings
         self.app.dependency_overrides[shared_get_available_controlnets] = get_available_controlnets
-        
+
         # Set up static files if not in API-only mode
         if not self.args.api_only:
             self.app.mount("/", StaticFiles(directory="frontend/public", html=True), name="public")
-
 
     def _create_pipeline(self):
         """Create pipeline using AppState as single source of truth"""
         logger.info("_create_pipeline: Creating pipeline using AppState as single source of truth")
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         torch_dtype = torch.float16
-        
+
         # Generate pipeline config from AppState - SINGLE SOURCE OF TRUTH
         pipeline_config = self.app_state.generate_pipeline_config()
-        
+
         # Load config style images into InputSourceManager before creating pipeline
         self._load_config_style_images()
-        
+
         # Create wrapper using the unified config - THIS IS NOW THE SINGLE PLACE WHERE WRAPPER IS CREATED
         from src.streamdiffusion.config import create_wrapper_from_config
-        
+
         # Create wrapper using the unified config
         wrapper = create_wrapper_from_config(pipeline_config)
-        
+
         # Update args with config values before passing to Pipeline
         from config import Args
+
         args_dict = self.args._asdict()
-        if 'acceleration' in pipeline_config:
-            args_dict['acceleration'] = pipeline_config['acceleration']
-        if 'engine_dir' in pipeline_config:
-            args_dict['engine_dir'] = pipeline_config['engine_dir']
-        if 'use_safety_checker' in pipeline_config:
-            args_dict['safety_checker'] = pipeline_config['use_safety_checker']
-        
+        if "acceleration" in pipeline_config:
+            args_dict["acceleration"] = pipeline_config["acceleration"]
+        if "engine_dir" in pipeline_config:
+            args_dict["engine_dir"] = pipeline_config["engine_dir"]
+        if "use_safety_checker" in pipeline_config:
+            args_dict["safety_checker"] = pipeline_config["use_safety_checker"]
+
         updated_args = Args(**args_dict)
-        
+
         # Create Pipeline instance with the pre-created wrapper and config
         pipeline = Pipeline(wrapper=wrapper, config=pipeline_config)
-        
+
         logger.info("_create_pipeline: Pipeline created successfully with pre-created wrapper")
         return pipeline
 
@@ -919,24 +918,25 @@ class App:
         """Load style images from config into InputSourceManager"""
         if not self.app_state.uploaded_config:
             return
-            
+
         try:
             # Load IPAdapter style images from config
-            ipadapters = self.app_state.uploaded_config.get('ipadapters', [])
+            ipadapters = self.app_state.uploaded_config.get("ipadapters", [])
             if ipadapters:
                 first_ipadapter = ipadapters[0]
-                style_image_path = first_ipadapter.get('style_image')
+                style_image_path = first_ipadapter.get("style_image")
                 if style_image_path:
                     # Use the config file path as base for relative paths
-                    base_config_path = getattr(self.args, 'controlnet_config', None)
+                    base_config_path = getattr(self.args, "controlnet_config", None)
                     self.input_source_manager.load_config_style_image(style_image_path, base_config_path)
         except Exception as e:
             logging.exception(f"_load_config_style_images: Error loading config style images: {e}")
 
     def _cleanup_temp_files(self):
         """Clean up any temporary config files"""
-        if hasattr(self, '_temp_config_files'):
+        if hasattr(self, "_temp_config_files"):
             import os
+
             for temp_path in self._temp_config_files:
                 try:
                     if os.path.exists(temp_path):
@@ -945,26 +945,24 @@ class App:
                     pass
             self._temp_config_files.clear()
 
-
     def _calculate_aspect_ratio(self, width: int, height: int) -> str:
         """Calculate and return aspect ratio as a string"""
-        import math
-        
+
         def gcd(a, b):
             while b:
                 a, b = b, a % b
             return a
-        
+
         ratio_gcd = gcd(width, height)
-        return f"{width//ratio_gcd}:{height//ratio_gcd}"
+        return f"{width // ratio_gcd}:{height // ratio_gcd}"
 
     def _cleanup_pipeline(self, pipeline):
         """Properly cleanup a pipeline and free VRAM"""
         if pipeline is None:
             return
-        
+
         try:
-            if hasattr(pipeline, 'cleanup'):
+            if hasattr(pipeline, "cleanup"):
                 pipeline.cleanup()
             del pipeline
             torch.cuda.empty_cache()

--- a/demo/realtime-img2img/main.py
+++ b/demo/realtime-img2img/main.py
@@ -1,3 +1,12 @@
+import os
+
+# ─── CUDA / PyTorch env var defaults (must be before import torch) ───
+# Only set if not already provided by the launch script or environment
+if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
+    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "max_split_size_mb:128,expandable_segments:True"
+if "CUDA_MODULE_LOADING" not in os.environ:
+    os.environ["CUDA_MODULE_LOADING"] = "LAZY"
+
 import logging
 import mimetypes
 import time

--- a/demo/realtime-img2img/routes/__init__.py
+++ b/demo/realtime-img2img/routes/__init__.py
@@ -1,4 +1,3 @@
 """
 Routes package for realtime-img2img API endpoints
 """
-

--- a/demo/realtime-img2img/routes/common/api_utils.py
+++ b/demo/realtime-img2img/routes/common/api_utils.py
@@ -3,46 +3,43 @@ Utility functions for API endpoints to reduce code duplication
 """
 
 import logging
+from typing import Any, Dict, Optional
+
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
-from typing import Any, Dict, Optional
 
 
 async def handle_api_request(
-    request: Request,
-    operation_name: str,
-    required_params: list = None,
-    pipeline_required: bool = True
+    request: Request, operation_name: str, required_params: list = None, pipeline_required: bool = True
 ) -> Dict[str, Any]:
     """
     Standard request handler for API endpoints
-    
+
     Args:
         request: FastAPI request object
         operation_name: Name of the operation for logging
         required_params: List of required parameter names
         pipeline_required: Whether an active pipeline is required
-        
+
     Returns:
         Parsed JSON data from request
-        
+
     Raises:
         HTTPException: For validation errors
     """
     try:
         data = await request.json()
-        
+
         # Check required parameters
         if required_params:
             missing_params = [param for param in required_params if param not in data]
             if missing_params:
                 raise HTTPException(
-                    status_code=400, 
-                    detail=f"Missing required parameters: {', '.join(missing_params)}"
+                    status_code=400, detail=f"Missing required parameters: {', '.join(missing_params)}"
                 )
-        
+
         return data
-        
+
     except Exception as e:
         logging.exception(f"{operation_name}: Failed to parse request: {e}")
         raise HTTPException(status_code=400, detail=f"Invalid request format: {str(e)}")
@@ -51,18 +48,15 @@ async def handle_api_request(
 def create_success_response(message: str, **extra_data) -> JSONResponse:
     """
     Create a standardized success response
-    
+
     Args:
         message: Success message
         **extra_data: Additional data to include in response
-        
+
     Returns:
         JSONResponse with standardized format
     """
-    response_data = {
-        "status": "success",
-        "message": message
-    }
+    response_data = {"status": "success", "message": message}
     response_data.update(extra_data)
     return JSONResponse(response_data)
 
@@ -70,84 +64,71 @@ def create_success_response(message: str, **extra_data) -> JSONResponse:
 def handle_api_error(error: Exception, operation_name: str, status_code: int = 500) -> HTTPException:
     """
     Standard error handler for API endpoints
-    
+
     Args:
         error: The caught exception
         operation_name: Name of the operation for logging
         status_code: HTTP status code to return
-        
+
     Returns:
         HTTPException with standardized error message
     """
     logging.error(f"{operation_name}: Failed: {error}")
-    return HTTPException(
-        status_code=status_code, 
-        detail=f"Failed to {operation_name.lower()}: {str(error)}"
-    )
+    return HTTPException(status_code=status_code, detail=f"Failed to {operation_name.lower()}: {str(error)}")
 
 
 def validate_pipeline(pipeline: Any, operation_name: str) -> None:
     """
     Validate that pipeline exists and is initialized
-    
+
     Args:
         pipeline: Pipeline object to validate
         operation_name: Name of the operation for error messages
-        
+
     Raises:
         HTTPException: If pipeline is not valid
     """
     logging.info(f"validate_pipeline: {operation_name} - pipeline is: {pipeline is not None}")
     if not pipeline:
         logging.error(f"validate_pipeline: {operation_name} - Pipeline is not initialized")
-        raise HTTPException(
-            status_code=400, 
-            detail="Pipeline is not initialized"
-        )
+        raise HTTPException(status_code=400, detail="Pipeline is not initialized")
 
 
 def validate_feature_enabled(pipeline: Any, feature_name: str, feature_check_attr: str) -> None:
     """
     Validate that a specific feature is enabled in the pipeline
-    
+
     Args:
         pipeline: Pipeline object
         feature_name: Human-readable feature name (e.g., "ControlNet", "IPAdapter")
         feature_check_attr: Attribute name to check (e.g., "has_controlnet", "has_ipadapter")
-        
+
     Raises:
         HTTPException: If feature is not enabled
     """
     if not getattr(pipeline, feature_check_attr, False):
-        raise HTTPException(
-            status_code=400, 
-            detail=f"{feature_name} is not enabled"
-        )
+        raise HTTPException(status_code=400, detail=f"{feature_name} is not enabled")
 
 
 def validate_config_mode(pipeline: Any, config_check: Optional[str] = None) -> None:
     """
     Validate that pipeline is using config mode
-    
+
     Args:
         pipeline: Pipeline object
         config_check: Optional specific config key to check for existence
-        
+
     Raises:
         HTTPException: If not in config mode or config key missing
     """
-    logging.info(f"validate_config_mode: use_config={getattr(pipeline, 'use_config', None)}, config exists={getattr(pipeline, 'config', None) is not None}")
+    logging.info(
+        f"validate_config_mode: use_config={getattr(pipeline, 'use_config', None)}, config exists={getattr(pipeline, 'config', None) is not None}"
+    )
     if not (pipeline.use_config and pipeline.config):
-        logging.error(f"validate_config_mode: Pipeline is not using configuration mode")
-        raise HTTPException(
-            status_code=400, 
-            detail="Pipeline is not using configuration mode"
-        )
-    
+        logging.error("validate_config_mode: Pipeline is not using configuration mode")
+        raise HTTPException(status_code=400, detail="Pipeline is not using configuration mode")
+
     if config_check and config_check not in pipeline.config:
         logging.error(f"validate_config_mode: Configuration key '{config_check}' not found in pipeline config")
         logging.info(f"validate_config_mode: Available config keys: {list(pipeline.config.keys())}")
-        raise HTTPException(
-            status_code=400, 
-            detail=f"Configuration missing required section: {config_check}"
-        ) 
+        raise HTTPException(status_code=400, detail=f"Configuration missing required section: {config_check}")

--- a/demo/realtime-img2img/routes/controlnet.py
+++ b/demo/realtime-img2img/routes/controlnet.py
@@ -1,18 +1,23 @@
 """
 ControlNet-related endpoints for realtime-img2img
 """
-from fastapi import APIRouter, Request, HTTPException, Depends, UploadFile, File
-from fastapi.responses import JSONResponse
-import logging
-import yaml
-import tempfile
-from pathlib import Path
-import copy
 
-from .common.api_utils import handle_api_request, create_success_response, handle_api_error, validate_feature_enabled, validate_config_mode
+import copy
+import logging
+
+import yaml
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
+from fastapi.responses import JSONResponse
+
+from .common.api_utils import (
+    create_success_response,
+    handle_api_error,
+)
 from .common.dependencies import get_app_instance, get_available_controlnets
 
+
 router = APIRouter(prefix="/api", tags=["controlnet"])
+
 
 def _ensure_runtime_controlnet_config(app_instance):
     """Ensure runtime controlnet config is initialized from uploaded config or create minimal config"""
@@ -22,45 +27,45 @@ def _ensure_runtime_controlnet_config(app_instance):
             app_instance.app_state.runtime_config = copy.deepcopy(app_instance.app_state.uploaded_config)
         else:
             # Create minimal config if no YAML exists
-            app_instance.app_state.runtime_config = {'controlnets': []}
-    
+            app_instance.app_state.runtime_config = {"controlnets": []}
+
     # Ensure controlnets key exists in runtime config
-    if 'controlnets' not in app_instance.app_state.runtime_config:
-        app_instance.app_state.runtime_config['controlnets'] = []
+    if "controlnets" not in app_instance.app_state.runtime_config:
+        app_instance.app_state.runtime_config["controlnets"] = []
 
 
 @router.post("/controlnet/upload-config")
 async def upload_controlnet_config(file: UploadFile = File(...), app_instance=Depends(get_app_instance)):
     """Upload and load a new ControlNet YAML configuration"""
     try:
-        if not file.filename.endswith(('.yaml', '.yml')):
+        if not file.filename.endswith((".yaml", ".yml")):
             raise HTTPException(status_code=400, detail="File must be a YAML file")
-        
+
         # Save uploaded file temporarily
         content = await file.read()
-        
+
         # Parse YAML content
         try:
-            config_data = yaml.safe_load(content.decode('utf-8'))
+            config_data = yaml.safe_load(content.decode("utf-8"))
         except yaml.YAMLError as e:
             raise HTTPException(status_code=400, detail=f"Invalid YAML format: {str(e)}")
-        
+
         # YAML is source of truth - completely replace any runtime modifications
         app_instance.app_state.uploaded_config = config_data
         app_instance.app_state.runtime_config = None
         app_instance.app_state.config_needs_reload = True
-        
+
         # SINGLE SOURCE OF TRUTH: Populate AppState from config
         app_instance.app_state.populate_from_config(config_data)
-        
+
         # RESET ALL INPUT SOURCES TO DEFAULTS WHEN NEW CONFIG IS UPLOADED
-        if hasattr(app_instance, 'input_source_manager'):
+        if hasattr(app_instance, "input_source_manager"):
             try:
                 app_instance.input_source_manager.reset_to_defaults()
                 logging.info("upload_controlnet_config: Reset all input sources to defaults")
             except Exception as e:
                 logging.exception(f"upload_controlnet_config: Failed to reset input sources: {e}")
-        
+
         # FORCE DESTROY ACTIVE PIPELINE TO MAKE CONFIG THE SOURCE OF TRUTH
         if app_instance.pipeline:
             logging.info("upload_controlnet_config: Destroying active pipeline to force config as source of truth")
@@ -69,43 +74,43 @@ async def upload_controlnet_config(file: UploadFile = File(...), app_instance=De
             app_instance.pipeline = None
             app_instance._cleanup_pipeline(old_pipeline)
             app_instance.app_state.pipeline_lifecycle = "stopped"
-        
+
         # Get config prompt if available
-        config_prompt = config_data.get('prompt', None)
+        config_prompt = config_data.get("prompt", None)
         # Get negative prompt if available
-        config_negative_prompt = config_data.get('negative_prompt', None)
-        
+        config_negative_prompt = config_data.get("negative_prompt", None)
+
         # Get t_index_list from config if available
         from app_config import DEFAULT_SETTINGS
-        t_index_list = config_data.get('t_index_list', DEFAULT_SETTINGS.get('t_index_list', [35, 45]))
-        
+
+        t_index_list = config_data.get("t_index_list", DEFAULT_SETTINGS.get("t_index_list", [35, 45]))
+
         # Get acceleration from config if available
-        config_acceleration = config_data.get('acceleration', app_instance.args.acceleration)
-        
+        config_acceleration = config_data.get("acceleration", app_instance.args.acceleration)
+
         # Get width and height from config if available
-        config_width = config_data.get('width', None)
-        config_height = config_data.get('height', None)
-        
+        config_width = config_data.get("width", None)
+        config_height = config_data.get("height", None)
+
         # Update resolution if width/height are specified in config
         if config_width is not None and config_height is not None:
             try:
                 # Validate resolution
                 if config_width % 64 != 0 or config_height % 64 != 0:
                     raise HTTPException(status_code=400, detail="Resolution must be multiples of 64")
-                
+
                 if not (384 <= config_width <= 1024) or not (384 <= config_height <= 1024):
                     raise HTTPException(status_code=400, detail="Resolution must be between 384 and 1024")
-                
-                app_instance.app_state.current_resolution = {
-                    "width": int(config_width),
-                    "height": int(config_height)
-                }
-                
-                logging.info(f"upload_controlnet_config: Updated resolution from config to {config_width}x{config_height}")
-                
+
+                app_instance.app_state.current_resolution = {"width": int(config_width), "height": int(config_height)}
+
+                logging.info(
+                    f"upload_controlnet_config: Updated resolution from config to {config_width}x{config_height}"
+                )
+
             except (ValueError, TypeError):
                 raise HTTPException(status_code=400, detail="Invalid width/height values in config")
-        
+
         # Build current resolution string
         current_resolution = None
         if config_width and config_height:
@@ -114,13 +119,13 @@ async def upload_controlnet_config(file: UploadFile = File(...), app_instance=De
             aspect_ratio = app_instance._calculate_aspect_ratio(config_width, config_height)
             if aspect_ratio:
                 current_resolution += f" ({aspect_ratio})"
-        
+
         # Build config_values for other parameters that frontend may expect
         config_values = {}
         for key in [
-            'use_taesd',
-            'cfg_type', 
-            'safety_checker',
+            "use_taesd",
+            "cfg_type",
+            "safety_checker",
         ]:
             if key in config_data:
                 config_values[key] = config_data[key]
@@ -155,45 +160,56 @@ async def upload_controlnet_config(file: UploadFile = File(...), app_instance=De
             "latent_preprocessing": app_instance.app_state.pipeline_hooks["latent_preprocessing"],
             "latent_postprocessing": app_instance.app_state.pipeline_hooks["latent_postprocessing"],
         }
-        
+
         return JSONResponse(response_data)
-        
+
     except Exception as e:
         logging.exception(f"upload_controlnet_config: Failed to upload configuration: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to upload configuration: {str(e)}")
+
 
 @router.get("/controlnet/info")
 async def get_controlnet_info(app_instance=Depends(get_app_instance)):
     """Get current ControlNet configuration info - SINGLE SOURCE OF TRUTH"""
     return JSONResponse({"controlnet": app_instance.app_state.controlnet_info})
 
+
 @router.get("/blending/current")
 async def get_current_blending_config(app_instance=Depends(get_app_instance)):
     """Get current prompt and seed blending configurations"""
     try:
-        if app_instance.pipeline and hasattr(app_instance.pipeline, 'stream') and hasattr(app_instance.pipeline.stream, 'get_stream_state'):
+        if (
+            app_instance.pipeline
+            and hasattr(app_instance.pipeline, "stream")
+            and hasattr(app_instance.pipeline.stream, "get_stream_state")
+        ):
             state = app_instance.pipeline.stream.get_stream_state(include_caches=False)
-            return JSONResponse({
-                "prompt_blending": state.get("prompt_list", []),
-                "seed_blending": state.get("seed_list", []),
-                "normalize_prompt_weights": state.get("normalize_prompt_weights", True),
-                "normalize_seed_weights": state.get("normalize_seed_weights", True),
-                "has_config": app_instance.app_state.uploaded_config is not None,
-                "pipeline_active": True
-            })
+            return JSONResponse(
+                {
+                    "prompt_blending": state.get("prompt_list", []),
+                    "seed_blending": state.get("seed_list", []),
+                    "normalize_prompt_weights": state.get("normalize_prompt_weights", True),
+                    "normalize_seed_weights": state.get("normalize_seed_weights", True),
+                    "has_config": app_instance.app_state.uploaded_config is not None,
+                    "pipeline_active": True,
+                }
+            )
 
         # Fallback to AppState when pipeline not initialized - SINGLE SOURCE OF TRUTH
-        return JSONResponse({
-            "prompt_blending": app_instance.app_state.prompt_blending,
-            "seed_blending": app_instance.app_state.seed_blending,
-            "normalize_prompt_weights": app_instance.app_state.normalize_prompt_weights,
-            "normalize_seed_weights": app_instance.app_state.normalize_seed_weights,
-            "has_config": app_instance.app_state.uploaded_config is not None,
-            "pipeline_active": False
-        })
-        
+        return JSONResponse(
+            {
+                "prompt_blending": app_instance.app_state.prompt_blending,
+                "seed_blending": app_instance.app_state.seed_blending,
+                "normalize_prompt_weights": app_instance.app_state.normalize_prompt_weights,
+                "normalize_seed_weights": app_instance.app_state.normalize_seed_weights,
+                "has_config": app_instance.app_state.uploaded_config is not None,
+                "pipeline_active": False,
+            }
+        )
+
     except Exception as e:
         raise handle_api_error(e, "get_current_blending_config")
+
 
 @router.post("/controlnet/update-strength")
 async def update_controlnet_strength(request: Request, app_instance=Depends(get_app_instance)):
@@ -202,13 +218,13 @@ async def update_controlnet_strength(request: Request, app_instance=Depends(get_
         data = await request.json()
         controlnet_index = data.get("index")
         strength = data.get("strength")
-        
+
         if controlnet_index is None or strength is None:
             raise HTTPException(status_code=400, detail="Missing index or strength parameter")
-        
+
         # Update ControlNet strength in AppState - SINGLE SOURCE OF TRUTH
         app_instance.app_state.update_controlnet_strength(controlnet_index, float(strength))
-        
+
         # Update pipeline if active
         if app_instance.pipeline:
             try:
@@ -216,114 +232,122 @@ async def update_controlnet_strength(request: Request, app_instance=Depends(get_
                 controlnet_config = []
                 for cn in app_instance.app_state.controlnet_info["controlnets"]:
                     config_entry = dict(cn)
-                    config_entry['conditioning_scale'] = cn['strength']  # Map strength back to conditioning_scale
+                    config_entry["conditioning_scale"] = cn["strength"]  # Map strength back to conditioning_scale
                     controlnet_config.append(config_entry)
                 app_instance.pipeline.update_stream_params(controlnet_config=controlnet_config)
             except Exception as e:
                 logging.exception(f"update_controlnet_strength: Failed to update pipeline: {e}")
                 # Mark for reload as fallback
                 app_instance.app_state.config_needs_reload = True
-            
+
         return create_success_response(f"Updated ControlNet {controlnet_index} strength to {strength}")
-        
+
     except Exception as e:
         raise handle_api_error(e, "update_controlnet_strength")
 
+
 @router.get("/controlnet/available")
-async def get_available_controlnets_endpoint(app_instance=Depends(get_app_instance), available_controlnets=Depends(get_available_controlnets)):
+async def get_available_controlnets_endpoint(
+    app_instance=Depends(get_app_instance), available_controlnets=Depends(get_available_controlnets)
+):
     """Get list of available ControlNets that can be added"""
     try:
         # Debug the dependency injection
-        
+
         # Detect current model architecture to filter appropriate ControlNets
         model_type = "sd15"  # Default fallback
-        
+
         # Try to determine model type from pipeline config or uploaded config
-        if app_instance.pipeline and hasattr(app_instance.pipeline, 'config') and app_instance.pipeline.config:
-            model_id = app_instance.pipeline.config.get('model_id', '')
-            if 'sdxl' in model_id.lower() or 'xl' in model_id.lower():
+        if app_instance.pipeline and hasattr(app_instance.pipeline, "config") and app_instance.pipeline.config:
+            model_id = app_instance.pipeline.config.get("model_id", "")
+            if "sdxl" in model_id.lower() or "xl" in model_id.lower():
                 model_type = "sdxl"
         elif app_instance.app_state.uploaded_config:
             # If no pipeline yet, try to get model type from uploaded config
-            model_id = app_instance.app_state.uploaded_config.get('model_id_or_path', '')
-            if 'sdxl' in model_id.lower() or 'xl' in model_id.lower():
+            model_id = app_instance.app_state.uploaded_config.get("model_id_or_path", "")
+            if "sdxl" in model_id.lower() or "xl" in model_id.lower():
                 model_type = "sdxl"
-        
+
         # Handle case where available_controlnets dependency returns None
         if available_controlnets is None:
             logging.warning("get_available_controlnets: available_controlnets dependency returned None")
             available = []
         else:
             available = available_controlnets.get(model_type, [])
-        
+
         # Filter out already active ControlNets
         current_controlnets = []
         # Check runtime config first, then fall back to uploaded config
-        if app_instance.app_state.runtime_config and 'controlnets' in app_instance.app_state.runtime_config:
-            current_controlnets = [cn.get('model_id', '') for cn in app_instance.app_state.runtime_config['controlnets']]
-        elif app_instance.app_state.uploaded_config and 'controlnets' in app_instance.app_state.uploaded_config:
-            current_controlnets = [cn.get('model_id', '') for cn in app_instance.app_state.uploaded_config['controlnets']]
-        
+        if app_instance.app_state.runtime_config and "controlnets" in app_instance.app_state.runtime_config:
+            current_controlnets = [
+                cn.get("model_id", "") for cn in app_instance.app_state.runtime_config["controlnets"]
+            ]
+        elif app_instance.app_state.uploaded_config and "controlnets" in app_instance.app_state.uploaded_config:
+            current_controlnets = [
+                cn.get("model_id", "") for cn in app_instance.app_state.uploaded_config["controlnets"]
+            ]
+
         filtered_available = []
         for cn in available:
-            if cn['model_id'] not in current_controlnets:
+            if cn["model_id"] not in current_controlnets:
                 filtered_available.append(cn)
-        
-        return JSONResponse({
-            "status": "success",
-            "available_controlnets": filtered_available,
-            "model_type": model_type
-        })
-        
+
+        return JSONResponse(
+            {"status": "success", "available_controlnets": filtered_available, "model_type": model_type}
+        )
+
     except Exception as e:
         raise handle_api_error(e, "get_available_controlnets_endpoint")
 
+
 @router.post("/controlnet/add")
-async def add_controlnet(request: Request, app_instance=Depends(get_app_instance), available_controlnets=Depends(get_available_controlnets)):
+async def add_controlnet(
+    request: Request, app_instance=Depends(get_app_instance), available_controlnets=Depends(get_available_controlnets)
+):
     """Add a ControlNet from the predefined list"""
     try:
         data = await request.json()
         controlnet_id = data.get("controlnet_id")
         conditioning_scale = data.get("conditioning_scale", None)
-        
+
         if not controlnet_id:
             raise HTTPException(status_code=400, detail="Missing controlnet_id parameter")
-        
+
         # Find the ControlNet definition
         controlnet_def = None
         for model_type, controlnets in available_controlnets.items():
             for cn in controlnets:
-                if cn['id'] == controlnet_id:
+                if cn["id"] == controlnet_id:
                     controlnet_def = cn
                     break
             if controlnet_def:
                 break
-        
+
         if not controlnet_def:
             raise HTTPException(status_code=400, detail=f"ControlNet {controlnet_id} not found in registry")
-        
+
         # Use provided scale or default
         if conditioning_scale is None:
-            conditioning_scale = controlnet_def['default_scale']
-        
+            conditioning_scale = controlnet_def["default_scale"]
+
         # Initialize runtime config from YAML if not already done
         _ensure_runtime_controlnet_config(app_instance)
-        
+
         # Create new ControlNet entry
         new_controlnet = {
-            'model_id': controlnet_def['model_id'],
-            'conditioning_scale': conditioning_scale,
-            'preprocessor': controlnet_def['default_preprocessor'],
-            'preprocessor_params': controlnet_def.get('preprocessor_params', {}),
-            'enabled': True
+            "model_id": controlnet_def["model_id"],
+            "conditioning_scale": conditioning_scale,
+            "preprocessor": controlnet_def["default_preprocessor"],
+            "preprocessor_params": controlnet_def.get("preprocessor_params", {}),
+            "enabled": True,
         }
-        
+
         # Add to runtime config (not YAML)
-        app_instance.app_state.runtime_config['controlnets'].append(new_controlnet)
-        
+        app_instance.app_state.runtime_config["controlnets"].append(new_controlnet)
+
         # Add to AppState - SINGLE SOURCE OF TRUTH
         app_instance.app_state.add_controlnet(new_controlnet)
-        
+
         # Update pipeline if active
         if app_instance.pipeline:
             try:
@@ -331,52 +355,57 @@ async def add_controlnet(request: Request, app_instance=Depends(get_app_instance
                 controlnet_config = []
                 for cn in app_instance.app_state.controlnet_info["controlnets"]:
                     config_entry = dict(cn)
-                    config_entry['conditioning_scale'] = cn['strength']  # Map strength back to conditioning_scale
+                    config_entry["conditioning_scale"] = cn["strength"]  # Map strength back to conditioning_scale
                     controlnet_config.append(config_entry)
                 app_instance.pipeline.update_stream_params(controlnet_config=controlnet_config)
             except Exception as e:
                 logging.exception(f"add_controlnet: Failed to update pipeline: {e}")
                 # Mark for reload as fallback
                 app_instance.app_state.config_needs_reload = True
-        
-        
+
         # Return updated ControlNet info immediately - SINGLE SOURCE OF TRUTH
-        added_index = len(app_instance.app_state.runtime_config['controlnets']) - 1
-        
-        return JSONResponse({
-            "status": "success", 
-            "message": f"Added {controlnet_def['name']}",
-            "controlnet_index": added_index,
-            "controlnet_info": app_instance.app_state.controlnet_info
-        })
-        
+        added_index = len(app_instance.app_state.runtime_config["controlnets"]) - 1
+
+        return JSONResponse(
+            {
+                "status": "success",
+                "message": f"Added {controlnet_def['name']}",
+                "controlnet_index": added_index,
+                "controlnet_info": app_instance.app_state.controlnet_info,
+            }
+        )
+
     except Exception as e:
         raise handle_api_error(e, "add_controlnet")
+
 
 @router.get("/controlnet/status")
 async def get_controlnet_status(app_instance=Depends(get_app_instance)):
     """Get the status of ControlNet configuration"""
     try:
         controlnet_pipeline = app_instance._get_controlnet_pipeline()
-        
+
         if not controlnet_pipeline:
-            return JSONResponse({
-                "status": "no_pipeline",
-                "message": "No ControlNet pipeline available",
-                "controlnet_count": 0
-            })
-        
+            return JSONResponse(
+                {"status": "no_pipeline", "message": "No ControlNet pipeline available", "controlnet_count": 0}
+            )
+
         # Use AppState - SINGLE SOURCE OF TRUTH
         controlnet_count = len(app_instance.app_state.controlnet_info["controlnets"])
-        
-        return JSONResponse({
-            "status": "ready",
-            "controlnet_count": controlnet_count,
-            "message": f"{controlnet_count} ControlNet(s) configured" if controlnet_count > 0 else "No ControlNets configured"
-        })
-        
+
+        return JSONResponse(
+            {
+                "status": "ready",
+                "controlnet_count": controlnet_count,
+                "message": f"{controlnet_count} ControlNet(s) configured"
+                if controlnet_count > 0
+                else "No ControlNets configured",
+            }
+        )
+
     except Exception as e:
         raise handle_api_error(e, "get_controlnet_status")
+
 
 @router.post("/controlnet/remove")
 async def remove_controlnet(request: Request, app_instance=Depends(get_app_instance)):
@@ -384,26 +413,26 @@ async def remove_controlnet(request: Request, app_instance=Depends(get_app_insta
     try:
         data = await request.json()
         index = data.get("index")
-        
+
         if index is None:
             raise HTTPException(status_code=400, detail="Missing index parameter")
-        
+
         # Initialize runtime config from YAML if not already done
         _ensure_runtime_controlnet_config(app_instance)
-        
-        if 'controlnets' not in app_instance.app_state.runtime_config:
+
+        if "controlnets" not in app_instance.app_state.runtime_config:
             raise HTTPException(status_code=400, detail="No ControlNet configuration found")
-        
-        controlnets = app_instance.app_state.runtime_config['controlnets']
-        
+
+        controlnets = app_instance.app_state.runtime_config["controlnets"]
+
         if index < 0 or index >= len(controlnets):
             raise HTTPException(status_code=400, detail=f"ControlNet index {index} out of range")
-        
+
         removed_controlnet = controlnets.pop(index)
-        
+
         # Remove from AppState - SINGLE SOURCE OF TRUTH
         app_instance.app_state.remove_controlnet(index)
-        
+
         # Update pipeline if active
         if app_instance.pipeline:
             try:
@@ -411,20 +440,22 @@ async def remove_controlnet(request: Request, app_instance=Depends(get_app_insta
                 controlnet_config = []
                 for cn in app_instance.app_state.controlnet_info["controlnets"]:
                     config_entry = dict(cn)
-                    config_entry['conditioning_scale'] = cn['strength']  # Map strength back to conditioning_scale
+                    config_entry["conditioning_scale"] = cn["strength"]  # Map strength back to conditioning_scale
                     controlnet_config.append(config_entry)
                 app_instance.pipeline.update_stream_params(controlnet_config=controlnet_config)
             except Exception as e:
                 logging.exception(f"remove_controlnet: Failed to update pipeline: {e}")
                 # Mark for reload as fallback
                 app_instance.app_state.config_needs_reload = True
-        
-        
+
         # Return updated ControlNet info immediately - SINGLE SOURCE OF TRUTH
-        return create_success_response(f"Removed ControlNet at index {index}", controlnet_info=app_instance.app_state.controlnet_info)
-        
+        return create_success_response(
+            f"Removed ControlNet at index {index}", controlnet_info=app_instance.app_state.controlnet_info
+        )
+
     except Exception as e:
         raise handle_api_error(e, "remove_controlnet")
+
 
 # Preprocessor endpoints (closely related to ControlNet)
 @router.get("/preprocessors/info")
@@ -432,43 +463,42 @@ async def get_preprocessors_info(app_instance=Depends(get_app_instance)):
     """Get preprocessor information using metadata from preprocessor classes"""
     try:
         # Use the same processor registry as pipeline hooks
-        from streamdiffusion.preprocessing.processors import list_preprocessors, get_preprocessor_class
-        
+        from streamdiffusion.preprocessing.processors import get_preprocessor_class, list_preprocessors
+
         available_processors = list_preprocessors()
         processors_info = {}
-        
+
         for processor_name in available_processors:
             try:
                 processor_class = get_preprocessor_class(processor_name)
-                if hasattr(processor_class, 'get_preprocessor_metadata'):
+                if hasattr(processor_class, "get_preprocessor_metadata"):
                     metadata = processor_class.get_preprocessor_metadata()
                     processors_info[processor_name] = {
                         "name": metadata.get("name", processor_name),
                         "description": metadata.get("description", ""),
-                        "parameters": metadata.get("parameters", {})
+                        "parameters": metadata.get("parameters", {}),
                     }
                 else:
                     processors_info[processor_name] = {
                         "name": processor_name,
                         "description": f"{processor_name} processor",
-                        "parameters": {}
+                        "parameters": {},
                     }
             except Exception as e:
                 logging.warning(f"get_preprocessors_info: Failed to load metadata for {processor_name}: {e}")
                 processors_info[processor_name] = {
                     "name": processor_name,
                     "description": f"{processor_name} processor",
-                    "parameters": {}
+                    "parameters": {},
                 }
-        
-        return JSONResponse({
-            "status": "success",
-            "available": list(processors_info.keys()),
-            "preprocessors": processors_info
-        })
-        
+
+        return JSONResponse(
+            {"status": "success", "available": list(processors_info.keys()), "preprocessors": processors_info}
+        )
+
     except Exception as e:
         raise handle_api_error(e, "get_preprocessors_info")
+
 
 @router.post("/preprocessors/switch")
 async def switch_preprocessor(request: Request, app_instance=Depends(get_app_instance)):
@@ -478,49 +508,58 @@ async def switch_preprocessor(request: Request, app_instance=Depends(get_app_ins
         # Support both parameter naming conventions for compatibility
         controlnet_index = data.get("controlnet_index") or data.get("processor_index")
         preprocessor_name = data.get("preprocessor") or data.get("processor")
-        
+
         if controlnet_index is None or not preprocessor_name:
-            raise HTTPException(status_code=400, detail="Missing controlnet_index/processor_index or preprocessor/processor parameter")
-        
+            raise HTTPException(
+                status_code=400, detail="Missing controlnet_index/processor_index or preprocessor/processor parameter"
+            )
+
         # Validate AppState has ControlNet configuration (pipeline not required)
-        if not app_instance.app_state.controlnet_info["enabled"] or not app_instance.app_state.controlnet_info["controlnets"]:
-            raise HTTPException(status_code=400, detail="No ControlNet configuration available. Please upload a config first.")
-        
+        if (
+            not app_instance.app_state.controlnet_info["enabled"]
+            or not app_instance.app_state.controlnet_info["controlnets"]
+        ):
+            raise HTTPException(
+                status_code=400, detail="No ControlNet configuration available. Please upload a config first."
+            )
+
         # Update AppState - SINGLE SOURCE OF TRUTH (works before pipeline creation)
         if controlnet_index >= len(app_instance.app_state.controlnet_info["controlnets"]):
             raise HTTPException(status_code=400, detail=f"ControlNet index {controlnet_index} out of range")
-        
+
         # Update the preprocessor in AppState
         controlnet = app_instance.app_state.controlnet_info["controlnets"][controlnet_index]
-        old_preprocessor = controlnet.get('preprocessor', 'unknown')
-        controlnet['preprocessor'] = preprocessor_name
-        controlnet['preprocessor_params'] = {}  # Reset parameters when switching
-        
+        old_preprocessor = controlnet.get("preprocessor", "unknown")
+        controlnet["preprocessor"] = preprocessor_name
+        controlnet["preprocessor_params"] = {}  # Reset parameters when switching
+
         # Update runtime config to keep in sync
-        if app_instance.app_state.runtime_config and 'controlnets' in app_instance.app_state.runtime_config:
-            if controlnet_index < len(app_instance.app_state.runtime_config['controlnets']):
-                app_instance.app_state.runtime_config['controlnets'][controlnet_index]['preprocessor'] = preprocessor_name
-                app_instance.app_state.runtime_config['controlnets'][controlnet_index]['preprocessor_params'] = {}
-        
+        if app_instance.app_state.runtime_config and "controlnets" in app_instance.app_state.runtime_config:
+            if controlnet_index < len(app_instance.app_state.runtime_config["controlnets"]):
+                app_instance.app_state.runtime_config["controlnets"][controlnet_index]["preprocessor"] = (
+                    preprocessor_name
+                )
+                app_instance.app_state.runtime_config["controlnets"][controlnet_index]["preprocessor_params"] = {}
+
         # Update pipeline if active
         if app_instance.pipeline:
             try:
                 controlnet_config = []
                 for cn in app_instance.app_state.controlnet_info["controlnets"]:
                     config_entry = dict(cn)
-                    config_entry['conditioning_scale'] = cn['strength']
+                    config_entry["conditioning_scale"] = cn["strength"]
                     controlnet_config.append(config_entry)
                 app_instance.pipeline.update_stream_params(controlnet_config=controlnet_config)
             except Exception as e:
                 logging.exception(f"switch_preprocessor: Failed to update pipeline: {e}")
                 # Mark for reload as fallback
                 app_instance.app_state.config_needs_reload = True
-        
-        
+
         return create_success_response(f"Switched ControlNet {controlnet_index} preprocessor to {preprocessor_name}")
-        
+
     except Exception as e:
         raise handle_api_error(e, "switch_preprocessor")
+
 
 @router.post("/preprocessors/update-params")
 async def update_preprocessor_params(request: Request, app_instance=Depends(get_app_instance)):
@@ -532,58 +571,72 @@ async def update_preprocessor_params(request: Request, app_instance=Depends(get_
         except Exception as json_error:
             logging.error(f"update_preprocessor_params: JSON parsing failed: {json_error}")
             raise HTTPException(status_code=400, detail=f"Invalid JSON: {json_error}")
-            
+
         controlnet_index = data.get("controlnet_index")
         params = data.get("params", {})
-        
+
         if controlnet_index is None:
-            logging.error(f"update_preprocessor_params: Missing controlnet_index parameter")
+            logging.error("update_preprocessor_params: Missing controlnet_index parameter")
             raise HTTPException(status_code=400, detail="Missing controlnet_index parameter")
-        
+
         # Validate AppState has ControlNet configuration (pipeline not required)
-        if not app_instance.app_state.controlnet_info["enabled"] or not app_instance.app_state.controlnet_info["controlnets"]:
-            logging.error(f"update_preprocessor_params: No ControlNet configuration available in AppState")
-            raise HTTPException(status_code=400, detail="No ControlNet configuration available. Please upload a config first.")
-        
+        if (
+            not app_instance.app_state.controlnet_info["enabled"]
+            or not app_instance.app_state.controlnet_info["controlnets"]
+        ):
+            logging.error("update_preprocessor_params: No ControlNet configuration available in AppState")
+            raise HTTPException(
+                status_code=400, detail="No ControlNet configuration available. Please upload a config first."
+            )
+
         # Update AppState - SINGLE SOURCE OF TRUTH (works before pipeline creation)
         if controlnet_index >= len(app_instance.app_state.controlnet_info["controlnets"]):
-            logging.error(f"update_preprocessor_params: ControlNet index {controlnet_index} out of range (max: {len(app_instance.app_state.controlnet_info['controlnets'])-1})")
+            logging.error(
+                f"update_preprocessor_params: ControlNet index {controlnet_index} out of range (max: {len(app_instance.app_state.controlnet_info['controlnets']) - 1})"
+            )
             raise HTTPException(status_code=400, detail=f"ControlNet index {controlnet_index} out of range")
-        
+
         # Update preprocessor parameters in AppState
         controlnet = app_instance.app_state.controlnet_info["controlnets"][controlnet_index]
-        if 'preprocessor_params' not in controlnet:
-            controlnet['preprocessor_params'] = {}
-        controlnet['preprocessor_params'].update(params)
-        
+        if "preprocessor_params" not in controlnet:
+            controlnet["preprocessor_params"] = {}
+        controlnet["preprocessor_params"].update(params)
+
         # Update runtime config to keep in sync
-        if app_instance.app_state.runtime_config and 'controlnets' in app_instance.app_state.runtime_config:
-            if controlnet_index < len(app_instance.app_state.runtime_config['controlnets']):
-                if 'preprocessor_params' not in app_instance.app_state.runtime_config['controlnets'][controlnet_index]:
-                    app_instance.app_state.runtime_config['controlnets'][controlnet_index]['preprocessor_params'] = {}
-                app_instance.app_state.runtime_config['controlnets'][controlnet_index]['preprocessor_params'].update(params)
-        
+        if app_instance.app_state.runtime_config and "controlnets" in app_instance.app_state.runtime_config:
+            if controlnet_index < len(app_instance.app_state.runtime_config["controlnets"]):
+                if "preprocessor_params" not in app_instance.app_state.runtime_config["controlnets"][controlnet_index]:
+                    app_instance.app_state.runtime_config["controlnets"][controlnet_index]["preprocessor_params"] = {}
+                app_instance.app_state.runtime_config["controlnets"][controlnet_index]["preprocessor_params"].update(
+                    params
+                )
+
         # Update pipeline if active
         if app_instance.pipeline:
             try:
                 controlnet_config = []
                 for cn in app_instance.app_state.controlnet_info["controlnets"]:
                     config_entry = dict(cn)
-                    config_entry['conditioning_scale'] = cn['strength']
+                    config_entry["conditioning_scale"] = cn["strength"]
                     controlnet_config.append(config_entry)
                 app_instance.pipeline.update_stream_params(controlnet_config=controlnet_config)
             except Exception as e:
                 logging.exception(f"update_preprocessor_params: Failed to update pipeline: {e}")
                 # Mark for reload as fallback
                 app_instance.app_state.config_needs_reload = True
-        
-        logging.debug(f"update_preprocessor_params: Updated ControlNet {controlnet_index} preprocessor params: {params}")
-        
-        return create_success_response(f"Updated ControlNet {controlnet_index} preprocessor parameters", updated_params=params)
-        
+
+        logging.debug(
+            f"update_preprocessor_params: Updated ControlNet {controlnet_index} preprocessor params: {params}"
+        )
+
+        return create_success_response(
+            f"Updated ControlNet {controlnet_index} preprocessor parameters", updated_params=params
+        )
+
     except Exception as e:
         logging.exception(f"update_preprocessor_params: Exception occurred: {str(e)}")
         raise handle_api_error(e, "update_preprocessor_params")
+
 
 @router.get("/preprocessors/current-params/{controlnet_index}")
 async def get_current_preprocessor_params(controlnet_index: int, app_instance=Depends(get_app_instance)):
@@ -591,48 +644,55 @@ async def get_current_preprocessor_params(controlnet_index: int, app_instance=De
     try:
         # First try to get from uploaded config if no pipeline
         if not app_instance.pipeline and app_instance.app_state.uploaded_config:
-            controlnets = app_instance.app_state.uploaded_config.get('controlnets', [])
+            controlnets = app_instance.app_state.uploaded_config.get("controlnets", [])
             if controlnet_index < len(controlnets):
                 controlnet = controlnets[controlnet_index]
-                return JSONResponse({
-                    "status": "success",
-                    "controlnet_index": controlnet_index,
-                    "preprocessor": controlnet.get('preprocessor', 'unknown'),
-                    "parameters": controlnet.get('preprocessor_params', {}),
-                    "note": "From uploaded config"
-                })
-        
+                return JSONResponse(
+                    {
+                        "status": "success",
+                        "controlnet_index": controlnet_index,
+                        "preprocessor": controlnet.get("preprocessor", "unknown"),
+                        "parameters": controlnet.get("preprocessor_params", {}),
+                        "note": "From uploaded config",
+                    }
+                )
+
         # Return empty/default response if no config available
         if not app_instance.pipeline:
-            return JSONResponse({
-                "status": "success",
-                "controlnet_index": controlnet_index,
-                "preprocessor": "unknown",
-                "parameters": {},
-                "note": "Pipeline not initialized - no config available"
-            })
-        
+            return JSONResponse(
+                {
+                    "status": "success",
+                    "controlnet_index": controlnet_index,
+                    "preprocessor": "unknown",
+                    "parameters": {},
+                    "note": "Pipeline not initialized - no config available",
+                }
+            )
+
         # Use AppState - SINGLE SOURCE OF TRUTH
         if controlnet_index >= len(app_instance.app_state.controlnet_info["controlnets"]):
-            return JSONResponse({
+            return JSONResponse(
+                {
+                    "status": "success",
+                    "controlnet_index": controlnet_index,
+                    "preprocessor": "unknown",
+                    "parameters": {},
+                    "note": f"ControlNet index {controlnet_index} out of range",
+                }
+            )
+
+        controlnet = app_instance.app_state.controlnet_info["controlnets"][controlnet_index]
+        preprocessor = controlnet.get("preprocessor", "unknown")
+        preprocessor_params = controlnet.get("preprocessor_params", {})
+
+        return JSONResponse(
+            {
                 "status": "success",
                 "controlnet_index": controlnet_index,
-                "preprocessor": "unknown",
-                "parameters": {},
-                "note": f"ControlNet index {controlnet_index} out of range"
-            })
-        
-        controlnet = app_instance.app_state.controlnet_info["controlnets"][controlnet_index]
-        preprocessor = controlnet.get('preprocessor', 'unknown')
-        preprocessor_params = controlnet.get('preprocessor_params', {})
-        
-        return JSONResponse({
-            "status": "success",
-            "controlnet_index": controlnet_index,
-            "preprocessor": preprocessor,
-            "parameters": preprocessor_params
-        })
-        
+                "preprocessor": preprocessor,
+                "parameters": preprocessor_params,
+            }
+        )
+
     except Exception as e:
         raise handle_api_error(e, "get_current_preprocessor_params")
-

--- a/demo/realtime-img2img/routes/debug.py
+++ b/demo/realtime-img2img/routes/debug.py
@@ -1,13 +1,17 @@
 """
 Debug mode API endpoints for realtime-img2img
 """
-from fastapi import APIRouter, HTTPException, Depends
-from pydantic import BaseModel
+
 import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 
 from .common.dependencies import get_app_instance
 
+
 router = APIRouter(prefix="/api/debug", tags=["debug"])
+
 
 class DebugResponse(BaseModel):
     success: bool
@@ -15,24 +19,26 @@ class DebugResponse(BaseModel):
     debug_mode: bool
     debug_pending_frame: bool = False
 
+
 @router.post("/enable", response_model=DebugResponse)
 async def enable_debug_mode(app_instance=Depends(get_app_instance)):
     """Enable debug mode - pauses automatic frame processing"""
     try:
         app_instance.app_state.debug_mode = True
         app_instance.app_state.debug_pending_frame = False
-        
+
         logging.info("enable_debug_mode: Debug mode enabled")
-        
+
         return DebugResponse(
             success=True,
             message="Debug mode enabled. Frame processing is now paused.",
             debug_mode=True,
-            debug_pending_frame=False
+            debug_pending_frame=False,
         )
     except Exception as e:
         logging.exception(f"enable_debug_mode: Failed to enable debug mode: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to enable debug mode: {str(e)}")
+
 
 @router.post("/disable", response_model=DebugResponse)
 async def disable_debug_mode(app_instance=Depends(get_app_instance)):
@@ -40,18 +46,19 @@ async def disable_debug_mode(app_instance=Depends(get_app_instance)):
     try:
         app_instance.app_state.debug_mode = False
         app_instance.app_state.debug_pending_frame = False
-        
+
         logging.info("disable_debug_mode: Debug mode disabled")
-        
+
         return DebugResponse(
             success=True,
             message="Debug mode disabled. Automatic frame processing resumed.",
             debug_mode=False,
-            debug_pending_frame=False
+            debug_pending_frame=False,
         )
     except Exception as e:
         logging.exception(f"disable_debug_mode: Failed to disable debug mode: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to disable debug mode: {str(e)}")
+
 
 @router.post("/step", response_model=DebugResponse)
 async def step_frame(app_instance=Depends(get_app_instance)):
@@ -59,23 +66,24 @@ async def step_frame(app_instance=Depends(get_app_instance)):
     try:
         if not app_instance.app_state.debug_mode:
             raise HTTPException(status_code=400, detail="Debug mode is not enabled")
-        
+
         # Set pending frame flag to allow one frame to be processed
         app_instance.app_state.debug_pending_frame = True
-        
+
         logging.info("step_frame: Frame step requested")
-        
+
         return DebugResponse(
             success=True,
             message="Frame step requested. Next frame will be processed.",
             debug_mode=True,
-            debug_pending_frame=True
+            debug_pending_frame=True,
         )
     except HTTPException:
         raise
     except Exception as e:
         logging.exception(f"step_frame: Failed to step frame: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to step frame: {str(e)}")
+
 
 @router.get("/status", response_model=DebugResponse)
 async def get_debug_status(app_instance=Depends(get_app_instance)):
@@ -85,7 +93,7 @@ async def get_debug_status(app_instance=Depends(get_app_instance)):
             success=True,
             message="Debug status retrieved",
             debug_mode=app_instance.app_state.debug_mode,
-            debug_pending_frame=app_instance.app_state.debug_pending_frame
+            debug_pending_frame=app_instance.app_state.debug_pending_frame,
         )
     except Exception as e:
         logging.exception(f"get_debug_status: Failed to get debug status: {e}")

--- a/demo/realtime-img2img/routes/inference.py
+++ b/demo/realtime-img2img/routes/inference.py
@@ -1,22 +1,26 @@
 """
 Inference and system status endpoints for realtime-img2img
 """
-from fastapi import APIRouter, Request, HTTPException, Depends
-from fastapi.responses import JSONResponse, StreamingResponse
+
 import logging
 import uuid
-import markdown2
 
-from .common.api_utils import handle_api_request, create_success_response, handle_api_error
-from .common.dependencies import get_app_instance, get_pipeline_class, get_default_settings
+import markdown2
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from .common.dependencies import get_app_instance, get_default_settings, get_pipeline_class
+
 
 router = APIRouter(prefix="/api", tags=["inference"])
+
 
 @router.get("/queue")
 async def get_queue_size(app_instance=Depends(get_app_instance)):
     """Get current queue size"""
     queue_size = app_instance.conn_manager.get_user_count()
     return JSONResponse({"queue_size": queue_size})
+
 
 @router.get("/stream/{user_id}")
 async def stream(user_id: uuid.UUID, request: Request, app_instance=Depends(get_app_instance)):
@@ -29,27 +33,38 @@ async def stream(user_id: uuid.UUID, request: Request, app_instance=Depends(get_
             app_instance.pipeline = app_instance._create_pipeline()
             app_instance.app_state.pipeline_lifecycle = "running"
             logging.info("stream: Pipeline created successfully")
-        
+
         # Recreate pipeline if config changed (but not resolution - that's handled separately)
-        elif app_instance.app_state.config_needs_reload or (app_instance.app_state.uploaded_config and not (app_instance.pipeline.use_config and app_instance.pipeline.config and 'controlnets' in app_instance.pipeline.config)) or (app_instance.app_state.uploaded_config and not app_instance.pipeline.use_config):
+        elif (
+            app_instance.app_state.config_needs_reload
+            or (
+                app_instance.app_state.uploaded_config
+                and not (
+                    app_instance.pipeline.use_config
+                    and app_instance.pipeline.config
+                    and "controlnets" in app_instance.pipeline.config
+                )
+            )
+            or (app_instance.app_state.uploaded_config and not app_instance.pipeline.use_config)
+        ):
             if app_instance.app_state.config_needs_reload:
                 logging.info("stream: Recreating pipeline with new ControlNet config...")
             else:
                 logging.info("stream: Upgrading to ControlNet pipeline...")
-            
+
             app_instance.app_state.pipeline_lifecycle = "restarting"
-            
+
             # Properly cleanup the old pipeline before creating new one
             old_pipeline = app_instance.pipeline
             app_instance.pipeline = None
-            
+
             if old_pipeline:
                 app_instance._cleanup_pipeline(old_pipeline)
                 old_pipeline = None
-            
+
             # Create new pipeline
             app_instance.pipeline = app_instance._create_pipeline()
-            
+
             app_instance.app_state.config_needs_reload = False
             app_instance.app_state.pipeline_lifecycle = "running"
             logging.info("stream: Pipeline recreated successfully")
@@ -59,25 +74,31 @@ async def stream(user_id: uuid.UUID, request: Request, app_instance=Depends(get_
 
         # Check for acceleration changes (requires pipeline recreation)
         acceleration_changed = False
-        if hasattr(app_instance, 'new_acceleration') and app_instance.new_acceleration != app_instance.args.acceleration:
-            logging.info(f"stream: Acceleration change detected: {app_instance.args.acceleration} -> {app_instance.new_acceleration}")
-            
+        if (
+            hasattr(app_instance, "new_acceleration")
+            and app_instance.new_acceleration != app_instance.args.acceleration
+        ):
+            logging.info(
+                f"stream: Acceleration change detected: {app_instance.args.acceleration} -> {app_instance.new_acceleration}"
+            )
+
             # Create new Args object with updated acceleration (NamedTuple is immutable)
             from config import Args
+
             args_dict = app_instance.args._asdict()
-            args_dict['acceleration'] = app_instance.new_acceleration
+            args_dict["acceleration"] = app_instance.new_acceleration
             app_instance.args = Args(**args_dict)
-            delattr(app_instance, 'new_acceleration')
-            
+            delattr(app_instance, "new_acceleration")
+
             # Recreate pipeline with new acceleration
             old_pipeline = app_instance.pipeline
             app_instance.pipeline = None
             if old_pipeline:
                 app_instance._cleanup_pipeline(old_pipeline)
-            
+
             app_instance.pipeline = app_instance._create_pipeline()
             acceleration_changed = True
-            logging.info(f"stream: Pipeline recreated with new acceleration")
+            logging.info("stream: Pipeline recreated with new acceleration")
 
         # IPAdapter style images are now handled dynamically in pipeline.predict()
         # No static application needed here
@@ -91,6 +112,7 @@ async def stream(user_id: uuid.UUID, request: Request, app_instance=Depends(get_
 
         # Generate and stream frames using pipeline.predict() in a loop (like original)
         try:
+
             async def generate_frames():
                 try:
                     while True:
@@ -105,219 +127,241 @@ async def stream(user_id: uuid.UUID, request: Request, app_instance=Depends(get_
                             else:
                                 # Wait in debug mode without requesting frames
                                 import asyncio
+
                                 await asyncio.sleep(0.1)  # Small delay to prevent busy waiting
                                 continue
                         else:
                             # Normal mode - request new frame automatically
                             await app_instance.conn_manager.send_json(user_id, {"status": "send_frame"})
-                        
+
                         # Get the latest parameters from the WebSocket connection manager
                         # This consumes data from the queue after requesting a new frame
                         # Get latest data from the queue (blocks until new data arrives)
                         params = await app_instance.conn_manager.get_latest_data(user_id)
                         if params is None:
                             continue
-                        
+
                         # Attach InputSourceManager to params for modular input routing
-                        if hasattr(app_instance, 'input_source_manager'):
+                        if hasattr(app_instance, "input_source_manager"):
                             params.input_manager = app_instance.input_source_manager
-                        
+
                         # Generate frame using pipeline.predict()
                         image = app_instance.pipeline.predict(params)
                         if image is None:
                             logging.error("stream: predict returned None image; skipping frame")
                             continue
-                            
+
                         # Update FPS counter
                         import time
+
                         current_time = time.time()
-                        if hasattr(app_instance, 'last_frame_time'):
+                        if hasattr(app_instance, "last_frame_time"):
                             frame_time = current_time - app_instance.last_frame_time
                             app_instance.fps_counter.append(frame_time)
                             if len(app_instance.fps_counter) > 30:  # Keep last 30 frames
                                 app_instance.fps_counter.pop(0)
                         app_instance.last_frame_time = current_time
-                        
+
                         # Convert image to frame format for streaming
                         # Use appropriate frame conversion based on output type
                         if app_instance.pipeline.output_type == "pt":
                             from util import pt_to_frame
+
                             frame = pt_to_frame(image)
                         else:
                             from util import pil_to_frame
+
                             frame = pil_to_frame(image)
                         yield frame
-                        
+
                 except Exception as e:
                     logging.exception(f"stream: Error in frame generation: {e}")
 
             return StreamingResponse(
                 generate_frames(),
                 media_type="multipart/x-mixed-replace; boundary=frame",
-                headers={"Cache-Control": "no-cache, no-store, must-revalidate"}
+                headers={"Cache-Control": "no-cache, no-store, must-revalidate"},
             )
-            
+
         except Exception as e:
             raise e
-            
+
     except Exception as e:
         logging.exception(f"stream: Error in streaming endpoint: {e}")
         raise HTTPException(status_code=500, detail=f"Streaming failed: {str(e)}")
 
+
 @router.get("/state")
-async def get_app_state(app_instance=Depends(get_app_instance), pipeline_class=Depends(get_pipeline_class), default_settings=Depends(get_default_settings)):
+async def get_app_state(
+    app_instance=Depends(get_app_instance),
+    pipeline_class=Depends(get_pipeline_class),
+    default_settings=Depends(get_default_settings),
+):
     """Get complete application state - replaces /api/settings with centralized state management"""
     try:
         # Update app_state with current dynamic values - SINGLE SOURCE OF TRUTH
         app_instance.app_state.pipeline_active = app_instance.pipeline is not None
-        
+
         # Update FPS from fps_counter
         if len(app_instance.fps_counter) > 0:
             avg_frame_time = sum(app_instance.fps_counter) / len(app_instance.fps_counter)
             app_instance.app_state.fps = round(1.0 / avg_frame_time if avg_frame_time > 0 else 0, 1)
         else:
             app_instance.app_state.fps = 0
-            
+
         # Update queue size
         app_instance.app_state.queue_size = app_instance.conn_manager.get_user_count()
-        
+
         # Update pipeline parameters schema
         app_instance.app_state.pipeline_params = pipeline_class.InputParams.schema()
-        
+
         # Update page content
-        if app_instance.pipeline and hasattr(app_instance.pipeline, 'info'):
+        if app_instance.pipeline and hasattr(app_instance.pipeline, "info"):
             info = app_instance.pipeline.info
         else:
             info = pipeline_class.Info()
-        
+
         if info.page_content:
             app_instance.app_state.page_content = markdown2.markdown(info.page_content)
-        
+
         # Get complete state
         state_data = app_instance.app_state.get_complete_state()
-        
+
         # Add additional fields expected by frontend for backward compatibility
-        state_data.update({
-            "info": pipeline_class.Info.schema(),
-            "input_params": app_instance.app_state.pipeline_params,
-            "max_queue_size": app_instance.args.max_queue_size,
-            "acceleration": app_instance.args.acceleration,
-            # Add config prompt for backward compatibility
-            "config_prompt": app_instance.app_state.uploaded_config.get('prompt') if app_instance.app_state.uploaded_config else None,
-            # Add resolution in expected format
-            "resolution": f"{app_instance.app_state.current_resolution['width']}x{app_instance.app_state.current_resolution['height']}",
-        })
-        
+        state_data.update(
+            {
+                "info": pipeline_class.Info.schema(),
+                "input_params": app_instance.app_state.pipeline_params,
+                "max_queue_size": app_instance.args.max_queue_size,
+                "acceleration": app_instance.args.acceleration,
+                # Add config prompt for backward compatibility
+                "config_prompt": app_instance.app_state.uploaded_config.get("prompt")
+                if app_instance.app_state.uploaded_config
+                else None,
+                # Add resolution in expected format
+                "resolution": f"{app_instance.app_state.current_resolution['width']}x{app_instance.app_state.current_resolution['height']}",
+            }
+        )
+
         return JSONResponse(state_data)
-        
+
     except Exception as e:
         logging.error(f"get_app_state: Error getting application state: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to get application state: {str(e)}")
 
+
 @router.get("/settings")
-async def settings(app_instance=Depends(get_app_instance), pipeline_class=Depends(get_pipeline_class), default_settings=Depends(get_default_settings)):
+async def settings(
+    app_instance=Depends(get_app_instance),
+    pipeline_class=Depends(get_pipeline_class),
+    default_settings=Depends(get_default_settings),
+):
     """Get pipeline settings and configuration info"""
     # Use Pipeline class directly for schema info (doesn't require instance)
     info_schema = pipeline_class.Info.schema()
-    
+
     # Get info from pipeline instance if available to get correct input_mode
-    if app_instance.pipeline and hasattr(app_instance.pipeline, 'info'):
+    if app_instance.pipeline and hasattr(app_instance.pipeline, "info"):
         info = app_instance.pipeline.info
     else:
         info = pipeline_class.Info()
-    
+
     page_content = ""
     if info.page_content:
         page_content = markdown2.markdown(info.page_content)
 
     input_params = pipeline_class.InputParams.schema()
-    
+
     # Add ControlNet information - SINGLE SOURCE OF TRUTH
     controlnet_info = app_instance.app_state.controlnet_info
-    
+
     # Add IPAdapter information - SINGLE SOURCE OF TRUTH
     ipadapter_info = app_instance.app_state.ipadapter_info
-    
+
     # Include config prompt if available, otherwise use default
     config_prompt = None
-    if app_instance.app_state.uploaded_config and 'prompt' in app_instance.app_state.uploaded_config:
-        config_prompt = app_instance.app_state.uploaded_config['prompt']
+    if app_instance.app_state.uploaded_config and "prompt" in app_instance.app_state.uploaded_config:
+        config_prompt = app_instance.app_state.uploaded_config["prompt"]
     elif not config_prompt:
-        config_prompt = default_settings.get('prompt')
-    
+        config_prompt = default_settings.get("prompt")
+
     # Get current t_index_list from pipeline or config
     current_t_index_list = None
-    if app_instance.pipeline and hasattr(app_instance.pipeline.stream, 't_list'):
+    if app_instance.pipeline and hasattr(app_instance.pipeline.stream, "t_list"):
         current_t_index_list = app_instance.pipeline.stream.t_list
-    elif app_instance.app_state.uploaded_config and 't_index_list' in app_instance.app_state.uploaded_config:
-        current_t_index_list = app_instance.app_state.uploaded_config['t_index_list']
+    elif app_instance.app_state.uploaded_config and "t_index_list" in app_instance.app_state.uploaded_config:
+        current_t_index_list = app_instance.app_state.uploaded_config["t_index_list"]
     else:
         # Default values
-        current_t_index_list = default_settings.get('t_index_list', [35, 45])
-    
+        current_t_index_list = default_settings.get("t_index_list", [35, 45])
+
     # Get current acceleration setting
     current_acceleration = app_instance.args.acceleration
-    
+
     # Get current resolution
-    current_resolution = f"{app_instance.app_state.current_resolution['width']}x{app_instance.app_state.current_resolution['height']}"
+    current_resolution = (
+        f"{app_instance.app_state.current_resolution['width']}x{app_instance.app_state.current_resolution['height']}"
+    )
     # Add aspect ratio for display
-    aspect_ratio = app_instance._calculate_aspect_ratio(app_instance.app_state.current_resolution['width'], app_instance.app_state.current_resolution['height'])
+    aspect_ratio = app_instance._calculate_aspect_ratio(
+        app_instance.app_state.current_resolution["width"], app_instance.app_state.current_resolution["height"]
+    )
     if aspect_ratio:
         current_resolution += f" ({aspect_ratio})"
-    if app_instance.app_state.uploaded_config and 'acceleration' in app_instance.app_state.uploaded_config:
-        current_acceleration = app_instance.app_state.uploaded_config['acceleration']
-    
+    if app_instance.app_state.uploaded_config and "acceleration" in app_instance.app_state.uploaded_config:
+        current_acceleration = app_instance.app_state.uploaded_config["acceleration"]
+
     # Get current streaming parameters (default values or from pipeline if available)
-    current_guidance_scale = default_settings.get('guidance_scale', 1.1)
-    current_delta = default_settings.get('delta', 0.7)
-    current_num_inference_steps = default_settings.get('num_inference_steps', 50)
-    current_seed = default_settings.get('seed', 2)
-    
-    if app_instance.pipeline and hasattr(app_instance.pipeline, 'stream'):
+    current_guidance_scale = default_settings.get("guidance_scale", 1.1)
+    current_delta = default_settings.get("delta", 0.7)
+    current_num_inference_steps = default_settings.get("num_inference_steps", 50)
+    current_seed = default_settings.get("seed", 2)
+
+    if app_instance.pipeline and hasattr(app_instance.pipeline, "stream"):
         try:
             state = app_instance.pipeline.stream.get_stream_state()
-            current_guidance_scale = state.get('guidance_scale', current_guidance_scale)
-            current_delta = state.get('delta', current_delta)
-            current_num_inference_steps = state.get('num_inference_steps', current_num_inference_steps)
-            current_seed = state.get('seed', current_seed)
+            current_guidance_scale = state.get("guidance_scale", current_guidance_scale)
+            current_delta = state.get("delta", current_delta)
+            current_num_inference_steps = state.get("num_inference_steps", current_num_inference_steps)
+            current_seed = state.get("seed", current_seed)
         except Exception as e:
             logging.warning(f"settings: Failed to get current stream parameters: {e}")
-    
+
     # Get negative prompt if available
-    current_negative_prompt = default_settings.get('negative_prompt', '')
-    if app_instance.app_state.uploaded_config and 'negative_prompt' in app_instance.app_state.uploaded_config:
-        current_negative_prompt = app_instance.app_state.uploaded_config['negative_prompt']
-    elif app_instance.pipeline and hasattr(app_instance.pipeline, 'stream'):
+    current_negative_prompt = default_settings.get("negative_prompt", "")
+    if app_instance.app_state.uploaded_config and "negative_prompt" in app_instance.app_state.uploaded_config:
+        current_negative_prompt = app_instance.app_state.uploaded_config["negative_prompt"]
+    elif app_instance.pipeline and hasattr(app_instance.pipeline, "stream"):
         try:
             state = app_instance.pipeline.stream.get_stream_state()
-            current_negative_prompt = state.get('negative_prompt', current_negative_prompt)
+            current_negative_prompt = state.get("negative_prompt", current_negative_prompt)
         except Exception:
             pass
-    
+
     # Get prompt and seed blending configuration - SINGLE SOURCE OF TRUTH
     prompt_blending_config = app_instance.app_state.prompt_blending
     seed_blending_config = app_instance.app_state.seed_blending
-    
+
     # Get normalization settings - SINGLE SOURCE OF TRUTH
     normalize_prompt_weights = app_instance.app_state.normalize_prompt_weights
     normalize_seed_weights = app_instance.app_state.normalize_seed_weights
-    
+
     # Get current skip_diffusion setting - SINGLE SOURCE OF TRUTH
     current_skip_diffusion = app_instance.app_state.skip_diffusion
-    
+
     # Determine current model id for UI badge - SINGLE SOURCE OF TRUTH
     model_id_for_ui = app_instance.app_state.model_id
-    
+
     # Check if pipeline is active
     pipeline_active = app_instance.pipeline is not None
-    
+
     # Build config_values for other parameters that frontend may expect
     config_values = {}
     if app_instance.app_state.uploaded_config:
         for key in [
-            'use_taesd',
-            'cfg_type', 
-            'safety_checker',
+            "use_taesd",
+            "cfg_type",
+            "safety_checker",
         ]:
             if key in app_instance.app_state.uploaded_config:
                 config_values[key] = app_instance.app_state.uploaded_config[key]
@@ -347,8 +391,9 @@ async def settings(app_instance=Depends(get_app_instance), pipeline_class=Depend
         "model_id": model_id_for_ui,
         "config_values": config_values,
     }
-    
+
     return JSONResponse(response_data)
+
 
 @router.get("/fps")
 async def get_fps(app_instance=Depends(get_app_instance)):
@@ -358,8 +403,5 @@ async def get_fps(app_instance=Depends(get_app_instance)):
         fps = 1.0 / avg_frame_time if avg_frame_time > 0 else 0
     else:
         fps = 0
-    
+
     return JSONResponse({"fps": round(fps, 1)})
-
-
-

--- a/demo/realtime-img2img/routes/input_sources.py
+++ b/demo/realtime-img2img/routes/input_sources.py
@@ -1,19 +1,21 @@
 """
 Input Source Management API endpoints for realtime-img2img
 """
-from fastapi import APIRouter, Request, HTTPException, Depends, UploadFile, File
-from fastapi.responses import JSONResponse
-import logging
-from pathlib import Path
-from typing import Optional, Any, Dict
-import uuid
-from PIL import Image
-import io
 
-from .common.api_utils import handle_api_request, create_success_response, handle_api_error
+import io
+import logging
+import uuid
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
+from input_sources import InputSource, InputSourceManager, InputSourceType
+from PIL import Image
+from utils.video_utils import is_supported_video_format, validate_video_file
+
+from .common.api_utils import create_success_response, handle_api_error, handle_api_request
 from .common.dependencies import get_app_instance
-from input_sources import InputSource, InputSourceType, InputSourceManager
-from utils.video_utils import validate_video_file, is_supported_video_format
+
 
 router = APIRouter(prefix="/api/input-sources", tags=["input-sources"])
 
@@ -22,7 +24,7 @@ logger = logging.getLogger("input_sources_api")
 
 def _get_input_source_manager(app_instance) -> InputSourceManager:
     """Get or create the input source manager for the app instance."""
-    if not hasattr(app_instance, 'input_source_manager'):
+    if not hasattr(app_instance, "input_source_manager"):
         app_instance.input_source_manager = InputSourceManager()
     return app_instance.input_source_manager
 
@@ -31,7 +33,7 @@ def _get_input_source_manager(app_instance) -> InputSourceManager:
 async def set_input_source(request: Request, app_instance=Depends(get_app_instance)):
     """
     Set input source for a component.
-    
+
     Body: {
         component: str,  # 'controlnet', 'ipadapter', 'base'
         index?: int,     # Required for controlnet
@@ -40,61 +42,60 @@ async def set_input_source(request: Request, app_instance=Depends(get_app_instan
     }
     """
     try:
-        data = await handle_api_request(request, "set_input_source", 
-                                      required_params=['component', 'source_type'],
-                                      pipeline_required=False)
-        
-        component = data['component']
-        source_type_str = data['source_type']
-        index = data.get('index')
-        source_data = data.get('source_data')
-        
+        data = await handle_api_request(
+            request, "set_input_source", required_params=["component", "source_type"], pipeline_required=False
+        )
+
+        component = data["component"]
+        source_type_str = data["source_type"]
+        index = data.get("index")
+        source_data = data.get("source_data")
+
         # Validate component
-        if component not in ['controlnet', 'ipadapter', 'base']:
+        if component not in ["controlnet", "ipadapter", "base"]:
             raise HTTPException(status_code=400, detail=f"Invalid component: {component}")
-        
+
         # Validate source type
         try:
             source_type = InputSourceType(source_type_str)
         except ValueError:
             raise HTTPException(status_code=400, detail=f"Invalid source type: {source_type_str}")
-        
+
         # Validate index for controlnet
-        if component == 'controlnet' and index is None:
+        if component == "controlnet" and index is None:
             raise HTTPException(status_code=400, detail="Index is required for ControlNet components")
-        
+
         # Get input source manager
         manager = _get_input_source_manager(app_instance)
-        
+
         # Create input source
         input_source = InputSource(source_type, source_data)
-        
+
         # Set the source
         manager.set_source(component, input_source, index)
-        
+
         logger.info(f"set_input_source: Set {component} input source to {source_type_str}")
-        
-        return create_success_response({
-            'message': f'Input source set for {component}',
-            'component': component,
-            'source_type': source_type_str,
-            'index': index
-        })
-        
+
+        return create_success_response(
+            {
+                "message": f"Input source set for {component}",
+                "component": component,
+                "source_type": source_type_str,
+                "index": index,
+            }
+        )
+
     except Exception as e:
         return handle_api_error(e, "set_input_source")
 
 
 @router.post("/upload-image/{component}")
 async def upload_component_image(
-    component: str, 
-    file: UploadFile = File(...),
-    index: Optional[int] = None,
-    app_instance=Depends(get_app_instance)
+    component: str, file: UploadFile = File(...), index: Optional[int] = None, app_instance=Depends(get_app_instance)
 ):
     """
     Upload image for specific component.
-    
+
     Args:
         component: Component name ('controlnet', 'ipadapter', 'base')
         file: Image file to upload
@@ -102,69 +103,72 @@ async def upload_component_image(
     """
     try:
         # Validate component
-        if component not in ['controlnet', 'ipadapter', 'base']:
+        if component not in ["controlnet", "ipadapter", "base"]:
             raise HTTPException(status_code=400, detail=f"Invalid component: {component}")
-        
+
         # Validate index for controlnet
-        if component == 'controlnet' and index is None:
+        if component == "controlnet" and index is None:
             raise HTTPException(status_code=400, detail="Index is required for ControlNet components")
-        
+
         # Validate file type
-        if not file.content_type.startswith('image/'):
+        if not file.content_type.startswith("image/"):
             raise HTTPException(status_code=400, detail="File must be an image")
-        
+
         # Generate unique filename
         file_id = str(uuid.uuid4())
-        file_extension = Path(file.filename).suffix if file.filename else '.jpg'
-        filename = f"{component}_{index}_{file_id}{file_extension}" if index is not None else f"{component}_{file_id}{file_extension}"
-        
+        file_extension = Path(file.filename).suffix if file.filename else ".jpg"
+        filename = (
+            f"{component}_{index}_{file_id}{file_extension}"
+            if index is not None
+            else f"{component}_{file_id}{file_extension}"
+        )
+
         # Save file
         uploads_dir = Path("uploads/images")
         uploads_dir.mkdir(parents=True, exist_ok=True)
         file_path = uploads_dir / filename
-        
+
         content = await file.read()
-        with open(file_path, 'wb') as f:
+        with open(file_path, "wb") as f:
             f.write(content)
-        
+
         # Create PIL Image for input source
         try:
             image = Image.open(io.BytesIO(content))
-            image = image.convert('RGB')  # Ensure RGB format
+            image = image.convert("RGB")  # Ensure RGB format
         except Exception as e:
             # Clean up file if image processing fails
             file_path.unlink(missing_ok=True)
             raise HTTPException(status_code=400, detail=f"Invalid image file: {str(e)}")
-        
+
         # Get input source manager and set source
         manager = _get_input_source_manager(app_instance)
         input_source = InputSource(InputSourceType.UPLOADED_IMAGE, image)
         manager.set_source(component, input_source, index)
-        
+
         logger.info(f"upload_component_image: Uploaded image for {component} (index: {index})")
-        
-        return create_success_response({
-            'message': f'Image uploaded for {component}',
-            'component': component,
-            'index': index,
-            'filename': filename,
-            'file_path': str(file_path)
-        })
-        
+
+        return create_success_response(
+            {
+                "message": f"Image uploaded for {component}",
+                "component": component,
+                "index": index,
+                "filename": filename,
+                "file_path": str(file_path),
+            }
+        )
+
     except Exception as e:
         return handle_api_error(e, "upload_component_image")
 
 
 @router.post("/upload-video/{component}")
 async def upload_component_video(
-    component: str,
-    file: UploadFile = File(...),
-    index: Optional[int] = None,
-    app_instance=Depends(get_app_instance)
+    component: str, file: UploadFile = File(...), index: Optional[int] = None, app_instance=Depends(get_app_instance)
 ):
     """
     Upload video for specific component.
-    
+
     Args:
         component: Component name ('controlnet', 'ipadapter', 'base')
         file: Video file to upload
@@ -172,91 +176,95 @@ async def upload_component_video(
     """
     try:
         # Validate component
-        if component not in ['controlnet', 'ipadapter', 'base']:
+        if component not in ["controlnet", "ipadapter", "base"]:
             raise HTTPException(status_code=400, detail=f"Invalid component: {component}")
-        
+
         # Validate index for controlnet
-        if component == 'controlnet' and index is None:
+        if component == "controlnet" and index is None:
             raise HTTPException(status_code=400, detail="Index is required for ControlNet components")
-        
+
         # Validate file type
         if not file.filename or not is_supported_video_format(file.filename):
             raise HTTPException(status_code=400, detail="File must be a supported video format")
-        
+
         # Generate unique filename
         file_id = str(uuid.uuid4())
         file_extension = Path(file.filename).suffix
-        filename = f"{component}_{index}_{file_id}{file_extension}" if index is not None else f"{component}_{file_id}{file_extension}"
-        
+        filename = (
+            f"{component}_{index}_{file_id}{file_extension}"
+            if index is not None
+            else f"{component}_{file_id}{file_extension}"
+        )
+
         # Save file
         uploads_dir = Path("uploads/videos")
         uploads_dir.mkdir(parents=True, exist_ok=True)
         file_path = uploads_dir / filename
-        
+
         content = await file.read()
-        with open(file_path, 'wb') as f:
+        with open(file_path, "wb") as f:
             f.write(content)
-        
+
         # Validate video file
         is_valid, error_msg = validate_video_file(str(file_path))
         if not is_valid:
             # Clean up file if validation fails
             file_path.unlink(missing_ok=True)
             raise HTTPException(status_code=400, detail=f"Invalid video file: {error_msg}")
-        
+
         # Get input source manager and set source
         manager = _get_input_source_manager(app_instance)
         input_source = InputSource(InputSourceType.UPLOADED_VIDEO, str(file_path))
         manager.set_source(component, input_source, index)
-        
+
         logger.info(f"upload_component_video: Uploaded video for {component} (index: {index})")
-        
-        return create_success_response({
-            'message': f'Video uploaded for {component}',
-            'component': component,
-            'index': index,
-            'filename': filename,
-            'file_path': str(file_path)
-        })
-        
+
+        return create_success_response(
+            {
+                "message": f"Video uploaded for {component}",
+                "component": component,
+                "index": index,
+                "filename": filename,
+                "file_path": str(file_path),
+            }
+        )
+
     except Exception as e:
         return handle_api_error(e, "upload_component_video")
 
 
 @router.get("/info/{component}")
 async def get_component_source_info(
-    component: str,
-    index: Optional[int] = None,
-    app_instance=Depends(get_app_instance)
+    component: str, index: Optional[int] = None, app_instance=Depends(get_app_instance)
 ):
     """
     Get information about a component's input source.
-    
+
     Args:
         component: Component name ('controlnet', 'ipadapter', 'base')
         index: Index for ControlNet (required for controlnet component)
     """
     try:
         # Validate component
-        if component not in ['controlnet', 'ipadapter', 'base']:
+        if component not in ["controlnet", "ipadapter", "base"]:
             raise HTTPException(status_code=400, detail=f"Invalid component: {component}")
-        
+
         # Validate index for controlnet
-        if component == 'controlnet' and index is None:
+        if component == "controlnet" and index is None:
             raise HTTPException(status_code=400, detail="Index is required for ControlNet components")
-        
+
         # Get input source manager
         manager = _get_input_source_manager(app_instance)
-        
+
         # Get source info
         source_info = manager.get_source_info(component, index)
-        
+
         # Make sure source_data is JSON serializable (remove PIL Image objects)
-        if source_info and 'source_data' in source_info:
-            source_data = source_info['source_data']
+        if source_info and "source_data" in source_info:
+            source_data = source_info["source_data"]
             # If source_data is a PIL Image, just indicate it's present rather than trying to serialize it
-            if hasattr(source_data, '__class__') and source_data.__class__.__name__ == 'Image':
-                source_info['source_data'] = 'image_present'
+            if hasattr(source_data, "__class__") and source_data.__class__.__name__ == "Image":
+                source_info["source_data"] = "image_present"
             elif isinstance(source_data, str):
                 # Keep strings (file paths) as-is
                 pass
@@ -264,16 +272,13 @@ async def get_component_source_info(
                 # For other non-serializable objects, convert to string representation
                 try:
                     import json
+
                     json.dumps(source_data)  # Test if it's serializable
                 except (TypeError, ValueError):
-                    source_info['source_data'] = str(type(source_data).__name__)
-        
-        return create_success_response({
-            'component': component,
-            'index': index,
-            'source_info': source_info
-        })
-        
+                    source_info["source_data"] = str(type(source_data).__name__)
+
+        return create_success_response({"component": component, "index": index, "source_info": source_info})
+
     except Exception as e:
         return handle_api_error(e, "get_component_source_info")
 
@@ -284,64 +289,60 @@ async def list_all_source_info(app_instance=Depends(get_app_instance)):
     try:
         # Get input source manager
         manager = _get_input_source_manager(app_instance)
-        
+
         # Collect all source information
         all_sources = {
-            'base': manager.get_source_info('base'),
-            'ipadapter': manager.get_source_info('ipadapter'),
-            'controlnets': {}
+            "base": manager.get_source_info("base"),
+            "ipadapter": manager.get_source_info("ipadapter"),
+            "controlnets": {},
         }
-        
+
         # Get all controlnet sources
-        for index, source in manager.sources['controlnet'].items():
-            all_sources['controlnets'][index] = manager.get_source_info('controlnet', index)
-        
-        return create_success_response({
-            'sources': all_sources
-        })
-        
+        for index, source in manager.sources["controlnet"].items():
+            all_sources["controlnets"][index] = manager.get_source_info("controlnet", index)
+
+        return create_success_response({"sources": all_sources})
+
     except Exception as e:
         return handle_api_error(e, "list_all_source_info")
 
 
 @router.post("/reset/{component}")
-async def reset_component_source(
-    component: str,
-    index: Optional[int] = None,
-    app_instance=Depends(get_app_instance)
-):
+async def reset_component_source(component: str, index: Optional[int] = None, app_instance=Depends(get_app_instance)):
     """
     Reset a component's input source to webcam (default).
-    
+
     Args:
         component: Component name ('controlnet', 'ipadapter', 'base')
         index: Index for ControlNet (required for controlnet component)
     """
     try:
         # Validate component
-        if component not in ['controlnet', 'ipadapter', 'base']:
+        if component not in ["controlnet", "ipadapter", "base"]:
             raise HTTPException(status_code=400, detail=f"Invalid component: {component}")
-        
+
         # Validate index for controlnet
-        if component == 'controlnet' and index is None:
+        if component == "controlnet" and index is None:
             raise HTTPException(status_code=400, detail="Index is required for ControlNet components")
-        
+
         # Get input source manager
         manager = _get_input_source_manager(app_instance)
-        
+
         # Create webcam input source
         webcam_source = InputSource(InputSourceType.WEBCAM)
         manager.set_source(component, webcam_source, index)
-        
+
         logger.info(f"reset_component_source: Reset {component} to webcam (index: {index})")
-        
-        return create_success_response({
-            'message': f'Input source reset to webcam for {component}',
-            'component': component,
-            'index': index,
-            'source_type': 'webcam'
-        })
-        
+
+        return create_success_response(
+            {
+                "message": f"Input source reset to webcam for {component}",
+                "component": component,
+                "index": index,
+                "source_type": "webcam",
+            }
+        )
+
     except Exception as e:
         return handle_api_error(e, "reset_component_source")
 
@@ -355,20 +356,22 @@ async def reset_all_input_sources(app_instance=Depends(get_app_instance)):
     try:
         # Get input source manager
         manager = _get_input_source_manager(app_instance)
-        
+
         # Reset all sources to defaults
         manager.reset_to_defaults()
-        
+
         logger.info("reset_all_input_sources: Reset all input sources to defaults")
-        
-        return create_success_response({
-            'message': 'All input sources reset to defaults',
-            'defaults': {
-                'base': 'webcam',
-                'ipadapter': 'uploaded_image (default image)',
-                'controlnet': 'fallback to base pipeline'
+
+        return create_success_response(
+            {
+                "message": "All input sources reset to defaults",
+                "defaults": {
+                    "base": "webcam",
+                    "ipadapter": "uploaded_image (default image)",
+                    "controlnet": "fallback to base pipeline",
+                },
             }
-        })
-        
+        )
+
     except Exception as e:
         return handle_api_error(e, "reset_all_input_sources")

--- a/demo/realtime-img2img/routes/ipadapter.py
+++ b/demo/realtime-img2img/routes/ipadapter.py
@@ -1,13 +1,21 @@
 """
 IPAdapter-related endpoints for realtime-img2img
 """
-from fastapi import APIRouter, Request, HTTPException, Depends
-from fastapi.responses import JSONResponse, Response
+
 import logging
 import os
 
-from .common.api_utils import handle_api_request, create_success_response, handle_api_error, validate_pipeline, validate_feature_enabled, validate_config_mode
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import Response
+
+from .common.api_utils import (
+    create_success_response,
+    handle_api_error,
+    handle_api_request,
+    validate_config_mode,
+)
 from .common.dependencies import get_app_instance
+
 
 router = APIRouter(prefix="/api", tags=["ipadapter"])
 
@@ -15,23 +23,27 @@ router = APIRouter(prefix="/api", tags=["ipadapter"])
 
 # Legacy get uploaded image endpoint removed - use InputSourceManager instead
 
+
 @router.get("/default-image")
 async def get_default_image():
     """Get the default image (input.png)"""
     try:
         default_image_path = os.path.join(os.path.dirname(__file__), "..", "..", "..", "images", "inputs", "input.png")
-        
+
         if not os.path.exists(default_image_path):
             raise HTTPException(status_code=404, detail="Default image not found")
-        
+
         # Read and return the default image file
         with open(default_image_path, "rb") as image_file:
             image_content = image_file.read()
-        
-        return Response(content=image_content, media_type="image/png", headers={"Cache-Control": "public, max-age=3600"})
-        
+
+        return Response(
+            content=image_content, media_type="image/png", headers={"Cache-Control": "public, max-age=3600"}
+        )
+
     except Exception as e:
         raise handle_api_error(e, "get_default_image")
+
 
 @router.post("/ipadapter/update-scale")
 async def update_ipadapter_scale(request: Request, app_instance=Depends(get_app_instance)):
@@ -39,22 +51,25 @@ async def update_ipadapter_scale(request: Request, app_instance=Depends(get_app_
     try:
         data = await handle_api_request(request, "update_ipadapter_scale", ["scale"])
         scale = data.get("scale")
-        
+
         # Validate AppState has IPAdapter configuration (pipeline not required)
         if not app_instance.app_state.ipadapter_info["enabled"]:
-            raise HTTPException(status_code=400, detail="IPAdapter is not enabled. Please upload a config with IPAdapter first.")
-        
+            raise HTTPException(
+                status_code=400, detail="IPAdapter is not enabled. Please upload a config with IPAdapter first."
+            )
+
         # Update AppState as single source of truth (works before pipeline creation)
         app_instance.app_state.update_parameter("ipadapter_scale", float(scale))
-        
+
         # Sync to pipeline if active
-        if app_instance.pipeline and hasattr(app_instance.pipeline, 'stream'):
+        if app_instance.pipeline and hasattr(app_instance.pipeline, "stream"):
             app_instance._sync_appstate_to_pipeline()
-        
+
         return create_success_response(f"Updated IPAdapter scale to {scale}")
-        
+
     except Exception as e:
         raise handle_api_error(e, "update_ipadapter_scale")
+
 
 @router.post("/ipadapter/update-weight-type")
 async def update_ipadapter_weight_type(request: Request, app_instance=Depends(get_app_instance)):
@@ -62,22 +77,25 @@ async def update_ipadapter_weight_type(request: Request, app_instance=Depends(ge
     try:
         data = await handle_api_request(request, "update_ipadapter_weight_type", ["weight_type"])
         weight_type = data.get("weight_type")
-        
+
         # Validate AppState has IPAdapter configuration (pipeline not required)
         if not app_instance.app_state.ipadapter_info["enabled"]:
-            raise HTTPException(status_code=400, detail="IPAdapter is not enabled. Please upload a config with IPAdapter first.")
-        
+            raise HTTPException(
+                status_code=400, detail="IPAdapter is not enabled. Please upload a config with IPAdapter first."
+            )
+
         # Update AppState as single source of truth (works before pipeline creation)
         app_instance.app_state.ipadapter_info["weight_type"] = weight_type
-        
+
         # Sync to pipeline if active
-        if app_instance.pipeline and hasattr(app_instance.pipeline, 'stream'):
+        if app_instance.pipeline and hasattr(app_instance.pipeline, "stream"):
             app_instance._sync_appstate_to_pipeline()
-        
+
         return create_success_response(f"Updated IPAdapter weight type to {weight_type}")
-        
+
     except Exception as e:
         raise handle_api_error(e, "update_ipadapter_weight_type")
+
 
 @router.post("/ipadapter/update-enabled")
 async def update_ipadapter_enabled(request: Request, app_instance=Depends(get_app_instance)):
@@ -85,23 +103,20 @@ async def update_ipadapter_enabled(request: Request, app_instance=Depends(get_ap
     try:
         data = await handle_api_request(request, "update_ipadapter_enabled", ["enabled"])
         enabled = data.get("enabled")
-        
+
         # Update AppState as single source of truth (works before pipeline creation)
         app_instance.app_state.ipadapter_info["enabled"] = bool(enabled)
         logging.info(f"update_ipadapter_enabled: Updated AppState ipadapter enabled to {enabled}")
-        
+
         # Sync to pipeline if active
         if app_instance.pipeline:
             validate_config_mode(app_instance.pipeline, "ipadapters")
-            
+
             # Update IPAdapter enabled state in the pipeline
-            app_instance.pipeline.stream.update_stream_params(
-                ipadapter_config={'enabled': bool(enabled)}
-            )
-            logging.info(f"update_ipadapter_enabled: Synced to active pipeline")
-        
+            app_instance.pipeline.stream.update_stream_params(ipadapter_config={"enabled": bool(enabled)})
+            logging.info("update_ipadapter_enabled: Synced to active pipeline")
+
         return create_success_response(f"IPAdapter {'enabled' if enabled else 'disabled'} successfully")
-        
+
     except Exception as e:
         raise handle_api_error(e, "update_ipadapter_enabled")
-

--- a/demo/realtime-img2img/routes/parameters.py
+++ b/demo/realtime-img2img/routes/parameters.py
@@ -1,14 +1,18 @@
 """
 Parameter update endpoints for realtime-img2img
 """
-from fastapi import APIRouter, Request, HTTPException, Depends
-from fastapi.responses import JSONResponse
+
 import logging
 
-from .common.api_utils import handle_api_request, create_success_response, handle_api_error
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from .common.api_utils import create_success_response, handle_api_error, handle_api_request
 from .common.dependencies import get_app_instance
 
+
 router = APIRouter(prefix="/api", tags=["parameters"])
+
 
 @router.post("/params")
 async def update_params(request: Request, app_instance=Depends(get_app_instance)):
@@ -17,7 +21,7 @@ async def update_params(request: Request, app_instance=Depends(get_app_instance)
         data = await request.json()
         logging.info(f"update_params: Received data: {data}")
         logging.info(f"update_params: Pipeline exists: {app_instance.pipeline is not None}")
-        
+
         # Allow updating resolution even when pipeline is not initialized.
         # We save the new values so they take effect on the next stream start.
         if "resolution" in data:
@@ -25,48 +29,44 @@ async def update_params(request: Request, app_instance=Depends(get_app_instance)
                 logging.info("update_params: No pipeline exists, updating resolution directly")
             else:
                 logging.info("update_params: Pipeline exists, resolution update may be handled differently")
-        
+
         if "resolution" in data:
             resolution = data["resolution"]
             if isinstance(resolution, dict) and "width" in resolution and "height" in resolution:
                 width, height = int(resolution["width"]), int(resolution["height"])
-                
+
                 # Call the proper pipeline recreation method
                 app_instance._update_resolution(width, height)
-                
+
                 message = f"Resolution updated to {width}x{height} and pipeline recreated successfully"
                 logging.info(f"update_params: {message}")
-                return JSONResponse({
-                    "status": "success", 
-                    "message": message
-                })
+                return JSONResponse({"status": "success", "message": message})
             elif isinstance(resolution, str):
                 # Handle string format like "512x768 (2:3)" or "512x768"
-                resolution_part = resolution.split(' ')[0]
+                resolution_part = resolution.split(" ")[0]
                 logging.info(f"update_params: Parsing resolution string: {resolution} -> {resolution_part}")
                 try:
-                    width, height = map(int, resolution_part.split('x'))
+                    width, height = map(int, resolution_part.split("x"))
                     logging.info(f"update_params: Parsed width={width}, height={height}")
-                    
+
                     # Call the proper pipeline recreation method
                     app_instance._update_resolution(width, height)
-                    
+
                     message = f"Resolution updated to {width}x{height} and pipeline recreated successfully"
                     logging.info(f"update_params: {message}")
-                    return JSONResponse({
-                        "status": "success", 
-                        "message": message
-                    })
+                    return JSONResponse({"status": "success", "message": message})
                 except ValueError:
                     raise HTTPException(status_code=400, detail="Invalid resolution format")
             else:
-                raise HTTPException(status_code=400, detail="Resolution must be {width: int, height: int} or 'widthxheight' string")
+                raise HTTPException(
+                    status_code=400, detail="Resolution must be {width: int, height: int} or 'widthxheight' string"
+                )
 
         # No pipeline validation needed - AppState updates work before pipeline creation
-        
+
         # Update parameters that exist in the data
         params = {}
-        
+
         if "guidance_scale" in data:
             params["guidance_scale"] = float(data["guidance_scale"])
         if "delta" in data:
@@ -86,65 +86,60 @@ async def update_params(request: Request, app_instance=Depends(get_app_instance)
             # Update AppState as single source of truth (works before pipeline creation)
             for param_name, param_value in params.items():
                 app_instance.app_state.update_parameter(param_name, param_value)
-            
+
             # Sync to pipeline if active (for real-time updates)
-            if app_instance.pipeline and hasattr(app_instance.pipeline, 'stream'):
+            if app_instance.pipeline and hasattr(app_instance.pipeline, "stream"):
                 app_instance._sync_appstate_to_pipeline()
-            
-            return JSONResponse({
-                "status": "success",
-                "message": f"Updated parameters: {list(params.keys())}",
-                "updated_params": params
-            })
+
+            return JSONResponse(
+                {
+                    "status": "success",
+                    "message": f"Updated parameters: {list(params.keys())}",
+                    "updated_params": params,
+                }
+            )
         else:
-            return JSONResponse({
-                "status": "success",
-                "message": "No valid parameters provided to update"
-            })
-        
+            return JSONResponse({"status": "success", "message": "No valid parameters provided to update"})
+
     except Exception as e:
         logging.exception(f"update_params: Failed to update parameters: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to update parameters: {str(e)}")
 
+
 async def _update_single_parameter(
-    request: Request, 
-    app_instance, 
-    parameter_name: str, 
-    value_converter: callable,
-    operation_name: str
+    request: Request, app_instance, parameter_name: str, value_converter: callable, operation_name: str
 ):
     """Generic function to update a single parameter"""
     try:
         data = await handle_api_request(request, operation_name, [parameter_name])
         # No pipeline validation needed - AppState updates work before pipeline creation
-        
+
         value = value_converter(data[parameter_name])
-        
+
         # Update AppState as single source of truth (works before pipeline creation)
         app_instance.app_state.update_parameter(parameter_name, value)
-        
+
         # Sync to pipeline if active (for real-time updates)
-        if app_instance.pipeline and hasattr(app_instance.pipeline, 'stream'):
+        if app_instance.pipeline and hasattr(app_instance.pipeline, "stream"):
             app_instance._sync_appstate_to_pipeline()
-        
+
         return create_success_response(f"Updated {parameter_name} to {value}", **{parameter_name: value})
-        
+
     except Exception as e:
         raise handle_api_error(e, operation_name)
+
 
 @router.post("/update-guidance-scale")
 async def update_guidance_scale(request: Request, app_instance=Depends(get_app_instance)):
     """Update guidance scale parameter"""
-    return await _update_single_parameter(
-        request, app_instance, "guidance_scale", float, "update_guidance_scale"
-    )
+    return await _update_single_parameter(request, app_instance, "guidance_scale", float, "update_guidance_scale")
+
 
 @router.post("/update-delta")
 async def update_delta(request: Request, app_instance=Depends(get_app_instance)):
     """Update delta parameter"""
-    return await _update_single_parameter(
-        request, app_instance, "delta", float, "update_delta"
-    )
+    return await _update_single_parameter(request, app_instance, "delta", float, "update_delta")
+
 
 @router.post("/update-num-inference-steps")
 async def update_num_inference_steps(request: Request, app_instance=Depends(get_app_instance)):
@@ -153,32 +148,32 @@ async def update_num_inference_steps(request: Request, app_instance=Depends(get_
         request, app_instance, "num_inference_steps", int, "update_num_inference_steps"
     )
 
+
 @router.post("/update-seed")
 async def update_seed(request: Request, app_instance=Depends(get_app_instance)):
     """Update seed parameter"""
-    return await _update_single_parameter(
-        request, app_instance, "seed", int, "update_seed"
-    )
+    return await _update_single_parameter(request, app_instance, "seed", int, "update_seed")
+
 
 @router.post("/blending")
 async def update_blending(request: Request, app_instance=Depends(get_app_instance)):
     """Update prompt and/or seed blending configuration in real-time"""
     try:
         data = await request.json()
-        
+
         # No pipeline validation needed - AppState updates work before pipeline creation
-        
+
         params = {}
         updated_types = []
-        
+
         # Handle prompt blending
         if "prompt_list" in data:
             prompt_list = data["prompt_list"]
             interpolation_method = data.get("prompt_interpolation_method", "slerp")
-            
+
             if not isinstance(prompt_list, list):
                 raise HTTPException(status_code=400, detail="prompt_list must be a list")
-            
+
             # Validate and convert format
             prompt_tuples = []
             for item in prompt_list:
@@ -187,8 +182,11 @@ async def update_blending(request: Request, app_instance=Depends(get_app_instanc
                 elif isinstance(item, dict) and "prompt" in item and "weight" in item:
                     prompt_tuples.append((str(item["prompt"]), float(item["weight"])))
                 else:
-                    raise HTTPException(status_code=400, detail="Each prompt item must be [prompt, weight] or {prompt: str, weight: float}")
-            
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Each prompt item must be [prompt, weight] or {prompt: str, weight: float}",
+                    )
+
             params["prompt_list"] = prompt_tuples
             params["prompt_interpolation_method"] = interpolation_method
             updated_types.append("prompt")
@@ -197,10 +195,10 @@ async def update_blending(request: Request, app_instance=Depends(get_app_instanc
         if "seed_list" in data:
             seed_list = data["seed_list"]
             interpolation_method = data.get("seed_interpolation_method", "linear")
-            
+
             if not isinstance(seed_list, list):
                 raise HTTPException(status_code=400, detail="seed_list must be a list")
-            
+
             # Validate and convert format
             seed_tuples = []
             for item in seed_list:
@@ -209,8 +207,10 @@ async def update_blending(request: Request, app_instance=Depends(get_app_instanc
                 elif isinstance(item, dict) and "seed" in item and "weight" in item:
                     seed_tuples.append((int(item["seed"]), float(item["weight"])))
                 else:
-                    raise HTTPException(status_code=400, detail="Each seed item must be [seed, weight] or {seed: int, weight: float}")
-            
+                    raise HTTPException(
+                        status_code=400, detail="Each seed item must be [seed, weight] or {seed: int, weight: float}"
+                    )
+
             params["seed_list"] = seed_tuples
             params["seed_interpolation_method"] = interpolation_method
             updated_types.append("seed")
@@ -223,63 +223,64 @@ async def update_blending(request: Request, app_instance=Depends(get_app_instanc
             app_instance.app_state.prompt_blending = params["prompt_list"]
         if "seed_list" in params:
             app_instance.app_state.seed_blending = params["seed_list"]
-        
+
         # Sync to pipeline if active
-        if app_instance.pipeline and hasattr(app_instance.pipeline, 'stream'):
+        if app_instance.pipeline and hasattr(app_instance.pipeline, "stream"):
             app_instance._sync_appstate_to_pipeline()
-        
+
         return create_success_response(f"Updated {' and '.join(updated_types)} blending", updated_types=updated_types)
-        
+
     except Exception as e:
         raise handle_api_error(e, "update_blending")
+
 
 @router.post("/blending/update-prompt-weight")
 async def update_prompt_weight(request: Request, app_instance=Depends(get_app_instance)):
     """Update a specific prompt weight in the current blending configuration"""
     try:
         data = await request.json()
-        index = data.get('index')
-        weight = data.get('weight')
-        
+        index = data.get("index")
+        weight = data.get("weight")
+
         if index is None or weight is None:
             raise HTTPException(status_code=400, detail="Missing index or weight parameter")
-        
+
         # No pipeline validation needed - AppState updates work before pipeline creation
-        
+
         # Update AppState as single source of truth
         app_instance.app_state.update_parameter(f"prompt_weight_{index}", float(weight))
-        
+
         # Sync to pipeline if active
-        if app_instance.pipeline and hasattr(app_instance.pipeline, 'stream'):
+        if app_instance.pipeline and hasattr(app_instance.pipeline, "stream"):
             app_instance._sync_appstate_to_pipeline()
-        
+
         return create_success_response(f"Updated prompt weight {index} to {weight}")
-        
+
     except Exception as e:
         raise handle_api_error(e, "update_prompt_weight")
 
-@router.post("/blending/update-seed-weight") 
+
+@router.post("/blending/update-seed-weight")
 async def update_seed_weight(request: Request, app_instance=Depends(get_app_instance)):
     """Update a specific seed weight in the current blending configuration"""
     try:
         data = await request.json()
-        index = data.get('index')
-        weight = data.get('weight')
-        
+        index = data.get("index")
+        weight = data.get("weight")
+
         if index is None or weight is None:
             raise HTTPException(status_code=400, detail="Missing index or weight parameter")
-        
+
         # No pipeline validation needed - AppState updates work before pipeline creation
-        
+
         # Update AppState as single source of truth
         app_instance.app_state.update_parameter(f"seed_weight_{index}", float(weight))
-        
+
         # Sync to pipeline if active
-        if app_instance.pipeline and hasattr(app_instance.pipeline, 'stream'):
+        if app_instance.pipeline and hasattr(app_instance.pipeline, "stream"):
             app_instance._sync_appstate_to_pipeline()
-        
+
         return create_success_response(f"Updated seed weight {index} to {weight}")
-        
+
     except Exception as e:
         raise handle_api_error(e, "update_seed_weight")
-

--- a/demo/realtime-img2img/routes/pipeline_hooks.py
+++ b/demo/realtime-img2img/routes/pipeline_hooks.py
@@ -1,13 +1,15 @@
-
 """
 Pipeline hooks endpoints for realtime-img2img
 """
-from fastapi import APIRouter, Request, HTTPException, Depends
-from fastapi.responses import JSONResponse
+
 import logging
 
-from .common.api_utils import handle_api_request, create_success_response, handle_api_error
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from .common.api_utils import create_success_response, handle_api_error
 from .common.dependencies import get_app_instance
+
 
 router = APIRouter(prefix="/api", tags=["pipeline-hooks"])
 
@@ -22,11 +24,12 @@ async def get_pipeline_hooks_info_config(app_instance=Depends(get_app_instance))
             "image_preprocessing": app_instance.app_state.pipeline_hooks["image_preprocessing"],
             "image_postprocessing": app_instance.app_state.pipeline_hooks["image_postprocessing"],
             "latent_preprocessing": app_instance.app_state.pipeline_hooks["latent_preprocessing"],
-            "latent_postprocessing": app_instance.app_state.pipeline_hooks["latent_postprocessing"]
+            "latent_postprocessing": app_instance.app_state.pipeline_hooks["latent_postprocessing"],
         }
         return JSONResponse(hooks_info)
     except Exception as e:
         raise handle_api_error(e, "get_pipeline_hooks_info_config")
+
 
 # Individual hook type endpoints that frontend expects
 @router.get("/pipeline-hooks/image_preprocessing/info-config")
@@ -35,8 +38,9 @@ async def get_image_preprocessing_info_config(app_instance=Depends(get_app_insta
     try:
         hook_info = app_instance.app_state.pipeline_hooks["image_preprocessing"]
         return JSONResponse({"image_preprocessing": hook_info})
-    except Exception as e:
+    except Exception:
         return JSONResponse({"image_preprocessing": None})
+
 
 @router.get("/pipeline-hooks/image_postprocessing/info-config")
 async def get_image_postprocessing_info_config(app_instance=Depends(get_app_instance)):
@@ -44,8 +48,9 @@ async def get_image_postprocessing_info_config(app_instance=Depends(get_app_inst
     try:
         hook_info = app_instance.app_state.pipeline_hooks["image_postprocessing"]
         return JSONResponse({"image_postprocessing": hook_info})
-    except Exception as e:
+    except Exception:
         return JSONResponse({"image_postprocessing": None})
+
 
 @router.get("/pipeline-hooks/latent_preprocessing/info-config")
 async def get_latent_preprocessing_info_config(app_instance=Depends(get_app_instance)):
@@ -53,8 +58,9 @@ async def get_latent_preprocessing_info_config(app_instance=Depends(get_app_inst
     try:
         hook_info = app_instance.app_state.pipeline_hooks["latent_preprocessing"]
         return JSONResponse({"latent_preprocessing": hook_info})
-    except Exception as e:
+    except Exception:
         return JSONResponse({"latent_preprocessing": None})
+
 
 @router.get("/pipeline-hooks/latent_postprocessing/info-config")
 async def get_latent_postprocessing_info_config(app_instance=Depends(get_app_instance)):
@@ -62,55 +68,64 @@ async def get_latent_postprocessing_info_config(app_instance=Depends(get_app_ins
     try:
         hook_info = app_instance.app_state.pipeline_hooks["latent_postprocessing"]
         return JSONResponse({"latent_postprocessing": hook_info})
-    except Exception as e:
+    except Exception:
         return JSONResponse({"latent_postprocessing": None})
+
 
 @router.get("/pipeline-hooks/{hook_type}/info")
 async def get_hook_processors_info(hook_type: str, app_instance=Depends(get_app_instance)):
     """Get available processors for a specific hook type"""
     try:
-        if hook_type not in ["image_preprocessing", "image_postprocessing", "latent_preprocessing", "latent_postprocessing"]:
+        if hook_type not in [
+            "image_preprocessing",
+            "image_postprocessing",
+            "latent_preprocessing",
+            "latent_postprocessing",
+        ]:
             raise HTTPException(status_code=400, detail=f"Invalid hook type: {hook_type}")
-        
+
         # Use the same processor registry as ControlNet
-        from streamdiffusion.preprocessing.processors import list_preprocessors, get_preprocessor_class
-        
+        from streamdiffusion.preprocessing.processors import get_preprocessor_class, list_preprocessors
+
         available_processors = list_preprocessors()
         processors_info = {}
-        
+
         for processor_name in available_processors:
             try:
                 processor_class = get_preprocessor_class(processor_name)
-                if hasattr(processor_class, 'get_preprocessor_metadata'):
+                if hasattr(processor_class, "get_preprocessor_metadata"):
                     metadata = processor_class.get_preprocessor_metadata()
                     processors_info[processor_name] = {
                         "name": metadata.get("name", processor_name),
                         "description": metadata.get("description", ""),
-                        "parameters": metadata.get("parameters", {})
+                        "parameters": metadata.get("parameters", {}),
                     }
                 else:
                     processors_info[processor_name] = {
                         "name": processor_name,
                         "description": f"{processor_name} processor",
-                        "parameters": {}
+                        "parameters": {},
                     }
             except Exception as e:
                 logging.warning(f"get_hook_processors_info: Failed to load metadata for {processor_name}: {e}")
                 processors_info[processor_name] = {
                     "name": processor_name,
                     "description": f"{processor_name} processor",
-                    "parameters": {}
+                    "parameters": {},
                 }
-        
-        return JSONResponse({
-            "status": "success",
-            "hook_type": hook_type,
-            "available": list(processors_info.keys()),
-            "preprocessors": processors_info
-        })
-        
+
+        return JSONResponse(
+            {
+                "status": "success",
+                "hook_type": hook_type,
+                "available": list(processors_info.keys()),
+                "preprocessors": processors_info,
+            }
+        )
+
     except Exception as e:
         raise handle_api_error(e, "get_hook_processors_info")
+
 
 @router.post("/pipeline-hooks/{hook_type}/add")
 async def add_hook_processor(hook_type: str, request: Request, app_instance=Depends(get_app_instance)):
@@ -119,27 +134,28 @@ async def add_hook_processor(hook_type: str, request: Request, app_instance=Depe
         data = await request.json()
         processor_type = data.get("processor_type")
         processor_params = data.get("processor_params", {})
-        
+
         if not processor_type:
             raise HTTPException(status_code=400, detail="Missing processor_type parameter")
-        
+
         # No pipeline validation needed - AppState updates work before pipeline creation
-        
-        if hook_type not in ["image_preprocessing", "image_postprocessing", "latent_preprocessing", "latent_postprocessing"]:
+
+        if hook_type not in [
+            "image_preprocessing",
+            "image_postprocessing",
+            "latent_preprocessing",
+            "latent_postprocessing",
+        ]:
             raise HTTPException(status_code=400, detail=f"Invalid hook type: {hook_type}")
-        
+
         logging.debug(f"add_hook_processor: Adding {processor_type} to {hook_type}")
-        
+
         # Create processor config
-        new_processor = {
-            "type": processor_type,
-            "params": processor_params,
-            "enabled": True
-        }
-        
+        new_processor = {"type": processor_type, "params": processor_params, "enabled": True}
+
         # Add to AppState - SINGLE SOURCE OF TRUTH
         app_instance.app_state.add_hook_processor(hook_type, new_processor)
-        
+
         # Update pipeline if active
         if app_instance.pipeline:
             try:
@@ -148,7 +164,7 @@ async def add_hook_processor(hook_type: str, request: Request, app_instance=Depe
                     config_entry = {
                         "type": processor["type"],
                         "params": processor["params"],
-                        "enabled": processor["enabled"]
+                        "enabled": processor["enabled"],
                     }
                     hook_config.append(config_entry)
                 update_kwargs = {f"{hook_type}_config": hook_config}
@@ -157,25 +173,26 @@ async def add_hook_processor(hook_type: str, request: Request, app_instance=Depe
                 logging.exception(f"add_hook_processor: Failed to update pipeline: {e}")
                 # Mark for reload as fallback
                 app_instance.app_state.config_needs_reload = True
-        
+
         logging.info(f"add_hook_processor: Successfully added {processor_type} to {hook_type}")
-        
+
         return create_success_response(f"Added {processor_type} processor to {hook_type}")
-        
+
     except Exception as e:
         raise handle_api_error(e, "add_hook_processor")
+
 
 @router.delete("/pipeline-hooks/{hook_type}/remove/{processor_index}")
 async def remove_hook_processor(hook_type: str, processor_index: int, app_instance=Depends(get_app_instance)):
     """Remove a processor from a hook"""
     try:
         # No pipeline validation needed - AppState updates work before pipeline creation
-        
+
         logging.debug(f"remove_hook_processor: Removing processor {processor_index} from {hook_type}")
-        
+
         # Remove from AppState - SINGLE SOURCE OF TRUTH
         app_instance.app_state.remove_hook_processor(hook_type, processor_index)
-        
+
         # Update pipeline if active
         if app_instance.pipeline:
             try:
@@ -184,7 +201,7 @@ async def remove_hook_processor(hook_type: str, processor_index: int, app_instan
                     config_entry = {
                         "type": processor["type"],
                         "params": processor["params"],
-                        "enabled": processor["enabled"]
+                        "enabled": processor["enabled"],
                     }
                     hook_config.append(config_entry)
                 update_kwargs = {f"{hook_type}_config": hook_config}
@@ -193,13 +210,14 @@ async def remove_hook_processor(hook_type: str, processor_index: int, app_instan
                 logging.exception(f"remove_hook_processor: Failed to update pipeline: {e}")
                 # Mark for reload as fallback
                 app_instance.app_state.config_needs_reload = True
-        
+
         logging.info(f"remove_hook_processor: Successfully removed processor {processor_index} from {hook_type}")
-        
+
         return create_success_response(f"Removed processor {processor_index} from {hook_type}")
-        
+
     except Exception as e:
         raise handle_api_error(e, "remove_hook_processor")
+
 
 @router.post("/pipeline-hooks/{hook_type}/toggle")
 async def toggle_hook_processor(hook_type: str, request: Request, app_instance=Depends(get_app_instance)):
@@ -208,17 +226,19 @@ async def toggle_hook_processor(hook_type: str, request: Request, app_instance=D
         data = await request.json()
         processor_index = data.get("processor_index")
         enabled = data.get("enabled")
-        
+
         if processor_index is None or enabled is None:
             raise HTTPException(status_code=400, detail="Missing processor_index or enabled parameter")
-        
+
         # No pipeline validation needed - AppState updates work before pipeline creation
-        
-        logging.debug(f"toggle_hook_processor: Toggling processor {processor_index} in {hook_type} to {'enabled' if enabled else 'disabled'}")
-        
+
+        logging.debug(
+            f"toggle_hook_processor: Toggling processor {processor_index} in {hook_type} to {'enabled' if enabled else 'disabled'}"
+        )
+
         # Update AppState - SINGLE SOURCE OF TRUTH
         app_instance.app_state.update_hook_processor(hook_type, processor_index, {"enabled": bool(enabled)})
-        
+
         # Update pipeline if active
         if app_instance.pipeline:
             try:
@@ -227,7 +247,7 @@ async def toggle_hook_processor(hook_type: str, request: Request, app_instance=D
                     config_entry = {
                         "type": processor["type"],
                         "params": processor["params"],
-                        "enabled": processor["enabled"]
+                        "enabled": processor["enabled"],
                     }
                     hook_config.append(config_entry)
                 update_kwargs = {f"{hook_type}_config": hook_config}
@@ -236,13 +256,16 @@ async def toggle_hook_processor(hook_type: str, request: Request, app_instance=D
                 logging.exception(f"toggle_hook_processor: Failed to update pipeline: {e}")
                 # Mark for reload as fallback
                 app_instance.app_state.config_needs_reload = True
-        
+
         logging.info(f"toggle_hook_processor: Successfully toggled processor {processor_index} in {hook_type}")
-        
-        return create_success_response(f"Processor {processor_index} in {hook_type} {'enabled' if enabled else 'disabled'}")
-        
+
+        return create_success_response(
+            f"Processor {processor_index} in {hook_type} {'enabled' if enabled else 'disabled'}"
+        )
+
     except Exception as e:
         raise handle_api_error(e, "toggle_hook_processor")
+
 
 @router.post("/pipeline-hooks/{hook_type}/switch")
 async def switch_hook_processor(hook_type: str, request: Request, app_instance=Depends(get_app_instance)):
@@ -252,45 +275,53 @@ async def switch_hook_processor(hook_type: str, request: Request, app_instance=D
         processor_index = data.get("processor_index")
         # Support both parameter naming conventions for compatibility
         new_processor_type = data.get("processor_type") or data.get("processor")
-        
+
         if processor_index is None or not new_processor_type:
-            raise HTTPException(status_code=400, detail="Missing processor_index or processor_type/processor parameter")
-        
+            raise HTTPException(
+                status_code=400, detail="Missing processor_index or processor_type/processor parameter"
+            )
+
         # Handle config-only mode when no pipeline is active
         if not app_instance.pipeline:
             if not app_instance.app_state.uploaded_config:
                 raise HTTPException(status_code=400, detail="No pipeline active and no uploaded config available")
-            
-            logging.info(f"switch_hook_processor: Updating config for {hook_type} processor {processor_index} to {new_processor_type}")
-            
+
+            logging.info(
+                f"switch_hook_processor: Updating config for {hook_type} processor {processor_index} to {new_processor_type}"
+            )
+
             # Update the uploaded config directly
             hook_config = app_instance.app_state.uploaded_config.get(hook_type, {"enabled": False, "processors": []})
             if processor_index >= len(hook_config.get("processors", [])):
-                raise HTTPException(status_code=400, detail=f"Invalid processor index {processor_index} for {hook_type}")
-            
+                raise HTTPException(
+                    status_code=400, detail=f"Invalid processor index {processor_index} for {hook_type}"
+                )
+
             # Update processor type in config
             hook_config["processors"][processor_index]["type"] = new_processor_type
             hook_config["processors"][processor_index]["params"] = {}
             app_instance.app_state.uploaded_config[hook_type] = hook_config
-            
+
         else:
             # No pipeline validation needed - AppState updates work before pipeline creation
-            
-            logging.debug(f"switch_hook_processor: Switching processor {processor_index} in {hook_type} to {new_processor_type}")
-            
+
+            logging.debug(
+                f"switch_hook_processor: Switching processor {processor_index} in {hook_type} to {new_processor_type}"
+            )
+
             # Update AppState - SINGLE SOURCE OF TRUTH
             processors = app_instance.app_state.pipeline_hooks[hook_type]["processors"]
-            
+
             if processor_index >= len(processors):
-                raise HTTPException(status_code=400, detail=f"Invalid processor index {processor_index} for {hook_type}")
-            
+                raise HTTPException(
+                    status_code=400, detail=f"Invalid processor index {processor_index} for {hook_type}"
+                )
+
             # Update the processor type and reset params in AppState
-            app_instance.app_state.update_hook_processor(hook_type, processor_index, {
-                "type": new_processor_type,
-                "name": new_processor_type,
-                "params": {}
-            })
-            
+            app_instance.app_state.update_hook_processor(
+                hook_type, processor_index, {"type": new_processor_type, "name": new_processor_type, "params": {}}
+            )
+
             # Update pipeline if active
             if app_instance.pipeline:
                 try:
@@ -299,7 +330,7 @@ async def switch_hook_processor(hook_type: str, request: Request, app_instance=D
                         config_entry = {
                             "type": processor["type"],
                             "params": processor["params"],
-                            "enabled": processor["enabled"]
+                            "enabled": processor["enabled"],
                         }
                         hook_config.append(config_entry)
                     update_kwargs = {f"{hook_type}_config": hook_config}
@@ -308,13 +339,16 @@ async def switch_hook_processor(hook_type: str, request: Request, app_instance=D
                     logging.exception(f"switch_hook_processor: Failed to update pipeline: {e}")
                     # Mark for reload as fallback
                     app_instance.app_state.config_needs_reload = True
-        
-        logging.info(f"switch_hook_processor: Successfully switched processor {processor_index} in {hook_type} to {new_processor_type}")
-        
+
+        logging.info(
+            f"switch_hook_processor: Successfully switched processor {processor_index} in {hook_type} to {new_processor_type}"
+        )
+
         return create_success_response(f"Switched processor {processor_index} in {hook_type} to {new_processor_type}")
-        
+
     except Exception as e:
         raise handle_api_error(e, "switch_hook_processor")
+
 
 @router.post("/pipeline-hooks/{hook_type}/update-params")
 async def update_hook_processor_params(hook_type: str, request: Request, app_instance=Depends(get_app_instance)):
@@ -323,48 +357,58 @@ async def update_hook_processor_params(hook_type: str, request: Request, app_ins
         logging.info(f"update_hook_processor_params: ===== STARTING {hook_type} REQUEST =====")
         data = await request.json()
         logging.info(f"update_hook_processor_params: Received data: {data}")
-        
+
         processor_index = data.get("processor_index")
         processor_params = data.get("processor_params", {})
-        logging.info(f"update_hook_processor_params: processor_index={processor_index}, processor_params={processor_params}")
-        
+        logging.info(
+            f"update_hook_processor_params: processor_index={processor_index}, processor_params={processor_params}"
+        )
+
         if processor_index is None:
-            logging.error(f"update_hook_processor_params: Missing processor_index parameter")
+            logging.error("update_hook_processor_params: Missing processor_index parameter")
             raise HTTPException(status_code=400, detail="Missing processor_index parameter")
-        
+
         # No pipeline validation needed - AppState updates work before pipeline creation
-        
+
         logging.debug(f"update_hook_processor_params: Updating params for processor {processor_index} in {hook_type}")
-        
+
         # Check if processors exist in AppState
         processors = app_instance.app_state.pipeline_hooks[hook_type]["processors"]
         if not processors:
             logging.error(f"update_hook_processor_params: Hook type {hook_type} not found or empty")
-            raise HTTPException(status_code=400, detail=f"No processors configured for {hook_type}. Add a processor first using the 'Add {hook_type.replace('_', ' ').title()} Processor' button.")
-            
+            raise HTTPException(
+                status_code=400,
+                detail=f"No processors configured for {hook_type}. Add a processor first using the 'Add {hook_type.replace('_', ' ').title()} Processor' button.",
+            )
+
         if processor_index >= len(processors):
-            logging.error(f"update_hook_processor_params: Processor index {processor_index} out of range for {hook_type} (max: {len(processors)-1})")
-            raise HTTPException(status_code=400, detail=f"Processor index {processor_index} not found. Only {len(processors)} processors are configured for {hook_type}.")
-        
+            logging.error(
+                f"update_hook_processor_params: Processor index {processor_index} out of range for {hook_type} (max: {len(processors) - 1})"
+            )
+            raise HTTPException(
+                status_code=400,
+                detail=f"Processor index {processor_index} not found. Only {len(processors)} processors are configured for {hook_type}.",
+            )
+
         # Update the processor parameters in AppState - SINGLE SOURCE OF TRUTH
         logging.info(f"update_hook_processor_params: Current processor config: {processors[processor_index]}")
-        
+
         # Handle 'enabled' field separately as it's a top-level processor field, not a parameter
         updates = {}
-        if 'enabled' in processor_params:
-            enabled_value = processor_params.pop('enabled')  # Remove from params dict
-            updates['enabled'] = bool(enabled_value)
+        if "enabled" in processor_params:
+            enabled_value = processor_params.pop("enabled")  # Remove from params dict
+            updates["enabled"] = bool(enabled_value)
             logging.info(f"update_hook_processor_params: Updated enabled field to: {enabled_value}")
-        
+
         # Update remaining parameters in the params field
         if processor_params:  # Only update if there are remaining params
-            current_params = processors[processor_index].get('params', {})
+            current_params = processors[processor_index].get("params", {})
             current_params.update(processor_params)
-            updates['params'] = current_params
-        
+            updates["params"] = current_params
+
         # Apply updates to AppState
         app_instance.app_state.update_hook_processor(hook_type, processor_index, updates)
-        
+
         # Update pipeline if active
         if app_instance.pipeline:
             try:
@@ -373,29 +417,36 @@ async def update_hook_processor_params(hook_type: str, request: Request, app_ins
                     config_entry = {
                         "type": processor["type"],
                         "params": processor["params"],
-                        "enabled": processor["enabled"]
+                        "enabled": processor["enabled"],
                     }
                     hook_config.append(config_entry)
                 update_kwargs = {f"{hook_type}_config": hook_config}
                 logging.info(f"update_hook_processor_params: Calling update_stream_params with: {update_kwargs}")
                 app_instance.pipeline.update_stream_params(**update_kwargs)
-                logging.info(f"update_hook_processor_params: update_stream_params completed successfully")
+                logging.info("update_hook_processor_params: update_stream_params completed successfully")
             except Exception as e:
                 logging.exception(f"update_hook_processor_params: Failed to update pipeline: {e}")
                 # Mark for reload as fallback
                 app_instance.app_state.config_needs_reload = True
-        
-        logging.info(f"update_hook_processor_params: Successfully updated params for processor {processor_index} in {hook_type}")
-        
-        return create_success_response(f"Updated parameters for processor {processor_index} in {hook_type}", updated_params=processor_params)
-        
+
+        logging.info(
+            f"update_hook_processor_params: Successfully updated params for processor {processor_index} in {hook_type}"
+        )
+
+        return create_success_response(
+            f"Updated parameters for processor {processor_index} in {hook_type}", updated_params=processor_params
+        )
+
     except Exception as e:
         logging.exception(f"update_hook_processor_params: Exception occurred: {str(e)}")
         logging.error(f"update_hook_processor_params: Exception type: {type(e).__name__}")
         raise handle_api_error(e, "update_hook_processor_params")
 
+
 @router.get("/pipeline-hooks/{hook_type}/current-params/{processor_index}")
-async def get_current_hook_processor_params(hook_type: str, processor_index: int, app_instance=Depends(get_app_instance)):
+async def get_current_hook_processor_params(
+    hook_type: str, processor_index: int, app_instance=Depends(get_app_instance)
+):
     """Get current parameters for a specific processor"""
     try:
         # First try to get from uploaded config if no pipeline
@@ -404,44 +455,50 @@ async def get_current_hook_processor_params(hook_type: str, processor_index: int
             processors = hook_config.get("processors", [])
             if processor_index < len(processors):
                 processor = processors[processor_index]
-                return JSONResponse({
+                return JSONResponse(
+                    {
+                        "status": "success",
+                        "hook_type": hook_type,
+                        "processor_index": processor_index,
+                        "processor_type": processor.get("type", "unknown"),
+                        "parameters": processor.get("params", {}),
+                        "enabled": processor.get("enabled", True),
+                        "note": "From uploaded config",
+                    }
+                )
+
+        # Return empty if no config available
+        if not app_instance.pipeline:
+            return JSONResponse(
+                {
                     "status": "success",
                     "hook_type": hook_type,
                     "processor_index": processor_index,
-                    "processor_type": processor.get('type', 'unknown'),
-                    "parameters": processor.get('params', {}),
-                    "enabled": processor.get('enabled', True),
-                    "note": "From uploaded config"
-                })
-        
-        # Return empty if no config available
-        if not app_instance.pipeline:
-            return JSONResponse({
+                    "processor_type": "unknown",
+                    "parameters": {},
+                    "enabled": False,
+                    "note": "Pipeline not initialized - no config available",
+                }
+            )
+
+        # Use AppState - SINGLE SOURCE OF TRUTH
+        processors = app_instance.app_state.pipeline_hooks[hook_type]["processors"]
+
+        if processor_index >= len(processors):
+            raise HTTPException(status_code=400, detail=f"Invalid processor index {processor_index} for {hook_type}")
+
+        processor = processors[processor_index]
+
+        return JSONResponse(
+            {
                 "status": "success",
                 "hook_type": hook_type,
                 "processor_index": processor_index,
-                "processor_type": "unknown",
-                "parameters": {},
-                "enabled": False,
-                "note": "Pipeline not initialized - no config available"
-            })
-        
-        # Use AppState - SINGLE SOURCE OF TRUTH
-        processors = app_instance.app_state.pipeline_hooks[hook_type]["processors"]
-        
-        if processor_index >= len(processors):
-            raise HTTPException(status_code=400, detail=f"Invalid processor index {processor_index} for {hook_type}")
-        
-        processor = processors[processor_index]
-        
-        return JSONResponse({
-            "status": "success",
-            "hook_type": hook_type,
-            "processor_index": processor_index,
-            "processor_type": processor.get('type', 'unknown'),
-            "parameters": processor.get('params', {}),
-            "enabled": processor.get('enabled', True)
-        })
-        
+                "processor_type": processor.get("type", "unknown"),
+                "parameters": processor.get("params", {}),
+                "enabled": processor.get("enabled", True),
+            }
+        )
+
     except Exception as e:
         raise handle_api_error(e, "get_current_hook_processor_params")

--- a/demo/realtime-img2img/routes/websocket.py
+++ b/demo/realtime-img2img/routes/websocket.py
@@ -1,39 +1,47 @@
 """
 WebSocket endpoints for realtime-img2img
 """
-from fastapi import APIRouter, WebSocket, HTTPException, Depends
+
 import logging
-import uuid
 import time
+import uuid
 from types import SimpleNamespace
 
-from util import bytes_to_pt
 from connection_manager import ServerFullException
-from .common.dependencies import get_app_instance, get_pipeline_class
+from fastapi import APIRouter, Depends, HTTPException, WebSocket
 from input_sources import InputSourceManager
+from util import bytes_to_pt
+
+from .common.dependencies import get_app_instance, get_pipeline_class
+
 
 router = APIRouter(prefix="/api", tags=["websocket"])
 
 
 def _get_input_source_manager(app_instance) -> InputSourceManager:
     """Get or create the input source manager for the app instance."""
-    if not hasattr(app_instance, 'input_source_manager'):
+    if not hasattr(app_instance, "input_source_manager"):
         app_instance.input_source_manager = InputSourceManager()
     return app_instance.input_source_manager
 
+
 @router.websocket("/ws/{user_id}")
-async def websocket_endpoint(user_id: uuid.UUID, websocket: WebSocket, app_instance=Depends(get_app_instance), pipeline_class=Depends(get_pipeline_class)):
+async def websocket_endpoint(
+    user_id: uuid.UUID,
+    websocket: WebSocket,
+    app_instance=Depends(get_app_instance),
+    pipeline_class=Depends(get_pipeline_class),
+):
     """Main WebSocket endpoint for real-time communication"""
     try:
-        await app_instance.conn_manager.connect(
-            user_id, websocket, app_instance.args.max_queue_size
-        )
+        await app_instance.conn_manager.connect(user_id, websocket, app_instance.args.max_queue_size)
         await handle_websocket_data(user_id, app_instance, pipeline_class)
     except ServerFullException as e:
         logging.exception(f"websocket_endpoint: Server Full: {e}")
     finally:
         await app_instance.conn_manager.disconnect(user_id)
         logging.info(f"websocket_endpoint: User disconnected: {user_id}")
+
 
 async def handle_websocket_data(user_id: uuid.UUID, app_instance, pipeline_class):
     """Handle WebSocket data flow for a specific user"""
@@ -42,10 +50,7 @@ async def handle_websocket_data(user_id: uuid.UUID, app_instance, pipeline_class
     last_time = time.time()
     try:
         while True:
-            if (
-                app_instance.args.timeout > 0
-                and time.time() - last_time > app_instance.args.timeout
-            ):
+            if app_instance.args.timeout > 0 and time.time() - last_time > app_instance.args.timeout:
                 await app_instance.conn_manager.send_json(
                     user_id,
                     {
@@ -62,45 +67,45 @@ async def handle_websocket_data(user_id: uuid.UUID, app_instance, pipeline_class
                 params = await app_instance.conn_manager.receive_json(user_id)
                 params = pipeline_class.InputParams(**params)
                 params = SimpleNamespace(**params.dict())
-                
+
                 # Check if we need image data based on pipeline
                 need_image = True
-                if app_instance.pipeline and hasattr(app_instance.pipeline, 'pipeline_mode'):
+                if app_instance.pipeline and hasattr(app_instance.pipeline, "pipeline_mode"):
                     # Need image for img2img OR for txt2img with ControlNets
-                    has_controlnets = app_instance.pipeline.use_config and app_instance.pipeline.config and 'controlnets' in app_instance.pipeline.config
+                    has_controlnets = (
+                        app_instance.pipeline.use_config
+                        and app_instance.pipeline.config
+                        and "controlnets" in app_instance.pipeline.config
+                    )
                     need_image = app_instance.pipeline.pipeline_mode == "img2img" or has_controlnets
-                elif app_instance.app_state.uploaded_config and 'mode' in app_instance.app_state.uploaded_config:
+                elif app_instance.app_state.uploaded_config and "mode" in app_instance.app_state.uploaded_config:
                     # Need image for img2img OR for txt2img with ControlNets
-                    has_controlnets = 'controlnets' in app_instance.app_state.uploaded_config
-                    need_image = app_instance.app_state.uploaded_config['mode'] == "img2img" or has_controlnets
-                
+                    has_controlnets = "controlnets" in app_instance.app_state.uploaded_config
+                    need_image = app_instance.app_state.uploaded_config["mode"] == "img2img" or has_controlnets
+
                 # Get input source manager
                 input_manager = _get_input_source_manager(app_instance)
-                
+
                 if need_image:
                     # Receive main webcam stream (fallback)
                     image_data = await app_instance.conn_manager.receive_bytes(user_id)
                     if len(image_data) == 0:
-                        await app_instance.conn_manager.send_json(
-                            user_id, {"status": "send_frame"}
-                        )
+                        await app_instance.conn_manager.send_json(user_id, {"status": "send_frame"})
                         continue
-                    
+
                     # Update webcam frame in input manager for all webcam sources
                     input_manager.update_webcam_frame(image_data)
-                    
+
                     # Always use direct bytes-to-tensor conversion for efficiency
                     params.image = bytes_to_pt(image_data)
                 else:
                     params.image = None
-                
+
                 # Store the input manager reference in params for later use by img2img.py
                 params.input_manager = input_manager
-                
+
                 await app_instance.conn_manager.update_data(user_id, params)
 
     except Exception as e:
         logging.exception(f"handle_websocket_data: Websocket Error: {e}, {user_id} ")
         await app_instance.conn_manager.disconnect(user_id)
-
-

--- a/demo/realtime-img2img/util.py
+++ b/demo/realtime-img2img/util.py
@@ -1,11 +1,10 @@
+import io
 from importlib import import_module
 from types import ModuleType
-from typing import Dict, Any
-from pydantic import BaseModel as PydanticBaseModel, Field
-from PIL import Image
-import io
+
 import torch
-from torchvision.io import encode_jpeg, decode_jpeg
+from PIL import Image
+from torchvision.io import decode_jpeg, encode_jpeg
 
 
 def get_pipeline_class(pipeline_name: str) -> ModuleType:
@@ -30,22 +29,22 @@ def bytes_to_pil(image_bytes: bytes) -> Image.Image:
 def bytes_to_pt(image_bytes: bytes) -> torch.Tensor:
     """
     Convert JPEG/PNG bytes directly to PyTorch tensor using torchvision
-    
+
     Args:
         image_bytes: Raw image bytes (JPEG/PNG format)
-        
+
     Returns:
         torch.Tensor: Image tensor with shape (C, H, W), values in [0, 1], dtype float32
     """
     # Convert bytes to tensor for torchvision
     byte_tensor = torch.frombuffer(image_bytes, dtype=torch.uint8)
-    
+
     # Decode JPEG/PNG directly to tensor (C, H, W) format, uint8 [0, 255]
     image_tensor = decode_jpeg(byte_tensor)
-    
+
     # Convert to float32 and normalize to [0, 1]
     image_tensor = image_tensor.float() / 255.0
-    
+
     return image_tensor
 
 
@@ -65,24 +64,24 @@ def pil_to_frame(image: Image.Image) -> bytes:
 def pt_to_frame(tensor: torch.Tensor) -> bytes:
     """
     Convert PyTorch tensor directly to JPEG frame bytes using torchvision
-    
+
     Args:
         tensor: PyTorch tensor with shape (C, H, W) or (1, C, H, W), values in [0, 1]
-        
+
     Returns:
         bytes: JPEG frame data for streaming
     """
     # Handle batch dimension - take first image if batched
     if tensor.dim() == 4:
         tensor = tensor[0]
-    
+
     # Convert to uint8 format (0-255) and ensure correct shape (C, H, W)
     tensor_uint8 = (tensor * 255).clamp(0, 255).to(torch.uint8)
-    
+
     # Encode directly to JPEG bytes using torchvision
     jpeg_bytes = encode_jpeg(tensor_uint8, quality=90)
     frame_data = jpeg_bytes.cpu().numpy().tobytes()
-    
+
     return (
         b"--frame\r\n"
         + b"Content-Type: image/jpeg\r\n"

--- a/demo/realtime-img2img/utils/video_utils.py
+++ b/demo/realtime-img2img/utils/video_utils.py
@@ -6,25 +6,26 @@ and managing video playback for input sources.
 """
 
 import logging
+from pathlib import Path
+from typing import Optional, Tuple
+
 import cv2
 import numpy as np
 import torch
-from pathlib import Path
-from typing import Optional, Tuple
 
 
 class VideoFrameExtractor:
     """
     Extracts frames from video files for use as input sources.
-    
+
     Handles video playback, looping, and frame extraction with automatic
     conversion to PyTorch tensors.
     """
-    
+
     def __init__(self, video_path: str):
         """
         Initialize the video frame extractor.
-        
+
         Args:
             video_path: Path to the video file
         """
@@ -34,34 +35,35 @@ class VideoFrameExtractor:
         self.frame_count = 0
         self.current_frame_idx = 0
         self._logger = logging.getLogger(f"VideoFrameExtractor.{self.video_path.name}")
-        
+
         self._initialize_capture()
-    
+
     def _initialize_capture(self):
         """Initialize the video capture object."""
         if not self.video_path.exists():
             self._logger.error(f"Video file not found: {self.video_path}")
             return
-        
+
         self.cap = cv2.VideoCapture(str(self.video_path))
-        
+
         if not self.cap.isOpened():
             self._logger.error(f"Failed to open video file: {self.video_path}")
             return
-        
+
         # Get video properties
         self.fps = self.cap.get(cv2.CAP_PROP_FPS)
         self.frame_count = int(self.cap.get(cv2.CAP_PROP_FRAME_COUNT))
-        
-        self._logger.info(f"Initialized video: {self.video_path.name}, "
-                         f"FPS: {self.fps:.2f}, Frames: {self.frame_count}")
-    
+
+        self._logger.info(
+            f"Initialized video: {self.video_path.name}, FPS: {self.fps:.2f}, Frames: {self.frame_count}"
+        )
+
     def get_frame(self) -> Optional[torch.Tensor]:
         """
         Extract the current frame and advance to the next frame.
-        
+
         Automatically loops back to the beginning when reaching the end.
-        
+
         Returns:
             torch.Tensor: Frame as tensor with shape (C, H, W), values in [0, 1], dtype float32
             None: If frame extraction fails
@@ -69,101 +71,101 @@ class VideoFrameExtractor:
         if not self.cap or not self.cap.isOpened():
             self._logger.error("Video capture not initialized or closed")
             return None
-        
+
         ret, frame = self.cap.read()
-        
+
         if not ret:
             # End of video, loop back to beginning
             self._logger.debug("End of video reached, looping back to start")
             self.cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
             self.current_frame_idx = 0
             ret, frame = self.cap.read()
-            
+
             if not ret:
                 self._logger.error("Failed to read frame even after reset")
                 return None
-        
+
         self.current_frame_idx += 1
-        
+
         # Convert frame to tensor
         return self._frame_to_tensor(frame)
-    
+
     def get_frame_at_time(self, timestamp: float) -> Optional[torch.Tensor]:
         """
         Get frame at a specific timestamp.
-        
+
         Args:
             timestamp: Time in seconds
-            
+
         Returns:
             torch.Tensor: Frame at the specified time or None if failed
         """
         if not self.cap or not self.cap.isOpened():
             return None
-        
+
         # Convert timestamp to frame number
         frame_number = int(timestamp * self.fps)
         frame_number = max(0, min(frame_number, self.frame_count - 1))
-        
+
         # Seek to frame
         self.cap.set(cv2.CAP_PROP_POS_FRAMES, frame_number)
         self.current_frame_idx = frame_number
-        
+
         ret, frame = self.cap.read()
         if ret:
             return self._frame_to_tensor(frame)
-        
+
         return None
-    
+
     def _frame_to_tensor(self, frame: np.ndarray) -> torch.Tensor:
         """
         Convert OpenCV frame to PyTorch tensor.
-        
+
         Args:
             frame: OpenCV frame in BGR format
-            
+
         Returns:
             torch.Tensor: Frame tensor in RGB format with shape (C, H, W)
         """
         # Convert BGR to RGB
         frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-        
+
         # Convert to tensor and normalize
         frame_tensor = torch.from_numpy(frame_rgb).permute(2, 0, 1).float() / 255.0
-        
+
         return frame_tensor
-    
+
     def get_video_info(self) -> dict:
         """
         Get information about the video.
-        
+
         Returns:
             Dictionary with video metadata
         """
         if not self.cap:
             return {}
-        
+
         width = int(self.cap.get(cv2.CAP_PROP_FRAME_WIDTH))
         height = int(self.cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
         duration = self.frame_count / self.fps if self.fps > 0 else 0
-        
+
         return {
-            'path': str(self.video_path),
-            'fps': self.fps,
-            'frame_count': self.frame_count,
-            'width': width,
-            'height': height,
-            'duration': duration,
-            'current_frame': self.current_frame_idx
+            "path": str(self.video_path),
+            "fps": self.fps,
+            "frame_count": self.frame_count,
+            "width": width,
+            "height": height,
+            "duration": duration,
+            "current_frame": self.current_frame_idx,
         }
-    
+
     def reset(self):
         """Reset video to beginning."""
         if self.cap:
             self.cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
             self.current_frame_idx = 0
             self._logger.debug("Video reset to beginning")
-    
+
     def cleanup(self):
         """Release video capture resources."""
         if self.cap:
@@ -175,25 +177,25 @@ class VideoFrameExtractor:
 def get_video_thumbnail(video_path: str, timestamp: float = 0.0) -> Optional[torch.Tensor]:
     """
     Get a thumbnail frame from a video file.
-    
+
     Args:
         video_path: Path to the video file
         timestamp: Time in seconds to extract thumbnail from
-        
+
     Returns:
         torch.Tensor: Thumbnail frame or None if failed
     """
     try:
         extractor = VideoFrameExtractor(video_path)
-        
+
         if timestamp > 0:
             thumbnail = extractor.get_frame_at_time(timestamp)
         else:
             thumbnail = extractor.get_frame()
-        
+
         extractor.cleanup()
         return thumbnail
-        
+
     except Exception as e:
         logging.getLogger("video_utils").error(f"Failed to get thumbnail: {e}")
         return None
@@ -202,52 +204,63 @@ def get_video_thumbnail(video_path: str, timestamp: float = 0.0) -> Optional[tor
 def validate_video_file(video_path: str) -> Tuple[bool, str]:
     """
     Validate if a file is a readable video.
-    
+
     Args:
         video_path: Path to the video file
-        
+
     Returns:
         Tuple of (is_valid, error_message)
     """
     try:
         path = Path(video_path)
-        
+
         if not path.exists():
             return False, "Video file does not exist"
-        
+
         # Try to open with OpenCV
         cap = cv2.VideoCapture(str(path))
-        
+
         if not cap.isOpened():
             return False, "Cannot open video file"
-        
+
         # Try to read first frame
         ret, frame = cap.read()
         cap.release()
-        
+
         if not ret:
             return False, "Cannot read frames from video"
-        
+
         return True, "Video file is valid"
-        
+
     except Exception as e:
         return False, f"Video validation error: {str(e)}"
 
 
 # Supported video formats
 SUPPORTED_VIDEO_FORMATS = {
-    '.mp4', '.avi', '.mov', '.mkv', '.webm', '.flv', '.wmv', 
-    '.m4v', '.3gp', '.ogv', '.ts', '.m2ts', '.mts'
+    ".mp4",
+    ".avi",
+    ".mov",
+    ".mkv",
+    ".webm",
+    ".flv",
+    ".wmv",
+    ".m4v",
+    ".3gp",
+    ".ogv",
+    ".ts",
+    ".m2ts",
+    ".mts",
 }
 
 
 def is_supported_video_format(filename: str) -> bool:
     """
     Check if a file has a supported video format.
-    
+
     Args:
         filename: Name or path of the file
-        
+
     Returns:
         bool: True if format is supported
     """

--- a/demo/realtime-txt2img/config.py
+++ b/demo/realtime-txt2img/config.py
@@ -1,8 +1,9 @@
+import os
 from dataclasses import dataclass, field
 from typing import List, Literal
 
 import torch
-import os
+
 
 SAFETY_CHECKER = os.environ.get("SAFETY_CHECKER", "False") == "True"
 

--- a/demo/vid2vid/app.py
+++ b/demo/vid2vid/app.py
@@ -1,17 +1,17 @@
-import gradio as gr
-
 import os
 import sys
-from typing import Literal, Dict, Optional
+from typing import Dict, Literal, Optional
 
-import fire
+import gradio as gr
 import torch
 from torchvision.io import read_video, write_video
 from tqdm import tqdm
 
+
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from streamdiffusion import StreamDiffusionWrapper
+
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -28,7 +28,6 @@ def main(
     enable_similar_image_filter: bool = True,
     seed: int = 2,
 ):
-
     """
     Process for generating images based on a prompt using a specified model.
 
@@ -106,9 +105,5 @@ def main(
     return output
 
 
-demo = gr.Interface(
-    main,
-    gr.Video(sources=['upload', 'webcam']),
-    "playable_video"
-)
+demo = gr.Interface(main, gr.Video(sources=["upload", "webcam"]), "playable_video")
 demo.launch()

--- a/examples/README-ja.md
+++ b/examples/README-ja.md
@@ -117,24 +117,26 @@ python vid2vid/main.py --input path/to/input.mp4 --output path/to/output.mp4
 ```
 
 # コマンドオプション
+
 ### モデル変更
+
 ```--model_id_or_path```　引数で使用するモデルを指定できる。
 Hugging Face のモデル id を指定することで実行時に Hugging Face からモデルをロードすることができる。<br>
 また、ローカルのモデルのパスを指定することでローカルフォルダ内のモデルを使用することも可能である。
-
 
 例 (Hugging Face) : ```--model_id_or_path "KBlueLeaf/kohaku-v2.1"```<br>
 例 (ローカル) : ```--model_id_or_path "C:/stable-diffusion-webui/models/Stable-diffusion/ModelName.safetensor"```
 
 ### LoRA 追加
+
 ```--lora_dict``` 引数で使用するLoRAを複数指定できる。<br>
 ```--lora_dict``` は ```"{'LoRA_1 のファイルパス' : LoRA_1 のスケール ,'LoRA_2 のファイルパス' : LoRA_2 のスケール}"``` という形式で指定する。
 
+例 :
+```--lora_dict "{'C:/stable-diffusion-webui/models/Stable-diffusion/LoRA_1.safetensor' : 0.5 ,'E:/ComfyUI/models/LoRA_2.safetensor' : 0.7}"```
 
-例 : 
-```--lora_dict "{'C:/stable-diffusion-webui/models/Stable-diffusion/LoRA_1.safetensor' : 0.5 ,'E:/ComfyUI/models/LoRA_2.safetensor' : 0.7}"``` 
+### Prompt
 
-### Prompt 
 ```--prompt``` 引数で Prompt を文字列で指定する。
 
 例 : ```--prompt "A cat with a hat"```
@@ -143,6 +145,5 @@ Hugging Face のモデル id を指定することで実行時に Hugging Face �
 
 ```--negative_prompt``` 引数で Negative Prompt を文字列で指定する。<br>
 ※※ ただし、txt2img ,optimal-performance, vid2vid では使用できない。
-
 
 例 : ```--negative_prompt "Bad quality"```

--- a/examples/README.md
+++ b/examples/README.md
@@ -121,31 +121,31 @@ python vid2vid/main.py --input path/to/input.mp4 --output path/to/output.mp4
 # Command Line Options
 
 ### model_id_or_path
+
 ```--model_id_or_path``` allows you to change models.<br>
 By specifying the model ID in Hugging Face (like "KBlueLeaf/kohaku-v2.1" ), the model can be loaded from Hugging Face  at runtime.<br>
 It is also possible to use models in a local directorys by specifying the local model path.
-
 
 Usage (Hugging Face) : ```--model_id_or_path "KBlueLeaf/kohaku-v2.1"```<br>
 Usage (Local) : ```--model_id_or_path "C:/stable-diffusion-webui/models/Stable-diffusion/ModelName.safetensor"```
 
 ### lora_dict
+
 ```--lora_dict``` can specify multiple LoRAs to be used. <br>
 The ```--lora_dict``` is in the format ```"{'LoRA_1 file path' : LoRA_1 scale , 'LoRA_2 file path' : LoRA_2 scale}"```.
 
+Usage :
+```--lora_dict "{'C:/stable-diffusion-webui/models/Stable-diffusion/LoRA_1.safetensor' : 0.5 ,'E:/ComfyUI/models/LoRA_2.safetensor' : 0.7 }"```
 
-Usage : 
-```--lora_dict "{'C:/stable-diffusion-webui/models/Stable-diffusion/LoRA_1.safetensor' : 0.5 ,'E:/ComfyUI/models/LoRA_2.safetensor' : 0.7 }"``` 
+### Prompt
 
-### Prompt 
 ```--prompt``` allows you to change Prompt.
 
 Usage : ```--prompt "A cat with a hat"```
 
 ### Negative Prompt
 
-```--negative_prompt``` allows you to change Negative Prompt. <br> 
+```--negative_prompt``` allows you to change Negative Prompt. <br>
 ※※ ```--negative_prompt``` Not available in txt2img ,optimal-performance, and vid2vid.
-
 
 Usage : ```--negative_prompt "Bad quality"```

--- a/examples/benchmark/multi.py
+++ b/examples/benchmark/multi.py
@@ -3,7 +3,7 @@ import os
 import sys
 import time
 from multiprocessing import Process, Queue
-from typing import List, Literal, Optional, Dict
+from typing import Dict, List, Literal, Optional
 
 import fire
 import PIL.Image
@@ -12,6 +12,7 @@ import torch
 from tqdm import tqdm
 
 from streamdiffusion.image_utils import postprocess_image
+
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 

--- a/examples/benchmark/single.py
+++ b/examples/benchmark/single.py
@@ -1,7 +1,7 @@
 import io
 import os
 import sys
-from typing import List, Literal, Optional, Dict
+from typing import Dict, List, Literal, Optional
 
 import fire
 import PIL.Image
@@ -101,9 +101,7 @@ def run(
         delta=0.5,
     )
 
-    downloaded_image = download_image("https://github.com/ddpn08.png").resize(
-        (width, height)
-    )
+    downloaded_image = download_image("https://github.com/ddpn08.png").resize((width, height))
 
     # warmup
     for _ in range(warmup):

--- a/examples/config/config_ipadapter_stream_test.py
+++ b/examples/config/config_ipadapter_stream_test.py
@@ -13,205 +13,217 @@ Key features:
 - Tests the IPAdapter stream behavior fix
 """
 
-import cv2
-import torch
-import numpy as np
-from PIL import Image
 import argparse
-from pathlib import Path
-import sys
-import time
+import json
 import os
 import shutil
-import json
-from collections import deque
+import sys
+import time
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+from PIL import Image
 
 
 def tensor_to_opencv(tensor: torch.Tensor, target_width: int, target_height: int) -> np.ndarray:
     """
     Convert a PyTorch tensor (output_type='pt') to OpenCV BGR format for video writing.
     Uses efficient tensor operations similar to the realtime-img2img demo.
-    
+
     Args:
         tensor: Tensor in range [0,1] with shape [B, C, H, W] or [C, H, W]
         target_width: Target width for output
         target_height: Target height for output
-    
+
     Returns:
         BGR numpy array ready for OpenCV
     """
     # Handle batch dimension - take first image if batched
     if tensor.dim() == 4:
         tensor = tensor[0]
-    
+
     # Convert to uint8 format (0-255) and ensure correct shape (C, H, W)
     tensor_uint8 = (tensor * 255).clamp(0, 255).to(torch.uint8)
-    
+
     # Convert from [C, H, W] to [H, W, C] format
     if tensor_uint8.dim() == 3:
         image_np = tensor_uint8.permute(1, 2, 0).cpu().numpy()
     else:
         raise ValueError(f"tensor_to_opencv: Unexpected tensor shape: {tensor_uint8.shape}")
-    
+
     # Convert RGB to BGR for OpenCV
     image_bgr = cv2.cvtColor(image_np, cv2.COLOR_RGB2BGR)
-    
+
     # Resize if needed
     if image_bgr.shape[:2] != (target_height, target_width):
         image_bgr = cv2.resize(image_bgr, (target_width, target_height))
-    
+
     return image_bgr
 
 
 def process_video_ipadapter_stream(config_path, input_video, static_image, output_dir, engine_only=False):
     """Process video using IPAdapter as primary driving force with static base image"""
     print(f"process_video_ipadapter_stream: Loading config from {config_path}")
-    
+
     # Import here to avoid loading at module level
     sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
-    from streamdiffusion import load_config, create_wrapper_from_config
-    
+    from streamdiffusion import create_wrapper_from_config, load_config
+
     # Load configuration
     config = load_config(config_path)
-    
+
     # Force tensor output for better performance
-    config['output_type'] = 'pt'
-    
+    config["output_type"] = "pt"
+
     # Get width and height from config (with defaults)
-    width = config.get('width', 512)
-    height = config.get('height', 512)
-    
+    width = config.get("width", 512)
+    height = config.get("height", 512)
+
     print(f"process_video_ipadapter_stream: Using dimensions: {width}x{height}")
-    print(f"process_video_ipadapter_stream: Using output_type='pt' for better performance")
-    
+    print("process_video_ipadapter_stream: Using output_type='pt' for better performance")
+
     # Create output directory
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    
+
     # Copy config, input video, and static image to output directory
     config_copy_path = output_dir / f"config_{Path(config_path).name}"
     shutil.copy2(config_path, config_copy_path)
     print(f"process_video_ipadapter_stream: Copied config to {config_copy_path}")
-    
+
     input_copy_path = output_dir / f"input_{Path(input_video).name}"
     shutil.copy2(input_video, input_copy_path)
     print(f"process_video_ipadapter_stream: Copied input video to {input_copy_path}")
-    
+
     static_copy_path = output_dir / f"static_{Path(static_image).name}"
     shutil.copy2(static_image, static_copy_path)
     print(f"process_video_ipadapter_stream: Copied static image to {static_copy_path}")
-    
+
     # Create wrapper using the built-in function
     wrapper = create_wrapper_from_config(config)
-    
+
     if engine_only:
         print("Engine-only mode: TensorRT engines have been built (if needed). Exiting.")
         return None
-    
+
     # Load and prepare static image
     static_img = Image.open(static_image)
     static_img = static_img.resize((width, height), Image.Resampling.LANCZOS)
     print(f"process_video_ipadapter_stream: Loaded static image: {static_image}")
-    
+
     # Open input video
     cap = cv2.VideoCapture(str(input_video))
     if not cap.isOpened():
         raise ValueError(f"Could not open input video: {input_video}")
-    
+
     # Get video properties
     fps = cap.get(cv2.CAP_PROP_FPS)
     frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-    
+
     print(f"process_video_ipadapter_stream: Input video - {frame_count} frames at {fps} FPS")
-    
+
     # Setup output video writer (3-panel display: input, static, generated)
     output_video_path = output_dir / "output_video.mp4"
-    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
     out = cv2.VideoWriter(str(output_video_path), fourcc, fps, (width * 3, height))
-    
+
     # Performance tracking
     frame_times = []
     total_start_time = time.time()
-    
+
     print("process_video_ipadapter_stream: Starting IPAdapter stream processing...")
     print("process_video_ipadapter_stream: Using static image as base input, video frames for ControlNet + IPAdapter")
-    
+
     frame_idx = 0
     while True:
         ret, frame = cap.read()
         if not ret:
             break
-        
+
         frame_start_time = time.time()
-        
+
         # Resize frame
         frame_resized = cv2.resize(frame, (width, height))
-        
+
         # Convert frame to PIL
         frame_rgb = cv2.cvtColor(frame_resized, cv2.COLOR_BGR2RGB)
         frame_pil = Image.fromarray(frame_rgb)
-        
+
         # Update ControlNet control images (structural guidance from video frames)
-        if hasattr(wrapper.stream, '_controlnet_module') and wrapper.stream._controlnet_module:
+        if hasattr(wrapper.stream, "_controlnet_module") and wrapper.stream._controlnet_module:
             controlnet_count = len(wrapper.stream._controlnet_module.controlnets)
-            print(f"process_video_ipadapter_stream: Updating control image for {controlnet_count} ControlNet(s) on frame {frame_idx}")
+            print(
+                f"process_video_ipadapter_stream: Updating control image for {controlnet_count} ControlNet(s) on frame {frame_idx}"
+            )
             for i in range(controlnet_count):
                 wrapper.update_control_image(i, frame_pil)
         else:
             print(f"process_video_ipadapter_stream: No ControlNet module found for frame {frame_idx}")
-        
+
         # Update IPAdapter style image (style/content guidance from video frames)
         # This is the key part - using video frames as IPAdapter style images with is_stream=True
-        if hasattr(wrapper.stream, '_ipadapter_module') and wrapper.stream._ipadapter_module:
-            print(f"process_video_ipadapter_stream: Updating IPAdapter style image on frame {frame_idx} (is_stream=True)")
+        if hasattr(wrapper.stream, "_ipadapter_module") and wrapper.stream._ipadapter_module:
+            print(
+                f"process_video_ipadapter_stream: Updating IPAdapter style image on frame {frame_idx} (is_stream=True)"
+            )
             # Update style image with is_stream=True for pipelined processing
             wrapper.update_style_image(frame_pil, is_stream=True)
         else:
             print(f"process_video_ipadapter_stream: No IPAdapter module found for frame {frame_idx}")
-        
+
         # Process with static image as base input (this is the key difference)
         # The static image provides the base structure, while ControlNet and IPAdapter
         # provide the dynamic guidance from the video frames
         output_tensor = wrapper(static_img)
-        
+
         # Convert tensor output to OpenCV BGR format
         output_bgr = tensor_to_opencv(output_tensor, width, height)
-        
+
         # Convert static image to display format
         static_array = np.array(static_img)
         static_bgr = cv2.cvtColor(static_array, cv2.COLOR_RGB2BGR)
-        
+
         # Create 3-panel display: Input Video | Static Base | Generated Output
         combined = np.hstack([frame_resized, static_bgr, output_bgr])
-        
+
         # Add labels
         cv2.putText(combined, "Input Video", (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
         cv2.putText(combined, "Static Base", (width + 10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
-        cv2.putText(combined, "Generated", (width * 2 + 10, 30), 
-                   cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
-        
+        cv2.putText(combined, "Generated", (width * 2 + 10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
+
         # Add frame info
-        cv2.putText(combined, f"Frame: {frame_idx}/{frame_count}", (10, height - 20), 
-                   cv2.FONT_HERSHEY_SIMPLEX, 0.5, (255, 255, 255), 1)
-        
+        cv2.putText(
+            combined,
+            f"Frame: {frame_idx}/{frame_count}",
+            (10, height - 20),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.5,
+            (255, 255, 255),
+            1,
+        )
+
         # Write frame
         out.write(combined)
-        
+
         # Track performance
         frame_time = time.time() - frame_start_time
         frame_times.append(frame_time)
-        
+
         frame_idx += 1
         if frame_idx % 10 == 0:
             avg_fps = len(frame_times) / sum(frame_times) if frame_times else 0
-            print(f"process_video_ipadapter_stream: Processed {frame_idx}/{frame_count} frames (Avg FPS: {avg_fps:.2f})")
-    
+            print(
+                f"process_video_ipadapter_stream: Processed {frame_idx}/{frame_count} frames (Avg FPS: {avg_fps:.2f})"
+            )
+
     total_time = time.time() - total_start_time
-    
+
     # Cleanup
     cap.release()
     out.release()
-    
+
     # Calculate performance metrics
     if frame_times:
         avg_frame_time = sum(frame_times) / len(frame_times)
@@ -222,7 +234,7 @@ def process_video_ipadapter_stream(config_path, input_video, static_image, outpu
         min_fps = 1.0 / max_frame_time
     else:
         avg_frame_time = avg_fps = min_frame_time = max_frame_time = max_fps = min_fps = 0
-    
+
     # Performance metrics
     metrics = {
         "input_video": str(input_video),
@@ -238,75 +250,94 @@ def process_video_ipadapter_stream(config_path, input_video, static_image, outpu
         "avg_frame_time_seconds": avg_frame_time,
         "min_frame_time_seconds": min_frame_time,
         "max_frame_time_seconds": max_frame_time,
-        "model_id": config['model_id'],
-        "acceleration": config.get('acceleration', 'none'),
-        "frame_buffer_size": config.get('frame_buffer_size', 1),
-        "num_inference_steps": config.get('num_inference_steps', 50),
-        "guidance_scale": config.get('guidance_scale', 1.1),
-        "controlnets": [cn['model_id'] for cn in config.get('controlnets', [])],
-        "ipadapter_configs": [ip['ipadapter_model_path'] for ip in config.get('ipadapter_config', [])],
+        "model_id": config["model_id"],
+        "acceleration": config.get("acceleration", "none"),
+        "frame_buffer_size": config.get("frame_buffer_size", 1),
+        "num_inference_steps": config.get("num_inference_steps", 50),
+        "guidance_scale": config.get("guidance_scale", 1.1),
+        "controlnets": [cn["model_id"] for cn in config.get("controlnets", [])],
+        "ipadapter_configs": [ip["ipadapter_model_path"] for ip in config.get("ipadapter_config", [])],
         "test_type": "ipadapter_stream_test",
         "is_stream_enabled": True,
         "output_type": "pt",
-        "description": "IPAdapter as primary driving force with static base image using tensor output for performance"
+        "description": "IPAdapter as primary driving force with static base image using tensor output for performance",
     }
-    
+
     # Save metrics
     metrics_path = output_dir / "performance_metrics.json"
-    with open(metrics_path, 'w') as f:
+    with open(metrics_path, "w") as f:
         json.dump(metrics, f, indent=2)
-    
-    print(f"process_video_ipadapter_stream: Processing completed!")
+
+    print("process_video_ipadapter_stream: Processing completed!")
     print(f"process_video_ipadapter_stream: Output video saved to: {output_video_path}")
     print(f"process_video_ipadapter_stream: Performance metrics saved to: {metrics_path}")
     print(f"process_video_ipadapter_stream: Average FPS: {avg_fps:.2f}")
     print(f"process_video_ipadapter_stream: Total time: {total_time:.2f} seconds")
-    print(f"process_video_ipadapter_stream: Test completed - IPAdapter stream behavior verified")
-    
+    print("process_video_ipadapter_stream: Test completed - IPAdapter stream behavior verified")
+
     return metrics
 
 
 def main():
-    parser = argparse.ArgumentParser(description="IPAdapter Stream Test Demo - Tests IPAdapter as primary driving force")
-    
-    parser.add_argument("--config", type=str, required=True,
-                       help="Path to configuration file (must include both ControlNet and IPAdapter configs)")
-    parser.add_argument("--input-video", type=str, required=True,
-                       help="Path to input video file (used for both ControlNet and IPAdapter guidance)")
-    parser.add_argument("--static-image", type=str, required=True,
-                       help="Path to static image file (used as base input to StreamDiffusion)")
-    parser.add_argument("--output-dir", type=str, default="output",
-                       help="Parent directory for results (default: 'output'). Script will create a timestamped subdirectory inside this.")
-    parser.add_argument("--engine-only", action="store_true", 
-                       help="Only build TensorRT engines and exit (no video processing)")
-    
+    parser = argparse.ArgumentParser(
+        description="IPAdapter Stream Test Demo - Tests IPAdapter as primary driving force"
+    )
+
+    parser.add_argument(
+        "--config",
+        type=str,
+        required=True,
+        help="Path to configuration file (must include both ControlNet and IPAdapter configs)",
+    )
+    parser.add_argument(
+        "--input-video",
+        type=str,
+        required=True,
+        help="Path to input video file (used for both ControlNet and IPAdapter guidance)",
+    )
+    parser.add_argument(
+        "--static-image",
+        type=str,
+        required=True,
+        help="Path to static image file (used as base input to StreamDiffusion)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="output",
+        help="Parent directory for results (default: 'output'). Script will create a timestamped subdirectory inside this.",
+    )
+    parser.add_argument(
+        "--engine-only", action="store_true", help="Only build TensorRT engines and exit (no video processing)"
+    )
+
     args = parser.parse_args()
-    
+
     # Create timestamped subdirectory within the specified parent directory
     timestamp = time.strftime("%Y%m%d_%H%M%S")
     input_name = Path(args.input_video).stem
     static_name = Path(args.static_image).stem
     config_name = Path(args.config).stem
     subdir_name = f"ipadapter_stream_test_{config_name}_{input_name}_{static_name}_{timestamp}"
-    
+
     # Combine parent directory with generated subdirectory name
     final_output_dir = Path(args.output_dir) / subdir_name
     args.output_dir = str(final_output_dir)
     print(f"main: Using output directory: {args.output_dir}")
-    
+
     # Validate input files
     if not Path(args.config).exists():
         print(f"main: Error - Config file not found: {args.config}")
         return 1
-    
+
     if not Path(args.input_video).exists():
         print(f"main: Error - Input video not found: {args.input_video}")
         return 1
-    
+
     if not Path(args.static_image).exists():
         print(f"main: Error - Static image not found: {args.static_image}")
         return 1
-    
+
     print("IPAdapter Stream Test Demo")
     print("=" * 50)
     print(f"main: Config: {args.config}")
@@ -321,14 +352,10 @@ def main():
     print("- is_stream=True → High-throughput pipelined processing")
     print("- Tests IPAdapter stream behavior fix")
     print("=" * 50)
-    
+
     try:
         metrics = process_video_ipadapter_stream(
-            args.config, 
-            args.input_video, 
-            args.static_image, 
-            args.output_dir, 
-            engine_only=args.engine_only
+            args.config, args.input_video, args.static_image, args.output_dir, engine_only=args.engine_only
         )
         if args.engine_only:
             print("main: Engine-only mode completed successfully!")
@@ -337,6 +364,7 @@ def main():
         return 0
     except Exception as e:
         import traceback
+
         print(f"main: Error during processing: {e}")
         print(f"main: Traceback:\n{''.join(traceback.format_tb(e.__traceback__))}")
         return 1

--- a/examples/config/config_video_test.py
+++ b/examples/config/config_video_test.py
@@ -7,136 +7,136 @@ for testing purposes. It saves output video, performance metrics, and copies
 of the config and input video to an output directory.
 """
 
-import cv2
-import torch
-import numpy as np
-from PIL import Image
 import argparse
-from pathlib import Path
-import sys
-import time
+import json
 import os
 import shutil
-import json
-from collections import deque
+import sys
+import time
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+from PIL import Image
 
 
 def tensor_to_opencv(tensor: torch.Tensor, target_width: int, target_height: int) -> np.ndarray:
     """
     Convert a PyTorch tensor (output_type='pt') to OpenCV BGR format for video writing.
     Uses efficient tensor operations similar to the realtime-img2img demo.
-    
+
     Args:
         tensor: Tensor in range [0,1] with shape [B, C, H, W] or [C, H, W]
         target_width: Target width for output
         target_height: Target height for output
-    
+
     Returns:
         BGR numpy array ready for OpenCV
     """
     # Handle batch dimension - take first image if batched
     if tensor.dim() == 4:
         tensor = tensor[0]
-    
+
     # Convert to uint8 format (0-255) and ensure correct shape (C, H, W)
     tensor_uint8 = (tensor * 255).clamp(0, 255).to(torch.uint8)
-    
+
     # Convert from [C, H, W] to [H, W, C] format
     if tensor_uint8.dim() == 3:
         image_np = tensor_uint8.permute(1, 2, 0).cpu().numpy()
     else:
         raise ValueError(f"tensor_to_opencv: Unexpected tensor shape: {tensor_uint8.shape}")
-    
+
     # Convert RGB to BGR for OpenCV
     image_bgr = cv2.cvtColor(image_np, cv2.COLOR_RGB2BGR)
-    
+
     # Resize if needed
     if image_bgr.shape[:2] != (target_height, target_width):
         image_bgr = cv2.resize(image_bgr, (target_width, target_height))
-    
+
     return image_bgr
 
 
 def process_video(config_path, input_video, output_dir, engine_only=False):
     """Process video through ControlNet pipeline"""
     print(f"process_video: Loading config from {config_path}")
-    
+
     # Import here to avoid loading at module level
     sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
-    from streamdiffusion import load_config, create_wrapper_from_config
-    
+    from streamdiffusion import create_wrapper_from_config, load_config
+
     # Load configuration
     config = load_config(config_path)
-    
+
     # Force tensor output for better performance
-    config['output_type'] = 'pt'
-    
+    config["output_type"] = "pt"
+
     # Get width and height from config (with defaults)
-    width = config.get('width', 512)
-    height = config.get('height', 512)
-    
+    width = config.get("width", 512)
+    height = config.get("height", 512)
+
     print(f"process_video: Using dimensions: {width}x{height}")
-    print(f"process_video: Using output_type='pt' for better performance")
-    
+    print("process_video: Using output_type='pt' for better performance")
+
     # Create output directory
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    
+
     # Copy config and input video to output directory
     config_copy_path = output_dir / f"config_{Path(config_path).name}"
     shutil.copy2(config_path, config_copy_path)
     print(f"process_video: Copied config to {config_copy_path}")
-    
+
     input_copy_path = output_dir / f"input_{Path(input_video).name}"
     shutil.copy2(input_video, input_copy_path)
     print(f"process_video: Copied input video to {input_copy_path}")
-    
+
     # Create wrapper using the built-in function (width/height from config)
     wrapper = create_wrapper_from_config(config)
-    
+
     if engine_only:
         print("Engine-only mode: TensorRT engines have been built (if needed). Exiting.")
         return None
-    
+
     # Open input video
     cap = cv2.VideoCapture(str(input_video))
     if not cap.isOpened():
         raise ValueError(f"Could not open input video: {input_video}")
-    
+
     # Get video properties
     fps = cap.get(cv2.CAP_PROP_FPS)
     frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-    
+
     print(f"process_video: Input video - {frame_count} frames at {fps} FPS")
-    
+
     # Setup output video writer
     output_video_path = output_dir / "output_video.mp4"
-    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
     out = cv2.VideoWriter(str(output_video_path), fourcc, fps, (width + width, height))
-    
+
     # Performance tracking
     frame_times = []
     total_start_time = time.time()
-    
+
     print("process_video: Starting video processing...")
-    
+
     frame_idx = 0
     while True:
         ret, frame = cap.read()
         if not ret:
             break
-        
+
         frame_start_time = time.time()
-        
+
         # Resize frame
         frame_resized = cv2.resize(frame, (width, height))
-        
+
         # Convert frame to PIL
         frame_rgb = cv2.cvtColor(frame_resized, cv2.COLOR_BGR2RGB)
         frame_pil = Image.fromarray(frame_rgb)
-        
+
         # Update control image for all configured ControlNets
-        if hasattr(wrapper.stream, '_controlnet_module') and wrapper.stream._controlnet_module:
+        if hasattr(wrapper.stream, "_controlnet_module") and wrapper.stream._controlnet_module:
             controlnet_count = len(wrapper.stream._controlnet_module.controlnets)
             print(f"process_video: Updating control image for {controlnet_count} ControlNet(s) on frame {frame_idx}")
             for i in range(controlnet_count):
@@ -144,36 +144,35 @@ def process_video(config_path, input_video, output_dir, engine_only=False):
         else:
             print(f"process_video: No ControlNet module found for frame {frame_idx}")
         output_tensor = wrapper(frame_pil)
-        
+
         # Convert tensor output to OpenCV BGR format
         output_bgr = tensor_to_opencv(output_tensor, width, height)
-        
+
         # Create side-by-side display
         combined = np.hstack([frame_resized, output_bgr])
-        
+
         # Add labels
         cv2.putText(combined, "Input", (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
-        cv2.putText(combined, "Generated", (width + 10, 30), 
-                   cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
-        
+        cv2.putText(combined, "Generated", (width + 10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
+
         # Write frame
         out.write(combined)
-        
+
         # Track performance
         frame_time = time.time() - frame_start_time
         frame_times.append(frame_time)
-        
+
         frame_idx += 1
         if frame_idx % 10 == 0:
             avg_fps = len(frame_times) / sum(frame_times) if frame_times else 0
             print(f"process_video: Processed {frame_idx}/{frame_count} frames (Avg FPS: {avg_fps:.2f})")
-    
+
     total_time = time.time() - total_start_time
-    
+
     # Cleanup
     cap.release()
     out.release()
-    
+
     # Calculate performance metrics
     if frame_times:
         avg_frame_time = sum(frame_times) / len(frame_times)
@@ -184,7 +183,7 @@ def process_video(config_path, input_video, output_dir, engine_only=False):
         min_fps = 1.0 / max_frame_time
     else:
         avg_frame_time = avg_fps = min_frame_time = max_frame_time = max_fps = min_fps = 0
-    
+
     # Performance metrics
     metrics = {
         "input_video": str(input_video),
@@ -199,72 +198,77 @@ def process_video(config_path, input_video, output_dir, engine_only=False):
         "avg_frame_time_seconds": avg_frame_time,
         "min_frame_time_seconds": min_frame_time,
         "max_frame_time_seconds": max_frame_time,
-        "model_id": config['model_id'],
-        "acceleration": config.get('acceleration', 'none'),
-        "frame_buffer_size": config.get('frame_buffer_size', 1),
-        "num_inference_steps": config.get('num_inference_steps', 50),
-        "guidance_scale": config.get('guidance_scale', 1.1),
+        "model_id": config["model_id"],
+        "acceleration": config.get("acceleration", "none"),
+        "frame_buffer_size": config.get("frame_buffer_size", 1),
+        "num_inference_steps": config.get("num_inference_steps", 50),
+        "guidance_scale": config.get("guidance_scale", 1.1),
         "output_type": "pt",
-        "controlnets": [cn['model_id'] for cn in config.get('controlnets', [])],
+        "controlnets": [cn["model_id"] for cn in config.get("controlnets", [])],
         "test_type": "controlnet_video_test",
-        "description": "ControlNet video processing using tensor output for performance"
+        "description": "ControlNet video processing using tensor output for performance",
     }
-    
+
     # Save metrics
     metrics_path = output_dir / "performance_metrics.json"
-    with open(metrics_path, 'w') as f:
+    with open(metrics_path, "w") as f:
         json.dump(metrics, f, indent=2)
-    
-    print(f"process_video: Processing completed!")
+
+    print("process_video: Processing completed!")
     print(f"process_video: Output video saved to: {output_video_path}")
     print(f"process_video: Performance metrics saved to: {metrics_path}")
     print(f"process_video: Average FPS: {avg_fps:.2f}")
     print(f"process_video: Total time: {total_time:.2f} seconds")
-    
+
     return metrics
+
 
 def main():
     parser = argparse.ArgumentParser(description="ControlNet Video Test Demo")
-    
+
     # Get the script directory to make paths relative to it
     script_dir = Path(__file__).parent
     default_config = script_dir.parent.parent / "configs" / "controlnet_examples" / "multi_controlnet_example.yaml"
-    
-    parser.add_argument("--config", type=str, required=True,
-                       help="Path to ControlNet configuration file")
-    parser.add_argument("--input-video", type=str, required=True,
-                       help="Path to input video file")
-    parser.add_argument("--output-dir", type=str, default="output",
-                       help="Parent directory for results (default: 'output'). Script will create a timestamped subdirectory inside this.")
-    parser.add_argument("--engine-only", action="store_true", help="Only build TensorRT engines and exit (no video processing)")
-    
+
+    parser.add_argument("--config", type=str, required=True, help="Path to ControlNet configuration file")
+    parser.add_argument("--input-video", type=str, required=True, help="Path to input video file")
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="output",
+        help="Parent directory for results (default: 'output'). Script will create a timestamped subdirectory inside this.",
+    )
+    parser.add_argument(
+        "--engine-only", action="store_true", help="Only build TensorRT engines and exit (no video processing)"
+    )
+
     args = parser.parse_args()
-    
+
     # Create timestamped subdirectory within the specified parent directory
     timestamp = time.strftime("%Y%m%d_%H%M%S")
     input_name = Path(args.input_video).stem
     config_name = Path(args.config).stem
     subdir_name = f"controlnet_test_{config_name}_{input_name}_{timestamp}"
-    
+
     # Combine parent directory with generated subdirectory name
     final_output_dir = Path(args.output_dir) / subdir_name
     args.output_dir = str(final_output_dir)
     print(f"main: Using output directory: {args.output_dir}")
-    
+
     # Validate input files
     if not Path(args.config).exists():
         print(f"main: Error - Config file not found: {args.config}")
         return 1
-    
+
     if not Path(args.input_video).exists():
         print(f"main: Error - Input video not found: {args.input_video}")
         return 1
-    
+
     print("ControlNet Video Test Demo")
     print(f"main: Config: {args.config}")
     print(f"main: Input video: {args.input_video}")
     print(f"main: Output directory: {args.output_dir}")
-    
+
     try:
         metrics = process_video(args.config, args.input_video, args.output_dir, engine_only=args.engine_only)
         if args.engine_only:
@@ -274,10 +278,11 @@ def main():
         return 0
     except Exception as e:
         import traceback
+
         print(f"main: Error during processing: {e}")
         print(f"main: Traceback:\n{''.join(traceback.format_tb(e.__traceback__))}")
         return 1
 
 
 if __name__ == "__main__":
-    exit(main()) 
+    exit(main())

--- a/examples/img2img/multi.py
+++ b/examples/img2img/multi.py
@@ -1,7 +1,7 @@
 import glob
 import os
 import sys
-from typing import Literal, Dict, Optional
+from typing import Dict, Literal, Optional
 
 import fire
 
@@ -9,6 +9,7 @@ import fire
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from streamdiffusion import StreamDiffusionWrapper
+
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/examples/img2img/single.py
+++ b/examples/img2img/single.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import Literal, Dict, Optional
+from typing import Dict, Literal, Optional
 
 import fire
 
@@ -8,6 +8,7 @@ import fire
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from streamdiffusion import StreamDiffusionWrapper
+
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/examples/optimal-performance/multi.py
+++ b/examples/optimal-performance/multi.py
@@ -3,7 +3,7 @@ import sys
 import threading
 import time
 import tkinter as tk
-from multiprocessing import Process, Queue, get_context
+from multiprocessing import Queue, get_context
 from typing import List, Literal
 
 import fire
@@ -98,9 +98,7 @@ def image_generation_process(
             return
 
 
-def _receive_images(
-    queue: Queue, fps_queue: Queue, labels: List[tk.Label], fps_label: tk.Label
-) -> None:
+def _receive_images(queue: Queue, fps_queue: Queue, labels: List[tk.Label], fps_label: tk.Label) -> None:
     """
     Continuously receive images from a queue and update the labels.
 
@@ -120,9 +118,7 @@ def _receive_images(
             if not queue.empty():
                 [
                     labels[0].after(0, update_image, image_data, labels)
-                    for image_data in postprocess_image(
-                        queue.get(block=False), output_type="pil"
-                    )
+                    for image_data in postprocess_image(queue.get(block=False), output_type="pil")
                 ]
             if not fps_queue.empty():
                 fps_label.config(text=f"FPS: {fps_queue.get(block=False):.2f}")
@@ -153,9 +149,7 @@ def receive_images(queue: Queue, fps_queue: Queue) -> None:
     fps_label = tk.Label(root, text="FPS: 0")
     fps_label.grid(rows=2, columnspan=2)
 
-    thread = threading.Thread(
-        target=_receive_images, args=(queue, fps_queue, labels, fps_label), daemon=True
-    )
+    thread = threading.Thread(target=_receive_images, args=(queue, fps_queue, labels, fps_label), daemon=True)
     thread.start()
 
     try:
@@ -173,7 +167,7 @@ def main(
     """
     Main function to start the image generation and viewer processes.
     """
-    ctx = get_context('spawn')
+    ctx = get_context("spawn")
     queue = ctx.Queue()
     fps_queue = ctx.Queue()
     process1 = ctx.Process(
@@ -187,6 +181,7 @@ def main(
 
     process1.join()
     process2.join()
+
 
 if __name__ == "__main__":
     fire.Fire(main)

--- a/examples/optimal-performance/single.py
+++ b/examples/optimal-performance/single.py
@@ -1,15 +1,17 @@
 import os
 import sys
 import time
-from multiprocessing import Process, Queue, get_context
+from multiprocessing import Queue, get_context
 from typing import Literal
 
 import fire
 
+
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from utils.viewer import receive_images
 from streamdiffusion import StreamDiffusionWrapper
+from utils.viewer import receive_images
+
 
 def image_generation_process(
     queue: Queue,
@@ -63,6 +65,7 @@ def image_generation_process(
             print(f"fps: {fps}")
             return
 
+
 def main(
     prompt: str = "cat with sunglasses and a hat, photoreal, 8K",
     model_id_or_path: str = "stabilityai/sd-turbo",
@@ -71,7 +74,7 @@ def main(
     """
     Main function to start the image generation and viewer processes.
     """
-    ctx = get_context('spawn')
+    ctx = get_context("spawn")
     queue = ctx.Queue()
     fps_queue = ctx.Queue()
     process1 = ctx.Process(
@@ -85,6 +88,7 @@ def main(
 
     process1.join()
     process2.join()
+
 
 if __name__ == "__main__":
     fire.Fire(main)

--- a/examples/screen/main.py
+++ b/examples/screen/main.py
@@ -1,25 +1,30 @@
 import os
 import sys
-import time
 import threading
-from multiprocessing import Process, Queue, get_context
-from multiprocessing.connection import Connection
-from typing import List, Literal, Dict, Optional
-import torch
-import PIL.Image
-from streamdiffusion.image_utils import pil2tensor
-import mss
-import fire
+import time
 import tkinter as tk
+from multiprocessing import Queue, get_context
+from multiprocessing.connection import Connection
+from typing import Dict, Literal, Optional
+
+import fire
+import mss
+import PIL.Image
+import torch
+
+from streamdiffusion.image_utils import pil2tensor
+
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from utils.viewer import receive_images
 from streamdiffusion import StreamDiffusionWrapper
+from utils.viewer import receive_images
+
 
 inputs = []
 top = 0
 left = 0
+
 
 def screen(
     event: threading.Event,
@@ -37,10 +42,12 @@ def screen(
             img = PIL.Image.frombytes("RGB", img.size, img.bgra, "raw", "BGRX")
             img.resize((height, width))
             inputs.append(pil2tensor(img))
-    print('exit : screen')
+    print("exit : screen")
+
+
 def dummy_screen(
-        width: int,
-        height: int,
+    width: int,
+    height: int,
 ):
     root = tk.Tk()
     root.title("Press Enter to start")
@@ -48,16 +55,21 @@ def dummy_screen(
     root.resizable(False, False)
     root.attributes("-alpha", 0.8)
     root.configure(bg="black")
+
     def destroy(event):
         root.destroy()
+
     root.bind("<Return>", destroy)
+
     def update_geometry(event):
         global top, left
         top = root.winfo_y()
         left = root.winfo_x()
+
     root.bind("<Configure>", update_geometry)
     root.mainloop()
     return {"top": top, "left": left, "width": width, "height": height}
+
 
 def monitor_setting_process(
     width: int,
@@ -66,6 +78,7 @@ def monitor_setting_process(
 ) -> None:
     monitor = dummy_screen(width, height)
     monitor_sender.send(monitor)
+
 
 def image_generation_process(
     queue: Queue,
@@ -88,7 +101,7 @@ def image_generation_process(
     enable_similar_image_filter: bool,
     similar_image_filter_threshold: float,
     similar_image_filter_max_skip_frame: float,
-    monitor_receiver : Connection,
+    monitor_receiver: Connection,
 ) -> None:
     """
     Process for generating images based on a prompt using a specified model.
@@ -179,7 +192,7 @@ def image_generation_process(
 
     while True:
         try:
-            if not close_queue.empty(): # closing check
+            if not close_queue.empty():  # closing check
                 break
             if len(inputs) < frame_buffer_size:
                 time.sleep(0.005)
@@ -191,9 +204,7 @@ def image_generation_process(
                 sampled_inputs.append(inputs[len(inputs) - index - 1])
             input_batch = torch.cat(sampled_inputs)
             inputs.clear()
-            output_images = stream.stream(
-                input_batch.to(device=stream.device, dtype=stream.dtype)
-            ).cpu()
+            output_images = stream.stream(input_batch.to(device=stream.device, dtype=stream.dtype)).cpu()
             if frame_buffer_size == 1:
                 output_images = [output_images]
             for output_image in output_images:
@@ -205,9 +216,10 @@ def image_generation_process(
             break
 
     print("closing image_generation_process...")
-    event.set() # stop capture thread
+    event.set()  # stop capture thread
     input_screen.join()
     print(f"fps: {fps}")
+
 
 def main(
     model_id_or_path: str = "KBlueLeaf/kohaku-v2.1",
@@ -231,7 +243,7 @@ def main(
     """
     Main function to start the image generation and viewer processes.
     """
-    ctx = get_context('spawn')
+    ctx = get_context("spawn")
     queue = ctx.Queue()
     fps_queue = ctx.Queue()
     close_queue = Queue()
@@ -262,7 +274,7 @@ def main(
             similar_image_filter_threshold,
             similar_image_filter_max_skip_frame,
             monitor_receiver,
-            ),
+        ),
     )
     process1.start()
 
@@ -272,7 +284,7 @@ def main(
             width,
             height,
             monitor_sender,
-            ),
+        ),
     )
     monitor_process.start()
     monitor_process.join()
@@ -285,10 +297,10 @@ def main(
     print("process2 terminated.")
     close_queue.put(True)
     print("process1 terminating...")
-    process1.join(5) # with timeout
+    process1.join(5)  # with timeout
     if process1.is_alive():
         print("process1 still alive. force killing...")
-        process1.terminate() # force kill...
+        process1.terminate()  # force kill...
     process1.join()
     print("process1 terminated.")
 

--- a/examples/txt2img/multi.py
+++ b/examples/txt2img/multi.py
@@ -1,18 +1,26 @@
 import os
 import sys
-from typing import Literal, Dict, Optional
+from typing import Dict, Literal, Optional
 
 import fire
+
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from streamdiffusion import StreamDiffusionWrapper
 
+
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def main(
-    output: str = os.path.join(CURRENT_DIR, "..", "..", "images", "outputs",),
+    output: str = os.path.join(
+        CURRENT_DIR,
+        "..",
+        "..",
+        "images",
+        "outputs",
+    ),
     model_id_or_path: str = "KBlueLeaf/kohaku-v2.1",
     lora_dict: Optional[Dict[str, float]] = None,
     prompt: str = "1girl with brown dog hair, thick glasses, smiling",
@@ -22,7 +30,6 @@ def main(
     acceleration: Literal["none", "xformers", "tensorrt"] = "xformers",
     seed: int = 2,
 ):
-
     """
     Process for generating images based on a prompt using a specified model.
 

--- a/examples/txt2img/single.py
+++ b/examples/txt2img/single.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import Literal, Dict, Optional
+from typing import Dict, Literal, Optional
 
 import fire
 
@@ -8,6 +8,7 @@ import fire
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from streamdiffusion import StreamDiffusionWrapper
+
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -23,7 +24,6 @@ def main(
     use_denoising_batch: bool = False,
     seed: int = 2,
 ):
-
     """
     Process for generating images based on a prompt using a specified model.
 

--- a/examples/vid2vid/main.py
+++ b/examples/vid2vid/main.py
@@ -1,15 +1,17 @@
 import os
 import sys
-from typing import Literal, Dict, Optional
+from typing import Dict, Literal, Optional
 
 import fire
 import torch
 from torchvision.io import read_video, write_video
 from tqdm import tqdm
 
+
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from streamdiffusion import StreamDiffusionWrapper
+
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -26,7 +28,6 @@ def main(
     enable_similar_image_filter: bool = True,
     seed: int = 2,
 ):
-
     """
     Process for generating images based on a prompt using a specified model.
 

--- a/set_env.bat
+++ b/set_env.bat
@@ -1,0 +1,22 @@
+@echo off
+:: StreamDiffusionTD Runtime Environment Variables
+:: Called automatically by Start_StreamDiffusion.bat if this file exists.
+:: Edit values here to tune GPU memory and CUDA behavior.
+
+:: Reduce CUDA memory fragmentation (required for large models at 512x512+)
+set PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:128,expandable_segments:True
+
+:: Lazy CUDA module loading — speeds up startup, reduces VRAM footprint
+set CUDA_MODULE_LOADING=LAZY
+
+:: L2 cache persistence (Ampere+ only, compute 8.0+)
+:: Set to "0" to disable. Default: "1" (enabled, 64 MB reserved)
+set SDTD_L2_PERSIST=1
+set SDTD_L2_PERSIST_MB=64
+
+:: HuggingFace offline mode — set to "1" to use cached models only (no downloads)
+:: set HF_HUB_OFFLINE=1
+:: set TRANSFORMERS_OFFLINE=1
+
+:: Uncomment to override CUDA version detected by setup.py (e.g., for CI)
+:: set STREAMDIFFUSION_CUDA_VERSION=12.8

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,8 @@ _deps = [
     "Pillow>=12.1.1",  # CVE-2026-25990: out-of-bounds write in PSD loading
     "fire==0.7.1",
     "omegaconf==2.3.0",
-    "onnx==1.17.0",  # IR 10 — onnxruntime-gpu 1.22 max IR 10; float32_to_bfloat16 present (removed in 1.19+)
-    "onnxruntime-gpu==1.22.0",  # TRT EP; never co-install CPU onnxruntime — shared files conflict
+    "onnx==1.18.0",  # IR 11 — modelopt needs FLOAT4E2M1 (added in 1.18); float32_to_bfloat16 present (removed in 1.19+)
+    "onnxruntime-gpu==1.24.3",  # TRT EP, supports IR 11; never co-install CPU onnxruntime — shared files conflict
     "polygraphy==0.49.24",
     "protobuf>=4.25.8,<5",  # mediapipe 0.10.21 requires protobuf 4.x; 4.25.8 fixes CVE-2025-4565; CVE-2026-0994 (JSON DoS) accepted risk for local pipeline
     "colored==2.3.1",

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@ import sys
 
 from setuptools import find_packages, setup
 
+
 # Copied from pip_utils.py to avoid import
 def _check_torch_installed():
     try:
         import torch
-        import torchvision
     except Exception:
         msg = (
             "Missing required pre-installed packages: torch, torchvision\n"
@@ -19,16 +19,18 @@ def _check_torch_installed():
         raise RuntimeError(msg)
 
     if not torch.version.cuda:
-        raise RuntimeError("Detected CPU-only PyTorch. Install CUDA-enabled torch/vision/audio before installing this package.")
+        raise RuntimeError(
+            "Detected CPU-only PyTorch. Install CUDA-enabled torch/vision/audio before installing this package."
+        )
 
 
 def get_cuda_constraint():
-    cuda_version = os.environ.get("STREAMDIFFUSION_CUDA_VERSION") or \
-                    os.environ.get("CUDA_VERSION")
+    cuda_version = os.environ.get("STREAMDIFFUSION_CUDA_VERSION") or os.environ.get("CUDA_VERSION")
 
     if not cuda_version:
         try:
             import torch
+
             cuda_version = torch.version.cuda
         except Exception:
             # might not be available during wheel build, so we have to ignore
@@ -56,10 +58,9 @@ _deps = [
     "Pillow>=12.1.1",  # CVE-2026-25990: out-of-bounds write in PSD loading
     "fire==0.7.1",
     "omegaconf==2.3.0",
-    "onnx==1.18.0",  # onnx-graphsurgeon 0.5.8 requires onnx.helper.float32_to_bfloat16 (removed in onnx 1.19+)
-    "onnxruntime==1.24.3",
-    "onnxruntime-gpu==1.24.3",
-    "polygraphy==0.49.26",
+    "onnx==1.17.0",  # IR 10 — onnxruntime-gpu 1.22 max IR 10; float32_to_bfloat16 present (removed in 1.19+)
+    "onnxruntime-gpu==1.22.0",  # TRT EP; never co-install CPU onnxruntime — shared files conflict
+    "polygraphy==0.49.24",
     "protobuf>=4.25.8,<5",  # mediapipe 0.10.21 requires protobuf 4.x; 4.25.8 fixes CVE-2025-4565; CVE-2026-0994 (JSON DoS) accepted risk for local pipeline
     "colored==2.3.1",
     "pywin32==311;sys_platform == 'win32'",
@@ -82,7 +83,9 @@ def deps_list(*pkgs):
 extras = {}
 extras["xformers"] = deps_list("xformers")
 extras["torch"] = deps_list("torch", "accelerate")
-extras["tensorrt"] = deps_list("protobuf", "cuda-python", "onnx", "onnxruntime", "onnxruntime-gpu", "colored", "polygraphy", "onnx-graphsurgeon")
+extras["tensorrt"] = deps_list(
+    "protobuf", "cuda-python", "onnx", "onnxruntime-gpu", "colored", "polygraphy", "onnx-graphsurgeon"
+)
 extras["controlnet"] = deps_list("onnx-graphsurgeon", "controlnet-aux")
 extras["ipadapter"] = deps_list("diffusers-ipadapter", "mediapipe", "insightface")
 

--- a/setup.py
+++ b/setup.py
@@ -55,14 +55,14 @@ _deps = [
     "transformers==4.56.0",
     "accelerate==1.13.0",
     "huggingface_hub==0.35.0",
-    "Pillow>=12.1.1",  # CVE-2026-25990: out-of-bounds write in PSD loading
+    "Pillow>=12.2.0",  # CVE-2026-25990: out-of-bounds write in PSD loading; 12.2.0 verified
     "fire==0.7.1",
     "omegaconf==2.3.0",
     "onnx==1.18.0",  # IR 11 — modelopt needs FLOAT4E2M1 (added in 1.18); float32_to_bfloat16 present (removed in 1.19+)
-    "onnxruntime-gpu==1.24.3",  # TRT EP, supports IR 11; never co-install CPU onnxruntime — shared files conflict
-    "polygraphy==0.49.24",
+    "onnxruntime-gpu==1.24.4",  # TRT EP, supports IR 11; never co-install CPU onnxruntime — shared files conflict
+    "polygraphy==0.49.26",
     "protobuf>=4.25.8,<5",  # mediapipe 0.10.21 requires protobuf 4.x; 4.25.8 fixes CVE-2025-4565; CVE-2026-0994 (JSON DoS) accepted risk for local pipeline
-    "colored==2.3.1",
+    "colored==2.3.2",
     "pywin32==311;sys_platform == 'win32'",
     "onnx-graphsurgeon==0.5.8",
     "controlnet-aux==0.0.10",

--- a/src/streamdiffusion/__init__.py
+++ b/src/streamdiffusion/__init__.py
@@ -1,13 +1,14 @@
+from .config import create_wrapper_from_config, load_config, save_config
 from .pipeline import StreamDiffusion
-from .wrapper import StreamDiffusionWrapper
-from .config import load_config, save_config, create_wrapper_from_config
 from .preprocessing.processors import list_preprocessors
+from .wrapper import StreamDiffusionWrapper
+
 
 __all__ = [
-        "StreamDiffusion",
-        "StreamDiffusionWrapper",
-        "load_config",
-        "list_preprocessors",
-        "save_config",
-        "create_wrapper_from_config",
-    ]
+    "StreamDiffusion",
+    "StreamDiffusionWrapper",
+    "load_config",
+    "list_preprocessors",
+    "save_config",
+    "create_wrapper_from_config",
+]

--- a/src/streamdiffusion/_hf_tracing_patches.py
+++ b/src/streamdiffusion/_hf_tracing_patches.py
@@ -5,7 +5,10 @@ Activated explicitly from StreamDiffusionWrapper when acceleration=='tensorrt'.
 
 import torch
 
+
 _ALREADY = False  # idempotence guard
+
+
 # --------------------------------------------------------------------------- #
 # 1. UNet2DConditionModel: guard in_channels % up_factor
 # --------------------------------------------------------------------------- #
@@ -16,11 +19,11 @@ def _patch_unet():
 
     def patched(self, sample, *args, **kwargs):
         if torch.jit.is_tracing():
-            dim       = torch.as_tensor(getattr(self.config, "in_channels", self.in_channels))
+            dim = torch.as_tensor(getattr(self.config, "in_channels", self.in_channels))
             up_factor = torch.as_tensor(getattr(self.config, "default_overall_up_factor", 1))
             torch._assert(
                 torch.remainder(dim, up_factor) == 0,
-                f"in_channels={dim} not divisible by default_overall_up_factor={up_factor}"
+                f"in_channels={dim} not divisible by default_overall_up_factor={up_factor}",
             )
         return orig_fwd(self, sample, *args, **kwargs)
 
@@ -32,12 +35,13 @@ def _patch_unet():
 # --------------------------------------------------------------------------- #
 def _patch_downsample():
     import diffusers.models.downsampling as d
+
     orig_fwd = d.Downsample2D.forward
 
     def patched(self, hidden_states, *args, **kwargs):
         torch._assert(
             hidden_states.shape[1] == self.channels,
-            f"[Downsample2D] channels mismatch: {hidden_states.shape[1]} vs {self.channels}"
+            f"[Downsample2D] channels mismatch: {hidden_states.shape[1]} vs {self.channels}",
         )
         return orig_fwd(self, hidden_states, *args, **kwargs)
 
@@ -49,12 +53,13 @@ def _patch_downsample():
 # --------------------------------------------------------------------------- #
 def _patch_upsample():
     import diffusers.models.upsampling as u
+
     orig_fwd = u.Upsample2D.forward
 
     def patched(self, hidden_states, *args, **kwargs):
         torch._assert(
             hidden_states.shape[1] == self.channels,
-            f"[Upsample2D] channels mismatch: {hidden_states.shape[1]} vs {self.channels}"
+            f"[Upsample2D] channels mismatch: {hidden_states.shape[1]} vs {self.channels}",
         )
         return orig_fwd(self, hidden_states, *args, **kwargs)
 

--- a/src/streamdiffusion/acceleration/tensorrt/__init__.py
+++ b/src/streamdiffusion/acceleration/tensorrt/__init__.py
@@ -1,22 +1,25 @@
 import torch
 import torch.nn as nn
-from diffusers import AutoencoderKL, UNet2DConditionModel, ControlNetModel
+from diffusers import AutoencoderKL, ControlNetModel, UNet2DConditionModel
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion_img2img import (
     retrieve_latents,
 )
 from diffusers.pipelines.stable_diffusion.safety_checker import StableDiffusionSafetyChecker
+
 from .builder import EngineBuilder
 from .models.models import BaseModel
+
 
 def cosine_distance(image_embeds, text_embeds):
     normalized_image_embeds = nn.functional.normalize(image_embeds)
     normalized_text_embeds = nn.functional.normalize(text_embeds)
     return torch.mm(normalized_image_embeds, normalized_text_embeds.t())
 
+
 class StableDiffusionSafetyCheckerWrapper(StableDiffusionSafetyChecker):
     def __init__(self, config):
         super().__init__(config)
-    
+
     @torch.no_grad()
     def forward(self, clip_input):
         pooled_output = self.vision_model(clip_input)[1]
@@ -37,6 +40,7 @@ class StableDiffusionSafetyCheckerWrapper(StableDiffusionSafetyChecker):
 
         return has_nsfw_concepts
 
+
 class TorchVAEEncoder(torch.nn.Module):
     def __init__(self, vae: AutoencoderKL):
         super().__init__()
@@ -44,6 +48,7 @@ class TorchVAEEncoder(torch.nn.Module):
 
     def forward(self, x: torch.Tensor):
         return retrieve_latents(self.vae.encode(x))
+
 
 def compile_vae_encoder(
     vae: TorchVAEEncoder,
@@ -84,6 +89,7 @@ def compile_vae_decoder(
         **engine_build_options,
     )
 
+
 def compile_safety_checker(
     safety_checker: StableDiffusionSafetyCheckerWrapper,
     model_data: BaseModel,
@@ -113,6 +119,12 @@ def compile_unet(
     opt_batch_size: int = 1,
     engine_build_options: dict = {},
 ):
+    # Extract FP8-specific options before passing the rest to EngineBuilder.build().
+    # These are not valid kwargs for build_engine() and must be handled here.
+    build_options = dict(engine_build_options)
+    fp8 = build_options.pop("fp8", False)
+    calibration_data_fn = build_options.pop("calibration_data_fn", None)
+
     unet = unet.to(torch.device("cuda"), dtype=torch.float16)
     builder = EngineBuilder(model_data, unet, device=torch.device("cuda"))
     builder.build(
@@ -120,7 +132,9 @@ def compile_unet(
         onnx_opt_path,
         engine_path,
         opt_batch_size=opt_batch_size,
-        **engine_build_options,
+        fp8=fp8,
+        calibration_data_fn=calibration_data_fn,
+        **build_options,
     )
 
 

--- a/src/streamdiffusion/acceleration/tensorrt/builder.py
+++ b/src/streamdiffusion/acceleration/tensorrt/builder.py
@@ -66,7 +66,6 @@ class EngineBuilder:
         build_enable_refit: bool = False,
         build_static_batch: bool = False,
         build_dynamic_shape: bool = True,
-        build_all_tactics: bool = False,
         onnx_opset: int = 17,
         force_engine_build: bool = False,
         force_onnx_export: bool = False,
@@ -84,7 +83,6 @@ class EngineBuilder:
             "opt_resolution": f"{opt_image_width}x{opt_image_height}",
             "dynamic_range": f"{min_image_resolution}-{max_image_resolution}" if build_dynamic_shape else "static",
             "batch_size": opt_batch_size,
-            "build_all_tactics": build_all_tactics,
             "stages": {},
         }
 
@@ -206,7 +204,6 @@ class EngineBuilder:
                 opt_batch_size=opt_batch_size,
                 build_static_batch=build_static_batch,
                 build_dynamic_shape=build_dynamic_shape,
-                build_all_tactics=build_all_tactics,
                 build_enable_refit=build_enable_refit,
                 fp8=fp8_trt,
             )
@@ -226,10 +223,10 @@ class EngineBuilder:
         _build_logger.warning(f"[BUILD] {engine_filename} complete: {total_elapsed:.1f}s total")
         _write_build_stats(engine_path, stats)
 
-        # Cleanup ONNX artifacts — preserve .engine, .fp8.onnx, and build_stats.json
+        # Cleanup ONNX artifacts — preserve .engine, .fp8.onnx, timing.cache, and build_stats.json
         # Two-pass deletion to handle Windows file locks (gc.collect releases Python handles)
-        _keep_suffixes = (".engine", ".fp8.onnx")
-        _keep_exact = {"build_stats.json"}
+        _keep_suffixes = (".engine", ".fp8.onnx", ".cache")
+        _keep_exact = {"build_stats.json", "timing.cache"}
         engine_dir = os.path.dirname(engine_path)
         _to_delete = []
         for file in os.listdir(engine_dir):

--- a/src/streamdiffusion/acceleration/tensorrt/builder.py
+++ b/src/streamdiffusion/acceleration/tensorrt/builder.py
@@ -128,6 +128,23 @@ class EngineBuilder:
         self.model.min_latent_shape = min_image_resolution // 8
         self.model.max_latent_shape = max_image_resolution // 8
 
+        # --- Verify ONNX artifacts exist before TRT build ---
+        if not os.path.exists(onnx_opt_path):
+            raise RuntimeError(
+                f"Optimized ONNX file missing: {onnx_opt_path}\n"
+                f"This usually means the ONNX optimization step failed silently.\n"
+                f"Try deleting the engine directory and rebuilding."
+            )
+        opt_file_size = os.path.getsize(onnx_opt_path)
+        if opt_file_size == 0:
+            os.remove(onnx_opt_path)
+            raise RuntimeError(
+                f"Optimized ONNX file is empty (0 bytes): {onnx_opt_path}\n"
+                f"This usually indicates a protobuf serialization failure for >2GB models.\n"
+                f"Try deleting the engine directory and rebuilding."
+            )
+        _build_logger.info(f"Verified ONNX opt file: {onnx_opt_path} ({opt_file_size / (1024**2):.1f} MB)")
+
         # --- TRT Engine Build ---
         if not force_engine_build and os.path.exists(engine_path):
             print(f"Found cached engine: {engine_path}")
@@ -150,11 +167,14 @@ class EngineBuilder:
             stats["stages"]["trt_build"] = {"status": "built", "elapsed_s": round(elapsed, 2)}
             _build_logger.warning(f"[BUILD] TRT engine build ({engine_filename}): {elapsed:.1f}s")
 
-        # Cleanup ONNX artifacts
+        # Cleanup ONNX artifacts — tolerate Windows file-lock failures (Issue #4)
         for file in os.listdir(os.path.dirname(engine_path)):
             if file.endswith('.engine'):
                 continue
-            os.remove(os.path.join(os.path.dirname(engine_path), file))
+            try:
+                os.remove(os.path.join(os.path.dirname(engine_path), file))
+            except OSError as cleanup_err:
+                _build_logger.warning(f"[BUILD] Could not delete temp file {file}: {cleanup_err}")
 
         # Record totals
         total_elapsed = time.perf_counter() - build_total_start

--- a/src/streamdiffusion/acceleration/tensorrt/builder.py
+++ b/src/streamdiffusion/acceleration/tensorrt/builder.py
@@ -1,5 +1,6 @@
 import gc
 import json
+import logging
 import os
 import time
 from datetime import datetime, timezone
@@ -15,7 +16,7 @@ from .utilities import (
     optimize_onnx,
 )
 
-import logging
+
 _build_logger = logging.getLogger(__name__)
 
 
@@ -70,6 +71,8 @@ class EngineBuilder:
         force_engine_build: bool = False,
         force_onnx_export: bool = False,
         force_onnx_optimize: bool = False,
+        fp8: bool = False,
+        calibration_data_fn=None,
     ):
         build_total_start = time.perf_counter()
         engine_name = Path(engine_path).parent.name
@@ -145,6 +148,31 @@ class EngineBuilder:
             )
         _build_logger.info(f"Verified ONNX opt file: {onnx_opt_path} ({opt_file_size / (1024**2):.1f} MB)")
 
+        # --- FP8 Quantization (if enabled) ---
+        # Inserts Q/DQ nodes into the optimized ONNX and replaces onnx_opt_path with
+        # the FP8-annotated ONNX for the TRT build step below.
+        onnx_trt_input = onnx_opt_path  # default: use FP16 opt ONNX
+        if fp8:
+            onnx_fp8_path = onnx_opt_path.replace(".opt.onnx", ".fp8.onnx")
+            if not os.path.exists(onnx_fp8_path):
+                if calibration_data_fn is None:
+                    raise ValueError(
+                        "fp8=True requires calibration_data_fn to generate calibration data. "
+                        "Pass a callable that returns List[Dict[str, np.ndarray]]."
+                    )
+                _build_logger.warning(f"[BUILD] FP8 quantization starting...")
+                t0 = time.perf_counter()
+                from .fp8_quantize import quantize_onnx_fp8
+                calibration_data = calibration_data_fn()
+                quantize_onnx_fp8(onnx_opt_path, onnx_fp8_path, calibration_data)
+                elapsed = time.perf_counter() - t0
+                stats["stages"]["fp8_quantize"] = {"status": "built", "elapsed_s": round(elapsed, 2)}
+                _build_logger.warning(f"[BUILD] FP8 quantization ({engine_filename}): {elapsed:.1f}s")
+            else:
+                _build_logger.info(f"[BUILD] Found cached FP8 ONNX: {onnx_fp8_path}")
+                stats["stages"]["fp8_quantize"] = {"status": "cached"}
+            onnx_trt_input = onnx_fp8_path
+
         # --- TRT Engine Build ---
         if not force_engine_build and os.path.exists(engine_path):
             print(f"Found cached engine: {engine_path}")
@@ -153,7 +181,7 @@ class EngineBuilder:
             t0 = time.perf_counter()
             build_engine(
                 engine_path=engine_path,
-                onnx_opt_path=onnx_opt_path,
+                onnx_opt_path=onnx_trt_input,
                 model_data=self.model,
                 opt_image_height=opt_image_height,
                 opt_image_width=opt_image_width,
@@ -162,14 +190,16 @@ class EngineBuilder:
                 build_dynamic_shape=build_dynamic_shape,
                 build_all_tactics=build_all_tactics,
                 build_enable_refit=build_enable_refit,
+                fp8=fp8,
             )
             elapsed = time.perf_counter() - t0
             stats["stages"]["trt_build"] = {"status": "built", "elapsed_s": round(elapsed, 2)}
             _build_logger.warning(f"[BUILD] TRT engine build ({engine_filename}): {elapsed:.1f}s")
 
-        # Cleanup ONNX artifacts — tolerate Windows file-lock failures (Issue #4)
+        # Cleanup ONNX artifacts — preserve .fp8.onnx alongside .engine for re-use
+        # Tolerate Windows file-lock failures (Issue #4)
         for file in os.listdir(os.path.dirname(engine_path)):
-            if file.endswith('.engine'):
+            if file.endswith(".engine") or file.endswith(".fp8.onnx"):
                 continue
             try:
                 os.remove(os.path.join(os.path.dirname(engine_path), file))

--- a/src/streamdiffusion/acceleration/tensorrt/builder.py
+++ b/src/streamdiffusion/acceleration/tensorrt/builder.py
@@ -152,26 +152,44 @@ class EngineBuilder:
         # Inserts Q/DQ nodes into the optimized ONNX and replaces onnx_opt_path with
         # the FP8-annotated ONNX for the TRT build step below.
         onnx_trt_input = onnx_opt_path  # default: use FP16 opt ONNX
+        fp8_trt = fp8  # may be set to False below if FP8 quantization fails
         if fp8:
             onnx_fp8_path = onnx_opt_path.replace(".opt.onnx", ".fp8.onnx")
             if not os.path.exists(onnx_fp8_path):
-                if calibration_data_fn is None:
-                    raise ValueError(
-                        "fp8=True requires calibration_data_fn to generate calibration data. "
-                        "Pass a callable that returns List[Dict[str, np.ndarray]]."
-                    )
                 _build_logger.warning(f"[BUILD] FP8 quantization starting...")
                 t0 = time.perf_counter()
                 from .fp8_quantize import quantize_onnx_fp8
-                calibration_data = calibration_data_fn()
-                quantize_onnx_fp8(onnx_opt_path, onnx_fp8_path, calibration_data)
-                elapsed = time.perf_counter() - t0
-                stats["stages"]["fp8_quantize"] = {"status": "built", "elapsed_s": round(elapsed, 2)}
-                _build_logger.warning(f"[BUILD] FP8 quantization ({engine_filename}): {elapsed:.1f}s")
+                try:
+                    quantize_onnx_fp8(
+                        onnx_opt_path,
+                        onnx_fp8_path,
+                        model_data=self.model,
+                        opt_batch_size=opt_batch_size,
+                        opt_image_height=opt_image_height,
+                        opt_image_width=opt_image_width,
+                    )
+                    elapsed = time.perf_counter() - t0
+                    stats["stages"]["fp8_quantize"] = {"status": "built", "elapsed_s": round(elapsed, 2)}
+                    _build_logger.warning(f"[BUILD] FP8 quantization ({engine_filename}): {elapsed:.1f}s")
+                    onnx_trt_input = onnx_fp8_path
+                except Exception as fp8_err:
+                    elapsed = time.perf_counter() - t0
+                    _build_logger.warning(
+                        f"[BUILD] FP8 quantization failed after {elapsed:.1f}s: {fp8_err}. "
+                        f"Falling back to FP16 TensorRT engine (onnx_trt_input unchanged)."
+                    )
+                    stats["stages"]["fp8_quantize"] = {
+                        "status": "failed_fallback_fp16",
+                        "elapsed_s": round(elapsed, 2),
+                        "error": str(fp8_err),
+                    }
+                    # onnx_trt_input remains onnx_opt_path (FP16 ONNX)
+                    # Disable FP8 engine build path (avoids STRONGLY_TYPED flag)
+                    fp8_trt = False
             else:
                 _build_logger.info(f"[BUILD] Found cached FP8 ONNX: {onnx_fp8_path}")
                 stats["stages"]["fp8_quantize"] = {"status": "cached"}
-            onnx_trt_input = onnx_fp8_path
+                onnx_trt_input = onnx_fp8_path
 
         # --- TRT Engine Build ---
         if not force_engine_build and os.path.exists(engine_path):
@@ -190,7 +208,7 @@ class EngineBuilder:
                 build_dynamic_shape=build_dynamic_shape,
                 build_all_tactics=build_all_tactics,
                 build_enable_refit=build_enable_refit,
-                fp8=fp8,
+                fp8=fp8_trt,
             )
             elapsed = time.perf_counter() - t0
             stats["stages"]["trt_build"] = {"status": "built", "elapsed_s": round(elapsed, 2)}

--- a/src/streamdiffusion/acceleration/tensorrt/builder.py
+++ b/src/streamdiffusion/acceleration/tensorrt/builder.py
@@ -214,17 +214,7 @@ class EngineBuilder:
             stats["stages"]["trt_build"] = {"status": "built", "elapsed_s": round(elapsed, 2)}
             _build_logger.warning(f"[BUILD] TRT engine build ({engine_filename}): {elapsed:.1f}s")
 
-        # Cleanup ONNX artifacts — preserve .fp8.onnx alongside .engine for re-use
-        # Tolerate Windows file-lock failures (Issue #4)
-        for file in os.listdir(os.path.dirname(engine_path)):
-            if file.endswith(".engine") or file.endswith(".fp8.onnx"):
-                continue
-            try:
-                os.remove(os.path.join(os.path.dirname(engine_path), file))
-            except OSError as cleanup_err:
-                _build_logger.warning(f"[BUILD] Could not delete temp file {file}: {cleanup_err}")
-
-        # Record totals
+        # Record totals (before cleanup so build_stats.json is preserved)
         total_elapsed = time.perf_counter() - build_total_start
         stats["total_elapsed_s"] = round(total_elapsed, 2)
         stats["build_end"] = datetime.now(timezone.utc).isoformat()
@@ -236,5 +226,46 @@ class EngineBuilder:
         _build_logger.warning(f"[BUILD] {engine_filename} complete: {total_elapsed:.1f}s total")
         _write_build_stats(engine_path, stats)
 
-        gc.collect()
-        torch.cuda.empty_cache()
+        # Cleanup ONNX artifacts — preserve .engine, .fp8.onnx, and build_stats.json
+        # Two-pass deletion to handle Windows file locks (gc.collect releases Python handles)
+        _keep_suffixes = (".engine", ".fp8.onnx")
+        _keep_exact = {"build_stats.json"}
+        engine_dir = os.path.dirname(engine_path)
+        _to_delete = []
+        for file in os.listdir(engine_dir):
+            if file in _keep_exact or any(file.endswith(s) for s in _keep_suffixes):
+                continue
+            _to_delete.append(os.path.join(engine_dir, file))
+
+        if _to_delete:
+            _failed = []
+            for fpath in _to_delete:
+                try:
+                    os.remove(fpath)
+                except OSError:
+                    _failed.append(fpath)
+
+            # Release Python-held file handles (ONNX model refs), retry failures
+            if _failed:
+                gc.collect()
+                torch.cuda.empty_cache()
+                time.sleep(0.5)
+                _still_failed = []
+                for fpath in _failed:
+                    try:
+                        os.remove(fpath)
+                    except OSError as cleanup_err:
+                        _still_failed.append(os.path.basename(fpath))
+                        _build_logger.warning(f"[BUILD] Could not delete temp file {os.path.basename(fpath)}: {cleanup_err}")
+                if _still_failed:
+                    _build_logger.warning(
+                        f"[BUILD] {len(_still_failed)} intermediate files could not be cleaned. "
+                        f"Manual cleanup: delete all files except *.engine and *.fp8.onnx from {engine_dir}"
+                    )
+                cleaned = len(_to_delete) - len(_still_failed)
+            else:
+                cleaned = len(_to_delete)
+            _build_logger.info(f"[BUILD] Cleaned {cleaned}/{len(_to_delete)} intermediate files")
+        else:
+            gc.collect()
+            torch.cuda.empty_cache()

--- a/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
+++ b/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
@@ -1,17 +1,18 @@
-
 import hashlib
 import logging
 from enum import Enum
 from pathlib import Path
-from typing import Any, Optional, Dict
+from typing import Any, Dict, Optional
+
 
 logger = logging.getLogger(__name__)
 
 
 class EngineType(Enum):
     """Engine types supported by the TensorRT engine manager."""
+
     UNET = "unet"
-    VAE_ENCODER = "vae_encoder" 
+    VAE_ENCODER = "vae_encoder"
     VAE_DECODER = "vae_decoder"
     CONTROLNET = "controlnet"
     SAFETY_CHECKER = "safety_checker"
@@ -20,62 +21,64 @@ class EngineType(Enum):
 class EngineManager:
     """
     Universal TensorRT engine manager using factory pattern.
-    
+
     Consolidates all engine management logic into a single class:
     - Path generation (moves create_prefix from wrapper.py)
-    - Compilation (moves compile_* calls from wrapper.py)  
+    - Compilation (moves compile_* calls from wrapper.py)
     - Loading (returns appropriate engine objects)
     """
-    
+
     def __init__(self, engine_dir: str):
         """Initialize with engine directory."""
         self.engine_dir = Path(engine_dir)
         self.engine_dir.mkdir(parents=True, exist_ok=True)
-        
+
         # Import the existing compile functions from tensorrt/__init__.py
         from streamdiffusion.acceleration.tensorrt import (
-            compile_unet, compile_vae_encoder, compile_vae_decoder, compile_safety_checker, compile_controlnet
+            compile_controlnet,
+            compile_safety_checker,
+            compile_unet,
+            compile_vae_decoder,
+            compile_vae_encoder,
         )
-        from streamdiffusion.acceleration.tensorrt.runtime_engines.unet_engine import (
-            UNet2DConditionModelEngine
-        )
-        from streamdiffusion.acceleration.tensorrt.runtime_engines.controlnet_engine import (
-            ControlNetModelEngine
-        )
-        
+        from streamdiffusion.acceleration.tensorrt.runtime_engines.controlnet_engine import ControlNetModelEngine
+        from streamdiffusion.acceleration.tensorrt.runtime_engines.unet_engine import UNet2DConditionModelEngine
+
         # TODO: add function to get use_cuda_graph from kwargs
         # Engine configurations - maps each type to its compile function and loader
         self._configs = {
             EngineType.UNET: {
-                'filename': 'unet.engine',
-                'compile_fn': compile_unet,
-                'loader': lambda path, cuda_stream, **kwargs: UNet2DConditionModelEngine(
+                "filename": "unet.engine",
+                "compile_fn": compile_unet,
+                "loader": lambda path, cuda_stream, **kwargs: UNet2DConditionModelEngine(
                     str(path), cuda_stream, use_cuda_graph=True
-                )
+                ),
             },
             EngineType.VAE_ENCODER: {
-                'filename': 'vae_encoder.engine', 
-                'compile_fn': compile_vae_encoder,
-                'loader': lambda path, cuda_stream, **kwargs: str(path)  # Return path for AutoencoderKLEngine
+                "filename": "vae_encoder.engine",
+                "compile_fn": compile_vae_encoder,
+                "loader": lambda path, cuda_stream, **kwargs: str(path),  # Return path for AutoencoderKLEngine
             },
             EngineType.VAE_DECODER: {
-                'filename': 'vae_decoder.engine',
-                'compile_fn': compile_vae_decoder, 
-                'loader': lambda path, cuda_stream, **kwargs: str(path)  # Return path for AutoencoderKLEngine
+                "filename": "vae_decoder.engine",
+                "compile_fn": compile_vae_decoder,
+                "loader": lambda path, cuda_stream, **kwargs: str(path),  # Return path for AutoencoderKLEngine
             },
             EngineType.CONTROLNET: {
-                'filename': 'cnet.engine',
-                'compile_fn': compile_controlnet,
-                'loader': lambda path, cuda_stream, **kwargs: ControlNetModelEngine(
-                    str(path), cuda_stream, use_cuda_graph=kwargs.get('use_cuda_graph', False),
-                    model_type=kwargs.get('model_type', 'sd15')
-                )
+                "filename": "cnet.engine",
+                "compile_fn": compile_controlnet,
+                "loader": lambda path, cuda_stream, **kwargs: ControlNetModelEngine(
+                    str(path),
+                    cuda_stream,
+                    use_cuda_graph=kwargs.get("use_cuda_graph", False),
+                    model_type=kwargs.get("model_type", "sd15"),
+                ),
             },
             EngineType.SAFETY_CHECKER: {
-                'filename': 'safety_checker.engine',
-                'compile_fn': compile_safety_checker,
-                'loader': lambda path, cuda_stream, **kwargs: str(path)
-            }
+                "filename": "safety_checker.engine",
+                "compile_fn": compile_safety_checker,
+                "loader": lambda path, cuda_stream, **kwargs: str(path),
+            },
         }
 
     def _lora_signature(self, lora_dict: Dict[str, float]) -> str:
@@ -93,53 +96,57 @@ class EngineManager:
         h = hashlib.sha1(canon.encode("utf-8")).hexdigest()[:10]
         return f"{len(lora_dict)}-{h}"
 
-    def get_engine_path(self,
-                       engine_type: EngineType,
-                       model_id_or_path: str,
-                       max_batch_size: int,
-                       min_batch_size: int,
-                       mode: str,
-                       use_tiny_vae: bool,
-                       lora_dict: Optional[Dict[str, float]] = None,
-                       ipadapter_scale: Optional[float] = None,
-                       ipadapter_tokens: Optional[int] = None,
-                       controlnet_model_id: Optional[str] = None,
-                       is_faceid: Optional[bool] = None,
-                       use_cached_attn: bool = False,
-                       use_controlnet: bool = False
-                       ) -> Path:
+    def get_engine_path(
+        self,
+        engine_type: EngineType,
+        model_id_or_path: str,
+        max_batch_size: int,
+        min_batch_size: int,
+        mode: str,
+        use_tiny_vae: bool,
+        lora_dict: Optional[Dict[str, float]] = None,
+        ipadapter_scale: Optional[float] = None,
+        ipadapter_tokens: Optional[int] = None,
+        controlnet_model_id: Optional[str] = None,
+        is_faceid: Optional[bool] = None,
+        use_cached_attn: bool = False,
+        use_controlnet: bool = False,
+        fp8: bool = False,
+    ) -> Path:
         """
         Generate engine path using wrapper.py's current logic.
-        
+
         Moves and consolidates create_prefix() function from wrapper.py lines 995-1014.
         Special handling for ControlNet engines which use model_id-based directories.
         """
-        filename = self._configs[engine_type]['filename']
-        
+        filename = self._configs[engine_type]["filename"]
+
         if engine_type == EngineType.CONTROLNET:
             # ControlNet engines use special model_id-based directory structure
             if controlnet_model_id is None:
                 raise ValueError("get_engine_path: controlnet_model_id required for CONTROLNET engines")
-            
+
             # Convert model_id to directory name format (replace "/" with "_")
             model_dir_name = controlnet_model_id.replace("/", "_")
-            
+
             # Use ControlNetEnginePool naming convention: dynamic engines with 384-1024 range
-            prefix = f"controlnet_{model_dir_name}--min_batch-{min_batch_size}--max_batch-{max_batch_size}--dyn-384-1024"
+            prefix = (
+                f"controlnet_{model_dir_name}--min_batch-{min_batch_size}--max_batch-{max_batch_size}--dyn-384-1024"
+            )
             return self.engine_dir / prefix / filename
         else:
             # Standard engines use the unified prefix format
             # Extract base name (from wrapper.py lines 1002-1003)
             maybe_path = Path(model_id_or_path)
             base_name = maybe_path.stem if maybe_path.exists() else model_id_or_path
-            
+
             # Create prefix (from wrapper.py lines 1005-1013)
             prefix = f"{base_name}--tiny_vae-{use_tiny_vae}--min_batch-{min_batch_size}--max_batch-{max_batch_size}"
-            
+
             # IP-Adapter differentiation: add type and (optionally) tokens
             # Keep scale out of identity for runtime control, but include a type flag to separate caches
             if is_faceid is True:
-                prefix += f"--fid"
+                prefix += "--fid"
             if ipadapter_tokens is not None:
                 prefix += f"--tokens{ipadapter_tokens}"
 
@@ -151,11 +158,13 @@ class EngineManager:
                 prefix += f"--use_cached_attn-{use_cached_attn}"
                 if use_controlnet:
                     prefix += "--controlnet"
+                if fp8:
+                    prefix += "--fp8"
 
             prefix += f"--mode-{mode}"
-            
+
             return self.engine_dir / prefix / filename
-    
+
     def _get_embedding_dim_for_model_type(self, model_type: str) -> int:
         """Get embedding dimension based on model type."""
         if model_type.lower() in ["sdxl"]:
@@ -164,8 +173,10 @@ class EngineManager:
             return 1024
         else:  # sd15 and others
             return 768
-    
-    def _execute_compilation(self, compile_fn, engine_path: Path, model, model_config, batch_size: int, kwargs: Dict) -> None:
+
+    def _execute_compilation(
+        self, compile_fn, engine_path: Path, model, model_config, batch_size: int, kwargs: Dict
+    ) -> None:
         """Execute compilation with common pattern to eliminate duplication."""
         compile_fn(
             model,
@@ -174,140 +185,147 @@ class EngineManager:
             str(engine_path) + ".opt.onnx",
             str(engine_path),
             opt_batch_size=batch_size,
-            engine_build_options=kwargs.get('engine_build_options', {})
+            engine_build_options=kwargs.get("engine_build_options", {}),
         )
-    
+
     def _prepare_controlnet_models(self, kwargs: Dict):
         """Prepare ControlNet models for compilation."""
-        from streamdiffusion.acceleration.tensorrt.models.controlnet_models import create_controlnet_model
         import torch
-        
-        model_type = kwargs.get('model_type', 'sd15')
-        max_batch_size = kwargs['max_batch_size']
-        min_batch_size = kwargs['min_batch_size']
+
+        from streamdiffusion.acceleration.tensorrt.models.controlnet_models import create_controlnet_model
+
+        model_type = kwargs.get("model_type", "sd15")
+        max_batch_size = kwargs["max_batch_size"]
+        min_batch_size = kwargs["min_batch_size"]
         embedding_dim = self._get_embedding_dim_for_model_type(model_type)
-        
+
         # Create ControlNet model configuration
         controlnet_model = create_controlnet_model(
             model_type=model_type,
-            unet=kwargs.get('unet'),
-            model_path=kwargs.get('model_path', ""),
+            unet=kwargs.get("unet"),
+            model_path=kwargs.get("model_path", ""),
             max_batch_size=max_batch_size,
             min_batch_size=min_batch_size,
             embedding_dim=embedding_dim,
-            conditioning_channels=kwargs.get('conditioning_channels', 3)
+            conditioning_channels=kwargs.get("conditioning_channels", 3),
         )
-        
+
         # Prepare ControlNet model for compilation
-        pytorch_model = kwargs['model'].to(dtype=torch.float16)
-        
+        pytorch_model = kwargs["model"].to(dtype=torch.float16)
+
         return pytorch_model, controlnet_model
-    
+
     def _get_default_controlnet_build_options(self) -> Dict:
         """Get default engine build options for ControlNet engines."""
         return {
-            'opt_image_height': 704,  # Dynamic optimal resolution
-            'opt_image_width': 704,
-            'build_dynamic_shape': True,
-            'min_image_resolution': 384,
-            'max_image_resolution': 1024,
-            'build_static_batch': False,
-            'build_all_tactics': True,
+            "opt_image_height": 704,  # Dynamic optimal resolution
+            "opt_image_width": 704,
+            "build_dynamic_shape": True,
+            "min_image_resolution": 384,
+            "max_image_resolution": 1024,
+            "build_static_batch": False,
+            "build_all_tactics": True,
         }
-    
-    def compile_and_load_engine(self, 
-                               engine_type: EngineType, 
-                               engine_path: Path,
-                               load_engine: bool = True,
-                               **kwargs) -> Any:
+
+    def compile_and_load_engine(
+        self, engine_type: EngineType, engine_path: Path, load_engine: bool = True, **kwargs
+    ) -> Any:
         """
         Universal compile and load logic for all engine types.
-        
+
         Moves compilation blocks from wrapper.py lines 1200-1252, 1254-1283, 1285-1313.
         """
         if not engine_path.exists():
             # Get the appropriate compile function for this engine type
             config = self._configs[engine_type]
-            compile_fn = config['compile_fn']
-            
+            compile_fn = config["compile_fn"]
+
             # Ensure parent directory exists
             engine_path.parent.mkdir(parents=True, exist_ok=True)
-            
+
             # Handle engine-specific compilation requirements
             if engine_type == EngineType.VAE_DECODER:
                 # VAE decoder requires modifying forward method during compilation
-                stream_vae = kwargs['stream_vae']
+                stream_vae = kwargs["stream_vae"]
                 stream_vae.forward = stream_vae.decode
                 try:
-                    self._execute_compilation(compile_fn, engine_path, kwargs['model'], kwargs['model_config'], kwargs['batch_size'], kwargs)
+                    self._execute_compilation(
+                        compile_fn, engine_path, kwargs["model"], kwargs["model_config"], kwargs["batch_size"], kwargs
+                    )
                 finally:
                     # Always clean up the forward attribute
                     delattr(stream_vae, "forward")
             elif engine_type == EngineType.CONTROLNET:
                 # ControlNet requires special model creation and compilation
                 model, model_config = self._prepare_controlnet_models(kwargs)
-                self._execute_compilation(compile_fn, engine_path, model, model_config, kwargs['batch_size'], kwargs)
+                self._execute_compilation(compile_fn, engine_path, model, model_config, kwargs["batch_size"], kwargs)
             else:
                 # Standard compilation for UNet and VAE encoder
-                self._execute_compilation(compile_fn, engine_path, kwargs['model'], kwargs['model_config'], kwargs['batch_size'], kwargs)
+                self._execute_compilation(
+                    compile_fn, engine_path, kwargs["model"], kwargs["model_config"], kwargs["batch_size"], kwargs
+                )
         else:
-            logger.info(f"EngineManager: engine_path already exists, skipping compile")
-            
+            logger.info("EngineManager: engine_path already exists, skipping compile")
+
         if load_engine:
             return self.load_engine(engine_type, engine_path, **kwargs)
         else:
-            logger.info(f"EngineManager: load_engine is False, skipping load engine")
+            logger.info("EngineManager: load_engine is False, skipping load engine")
             return None
-    
+
     def load_engine(self, engine_type: EngineType, engine_path: Path, **kwargs: Dict) -> Any:
         """Load engine with type-specific handling."""
         config = self._configs[engine_type]
-        loader = config['loader']
-        
+        loader = config["loader"]
+
         if engine_type == EngineType.UNET:
             # UNet engine needs special handling for metadata and error recovery
-            loaded_engine = loader(engine_path, kwargs.get('cuda_stream'))
+            loaded_engine = loader(engine_path, kwargs.get("cuda_stream"))
             self._set_unet_metadata(loaded_engine, kwargs)
             return loaded_engine
         elif engine_type == EngineType.CONTROLNET:
             # ControlNet engine needs model_type parameter
-            return loader(engine_path, kwargs.get('cuda_stream'), 
-                         model_type=kwargs.get('model_type', 'sd15'),
-                         use_cuda_graph=kwargs.get('use_cuda_graph', False))
+            return loader(
+                engine_path,
+                kwargs.get("cuda_stream"),
+                model_type=kwargs.get("model_type", "sd15"),
+                use_cuda_graph=kwargs.get("use_cuda_graph", False),
+            )
         else:
-            return loader(engine_path, kwargs.get('cuda_stream'))
-    
+            return loader(engine_path, kwargs.get("cuda_stream"))
+
     def _set_unet_metadata(self, loaded_engine, kwargs: Dict) -> None:
         """Set metadata on UNet engine for runtime use."""
-        setattr(loaded_engine, 'use_control', kwargs.get('use_controlnet_trt', False))
-        setattr(loaded_engine, 'use_ipadapter', kwargs.get('use_ipadapter_trt', False))
-        
-        if kwargs.get('use_controlnet_trt', False):
-            setattr(loaded_engine, 'unet_arch', kwargs.get('unet_arch', {}))
-            
-        if kwargs.get('use_ipadapter_trt', False):
-            setattr(loaded_engine, 'ipadapter_arch', kwargs.get('unet_arch', {}))
+        setattr(loaded_engine, "use_control", kwargs.get("use_controlnet_trt", False))
+        setattr(loaded_engine, "use_ipadapter", kwargs.get("use_ipadapter_trt", False))
+
+        if kwargs.get("use_controlnet_trt", False):
+            setattr(loaded_engine, "unet_arch", kwargs.get("unet_arch", {}))
+
+        if kwargs.get("use_ipadapter_trt", False):
+            setattr(loaded_engine, "ipadapter_arch", kwargs.get("unet_arch", {}))
             # number of IP-attention layers for runtime vector sizing
-            if 'num_ip_layers' in kwargs and kwargs['num_ip_layers'] is not None:
-                setattr(loaded_engine, 'num_ip_layers', kwargs['num_ip_layers'])
-        
-    
-    def get_or_load_controlnet_engine(self, 
-                                    model_id: str,
-                                    pytorch_model: Any,
-                                    load_engine=True,
-                                    model_type: str = "sd15",
-                                    batch_size: int = 1,
-                                    min_batch_size: int = 1,
-                                    max_batch_size: int = 4,
-                                    cuda_stream = None,
-                                    use_cuda_graph: bool = False,
-                                    unet = None,
-                                    model_path: str = "",
-                                    conditioning_channels: int = 3) -> Any:
+            if "num_ip_layers" in kwargs and kwargs["num_ip_layers"] is not None:
+                setattr(loaded_engine, "num_ip_layers", kwargs["num_ip_layers"])
+
+    def get_or_load_controlnet_engine(
+        self,
+        model_id: str,
+        pytorch_model: Any,
+        load_engine=True,
+        model_type: str = "sd15",
+        batch_size: int = 1,
+        min_batch_size: int = 1,
+        max_batch_size: int = 4,
+        cuda_stream=None,
+        use_cuda_graph: bool = False,
+        unet=None,
+        model_path: str = "",
+        conditioning_channels: int = 3,
+    ) -> Any:
         """
         Get or load ControlNet engine, providing unified interface for ControlNet management.
-        
+
         Replaces ControlNetEnginePool.get_or_load_engine functionality.
         """
         # Generate engine path using ControlNet-specific logic
@@ -318,9 +336,9 @@ class EngineManager:
             min_batch_size=min_batch_size,
             mode="",  # Not used for ControlNet
             use_tiny_vae=False,  # Not used for ControlNet
-            controlnet_model_id=model_id
+            controlnet_model_id=model_id,
         )
-        
+
         # Compile and load ControlNet engine
         return self.compile_and_load_engine(
             EngineType.CONTROLNET,
@@ -336,5 +354,5 @@ class EngineManager:
             unet=unet,
             model_path=model_path,
             conditioning_channels=conditioning_channels,
-            engine_build_options=self._get_default_controlnet_build_options()
+            engine_build_options=self._get_default_controlnet_build_options(),
         )

--- a/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
+++ b/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
@@ -112,6 +112,7 @@ class EngineManager:
         use_cached_attn: bool = False,
         use_controlnet: bool = False,
         fp8: bool = False,
+        resolution: Optional[tuple] = None,
     ) -> Path:
         """
         Generate engine path using wrapper.py's current logic.
@@ -129,10 +130,10 @@ class EngineManager:
             # Convert model_id to directory name format (replace "/" with "_")
             model_dir_name = controlnet_model_id.replace("/", "_")
 
-            # Use ControlNetEnginePool naming convention: dynamic engines with 384-1024 range
-            prefix = (
-                f"controlnet_{model_dir_name}--min_batch-{min_batch_size}--max_batch-{max_batch_size}--dyn-384-1024"
-            )
+            if resolution is not None:
+                prefix = f"controlnet_{model_dir_name}--min_batch-{min_batch_size}--max_batch-{max_batch_size}--res-{resolution[0]}x{resolution[1]}"
+            else:
+                prefix = f"controlnet_{model_dir_name}--min_batch-{min_batch_size}--max_batch-{max_batch_size}--dyn-384-1024"
             return self.engine_dir / prefix / filename
         else:
             # Standard engines use the unified prefix format
@@ -162,6 +163,9 @@ class EngineManager:
                     prefix += "--fp8"
 
             prefix += f"--mode-{mode}"
+
+            if resolution is not None:
+                prefix += f"--res-{resolution[0]}x{resolution[1]}"
 
             return self.engine_dir / prefix / filename
 
@@ -215,17 +219,23 @@ class EngineManager:
 
         return pytorch_model, controlnet_model
 
-    def _get_default_controlnet_build_options(self) -> Dict:
+    def _get_default_controlnet_build_options(
+        self,
+        opt_image_height: int = 704,
+        opt_image_width: int = 704,
+        build_dynamic_shape: bool = False,
+    ) -> Dict:
         """Get default engine build options for ControlNet engines."""
-        return {
-            "opt_image_height": 704,  # Dynamic optimal resolution
-            "opt_image_width": 704,
-            "build_dynamic_shape": True,
-            "min_image_resolution": 384,
-            "max_image_resolution": 1024,
+        opts = {
+            "opt_image_height": opt_image_height,
+            "opt_image_width": opt_image_width,
+            "build_dynamic_shape": build_dynamic_shape,
             "build_static_batch": False,
-            "build_all_tactics": True,
         }
+        if build_dynamic_shape:
+            opts["min_image_resolution"] = 384
+            opts["max_image_resolution"] = 1024
+        return opts
 
     def compile_and_load_engine(
         self, engine_type: EngineType, engine_path: Path, load_engine: bool = True, **kwargs
@@ -322,6 +332,8 @@ class EngineManager:
         unet=None,
         model_path: str = "",
         conditioning_channels: int = 3,
+        opt_image_height: int = 704,
+        opt_image_width: int = 704,
     ) -> Any:
         """
         Get or load ControlNet engine, providing unified interface for ControlNet management.
@@ -337,6 +349,7 @@ class EngineManager:
             mode="",  # Not used for ControlNet
             use_tiny_vae=False,  # Not used for ControlNet
             controlnet_model_id=model_id,
+            resolution=(opt_image_height, opt_image_width),
         )
 
         # Compile and load ControlNet engine
@@ -354,5 +367,8 @@ class EngineManager:
             unet=unet,
             model_path=model_path,
             conditioning_channels=conditioning_channels,
-            engine_build_options=self._get_default_controlnet_build_options(),
+            engine_build_options=self._get_default_controlnet_build_options(
+                opt_image_height=opt_image_height,
+                opt_image_width=opt_image_width,
+            ),
         )

--- a/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
+++ b/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
@@ -230,7 +230,7 @@ class EngineManager:
             "opt_image_height": opt_image_height,
             "opt_image_width": opt_image_width,
             "build_dynamic_shape": build_dynamic_shape,
-            "build_static_batch": False,
+            "build_static_batch": True,
         }
         if build_dynamic_shape:
             opts["min_image_resolution"] = 384

--- a/src/streamdiffusion/acceleration/tensorrt/export_wrappers/__init__.py
+++ b/src/streamdiffusion/acceleration/tensorrt/export_wrappers/__init__.py
@@ -1,15 +1,16 @@
 from .controlnet_export import SDXLControlNetExportWrapper
 from .unet_controlnet_export import ControlNetUNetExportWrapper, MultiControlNetUNetExportWrapper
 from .unet_ipadapter_export import IPAdapterUNetExportWrapper
-from .unet_sdxl_export import SDXLExportWrapper, SDXLConditioningHandler
+from .unet_sdxl_export import SDXLConditioningHandler, SDXLExportWrapper
 from .unet_unified_export import UnifiedExportWrapper
+
 
 __all__ = [
     "SDXLControlNetExportWrapper",
     "ControlNetUNetExportWrapper",
-    "MultiControlNetUNetExportWrapper", 
+    "MultiControlNetUNetExportWrapper",
     "IPAdapterUNetExportWrapper",
     "SDXLExportWrapper",
     "SDXLConditioningHandler",
     "UnifiedExportWrapper",
-] 
+]

--- a/src/streamdiffusion/acceleration/tensorrt/export_wrappers/controlnet_export.py
+++ b/src/streamdiffusion/acceleration/tensorrt/export_wrappers/controlnet_export.py
@@ -1,23 +1,24 @@
 import torch
 
+
 class SDXLControlNetExportWrapper(torch.nn.Module):
     """Wrapper for SDXL ControlNet models to handle added_cond_kwargs properly during ONNX export"""
-    
+
     def __init__(self, controlnet_model):
         super().__init__()
         self.controlnet = controlnet_model
-        
+
         # Get device and dtype from model
-        if hasattr(controlnet_model, 'device'):
+        if hasattr(controlnet_model, "device"):
             self.device = controlnet_model.device
         else:
             # Try to infer from first parameter
             try:
                 self.device = next(controlnet_model.parameters()).device
             except:
-                self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-        
-        if hasattr(controlnet_model, 'dtype'):
+                self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        if hasattr(controlnet_model, "dtype"):
             self.dtype = controlnet_model.dtype
         else:
             # Try to infer from first parameter
@@ -25,15 +26,14 @@ class SDXLControlNetExportWrapper(torch.nn.Module):
                 self.dtype = next(controlnet_model.parameters()).dtype
             except:
                 self.dtype = torch.float16
-    
-    def forward(self, sample, timestep, encoder_hidden_states, controlnet_cond, conditioning_scale, text_embeds, time_ids):
+
+    def forward(
+        self, sample, timestep, encoder_hidden_states, controlnet_cond, conditioning_scale, text_embeds, time_ids
+    ):
         """Forward pass that handles SDXL ControlNet requirements and produces 9 down blocks"""
         # Use the provided SDXL conditioning
-        added_cond_kwargs = {
-            'text_embeds': text_embeds,
-            'time_ids': time_ids
-        }
-        
+        added_cond_kwargs = {"text_embeds": text_embeds, "time_ids": time_ids}
+
         # Call the ControlNet with proper arguments including conditioning_scale
         result = self.controlnet(
             sample=sample,
@@ -42,40 +42,49 @@ class SDXLControlNetExportWrapper(torch.nn.Module):
             controlnet_cond=controlnet_cond,
             conditioning_scale=conditioning_scale,
             added_cond_kwargs=added_cond_kwargs,
-            return_dict=False
+            return_dict=False,
         )
-        
+
         # Extract down blocks and mid block from result
         if isinstance(result, tuple) and len(result) >= 2:
             down_block_res_samples, mid_block_res_sample = result[0], result[1]
-        elif hasattr(result, 'down_block_res_samples') and hasattr(result, 'mid_block_res_sample'):
+        elif hasattr(result, "down_block_res_samples") and hasattr(result, "mid_block_res_sample"):
             down_block_res_samples = result.down_block_res_samples
             mid_block_res_sample = result.mid_block_res_sample
         else:
             raise ValueError(f"Unexpected ControlNet output format: {type(result)}")
-        
+
         # SDXL ControlNet should have exactly 9 down blocks
         if len(down_block_res_samples) != 9:
             raise ValueError(f"SDXL ControlNet expected 9 down blocks, got {len(down_block_res_samples)}")
-        
+
         # Return 9 down blocks + 1 mid block with explicit names matching UNet pattern
         # Following the pattern from controlnet_wrapper.py and models.py:
         # down_block_00: Initial sample (320 channels)
-        # down_block_01-03: Block 0 residuals (320 channels) 
+        # down_block_01-03: Block 0 residuals (320 channels)
         # down_block_04-06: Block 1 residuals (640 channels)
         # down_block_07-08: Block 2 residuals (1280 channels)
         down_block_00 = down_block_res_samples[0]  # Initial: 320 channels, 88x88
         down_block_01 = down_block_res_samples[1]  # Block0: 320 channels, 88x88
-        down_block_02 = down_block_res_samples[2]  # Block0: 320 channels, 88x88  
+        down_block_02 = down_block_res_samples[2]  # Block0: 320 channels, 88x88
         down_block_03 = down_block_res_samples[3]  # Block0: 320 channels, 44x44
         down_block_04 = down_block_res_samples[4]  # Block1: 640 channels, 44x44
         down_block_05 = down_block_res_samples[5]  # Block1: 640 channels, 44x44
         down_block_06 = down_block_res_samples[6]  # Block1: 640 channels, 22x22
         down_block_07 = down_block_res_samples[7]  # Block2: 1280 channels, 22x22
         down_block_08 = down_block_res_samples[8]  # Block2: 1280 channels, 22x22
-        mid_block = mid_block_res_sample            # Mid: 1280 channels, 22x22
-        
+        mid_block = mid_block_res_sample  # Mid: 1280 channels, 22x22
+
         # Return as individual tensors to preserve names in ONNX
-        return (down_block_00, down_block_01, down_block_02, down_block_03, 
-                down_block_04, down_block_05, down_block_06, down_block_07, 
-                down_block_08, mid_block)
+        return (
+            down_block_00,
+            down_block_01,
+            down_block_02,
+            down_block_03,
+            down_block_04,
+            down_block_05,
+            down_block_06,
+            down_block_07,
+            down_block_08,
+            mid_block,
+        )

--- a/src/streamdiffusion/acceleration/tensorrt/export_wrappers/unet_controlnet_export.py
+++ b/src/streamdiffusion/acceleration/tensorrt/export_wrappers/unet_controlnet_export.py
@@ -1,30 +1,32 @@
 """ControlNet-aware UNet wrapper for ONNX export"""
 
+from typing import Dict, List, Optional
+
 import torch
-from typing import List, Optional, Dict, Any
 from diffusers.models.unets.unet_2d_condition import UNet2DConditionModel
+
 from ..models.utils import convert_list_to_structure
 
 
 class ControlNetUNetExportWrapper(torch.nn.Module):
     """Wrapper that combines UNet with ControlNet inputs for ONNX export"""
-    
+
     def __init__(self, unet: UNet2DConditionModel, control_input_names: List[str], kvo_cache_structure: List[int]):
         super().__init__()
         self.unet = unet
         self.control_input_names = control_input_names
         self.kvo_cache_structure = kvo_cache_structure
-        
+
         self.control_names = []
         for name in control_input_names:
             if "input_control" in name or "output_control" in name or "middle_control" in name:
                 self.control_names.append(name)
-        
+
         self.num_controlnet_args = len(self.control_names)
-        
+
         # Detect if this is SDXL based on UNet config
         self.is_sdxl = self._detect_sdxl_architecture(unet)
-        
+
         # SDXL ControlNet has different structure than SD1.5
         if self.is_sdxl:
             # SDXL has 1 initial + 3 down blocks producing 9 control tensors total
@@ -32,30 +34,30 @@ class ControlNetUNetExportWrapper(torch.nn.Module):
         else:
             # SD1.5 has 12 down blocks
             self.expected_down_blocks = 12
-    
+
     def _detect_sdxl_architecture(self, unet):
         """Detect if UNet is SDXL based on architecture"""
-        if hasattr(unet, 'config'):
+        if hasattr(unet, "config"):
             config = unet.config
             # SDXL has 3 down blocks vs SD1.5's 4 down blocks
-            block_out_channels = getattr(config, 'block_out_channels', None)
+            block_out_channels = getattr(config, "block_out_channels", None)
             if block_out_channels and len(block_out_channels) == 3:
                 return True
         return False
-    
+
     def forward(self, sample, timestep, encoder_hidden_states, *args, **kwargs):
         """Forward pass that organizes control inputs and calls UNet"""
-        
-        control_args = args[:self.num_controlnet_args]
-        kvo_cache = args[self.num_controlnet_args:]
-        
+
+        control_args = args[: self.num_controlnet_args]
+        kvo_cache = args[self.num_controlnet_args :]
+
         down_block_controls = []
         mid_block_control = None
-        
+
         if control_args:
             all_control_tensors = []
             middle_tensor = None
-            
+
             for tensor, name in zip(control_args, self.control_names):
                 if "input_control" in name:
                     if "middle" in name:
@@ -64,7 +66,7 @@ class ControlNetUNetExportWrapper(torch.nn.Module):
                         all_control_tensors.append(tensor)
                 elif "middle_control" in name:
                     middle_tensor = tensor
-            
+
             if len(all_control_tensors) == self.expected_down_blocks:
                 down_block_controls = all_control_tensors
                 mid_block_control = middle_tensor
@@ -73,7 +75,7 @@ class ControlNetUNetExportWrapper(torch.nn.Module):
                 if len(all_control_tensors) > 0:
                     if len(all_control_tensors) > self.expected_down_blocks:
                         # Too many tensors - take the first expected_down_blocks
-                        down_block_controls = all_control_tensors[:self.expected_down_blocks]
+                        down_block_controls = all_control_tensors[: self.expected_down_blocks]
                     else:
                         # Too few tensors - use what we have
                         down_block_controls = all_control_tensors
@@ -82,30 +84,29 @@ class ControlNetUNetExportWrapper(torch.nn.Module):
                     # No control tensors available - skip ControlNet
                     down_block_controls = None
                     mid_block_control = None
-        
+
         formatted_kvo_cache = []
         if len(kvo_cache) > 0:
             formatted_kvo_cache = convert_list_to_structure(kvo_cache, self.kvo_cache_structure)
 
         unet_kwargs = {
-            'sample': sample,
-            'timestep': timestep,
-            'encoder_hidden_states': encoder_hidden_states,
-            'kvo_cache': formatted_kvo_cache,
-            'return_dict': False,
+            "sample": sample,
+            "timestep": timestep,
+            "encoder_hidden_states": encoder_hidden_states,
+            "kvo_cache": formatted_kvo_cache,
+            "return_dict": False,
         }
-        
+
         # Pass through all additional kwargs (for SDXL models)
         unet_kwargs.update(kwargs)
 
         # Auto-generate SDXL conditioning if missing and UNet requires it
-        if 'added_cond_kwargs' not in unet_kwargs or unet_kwargs.get('added_cond_kwargs') is None:
-            if (hasattr(self.unet, 'config') and
-                    getattr(self.unet.config, 'addition_embed_type', None) == 'text_time'):
+        if "added_cond_kwargs" not in unet_kwargs or unet_kwargs.get("added_cond_kwargs") is None:
+            if hasattr(self.unet, "config") and getattr(self.unet.config, "addition_embed_type", None) == "text_time":
                 batch_size = sample.shape[0]
-                unet_kwargs['added_cond_kwargs'] = {
-                    'text_embeds': torch.zeros(batch_size, 1280, device=sample.device, dtype=sample.dtype),
-                    'time_ids': torch.zeros(batch_size, 6, device=sample.device, dtype=sample.dtype),
+                unet_kwargs["added_cond_kwargs"] = {
+                    "text_embeds": torch.zeros(batch_size, 1280, device=sample.device, dtype=sample.dtype),
+                    "time_ids": torch.zeros(batch_size, 6, device=sample.device, dtype=sample.dtype),
                 }
 
         if down_block_controls:
@@ -115,30 +116,30 @@ class ControlNetUNetExportWrapper(torch.nn.Module):
             # Control tensors are now generated in the correct order to match UNet's down_block_res_samples
             # For SDXL: [88x88, 88x88, 88x88, 44x44, 44x44, 44x44, 22x22, 22x22, 22x22]
             # This directly aligns with UNet's: [initial_sample] + [block0_residuals] + [block1_residuals] + [block2_residuals]
-            unet_kwargs['down_block_additional_residuals'] = adapted_controls
-        
+            unet_kwargs["down_block_additional_residuals"] = adapted_controls
+
         if mid_block_control is not None:
             # Adapt middle control tensor shape if needed
             adapted_mid_control = self._adapt_middle_control_tensor(mid_block_control, sample)
-            unet_kwargs['mid_block_additional_residual'] = adapted_mid_control
-        
+            unet_kwargs["mid_block_additional_residual"] = adapted_mid_control
+
         try:
             res = self.unet(**unet_kwargs)
             if len(kvo_cache) > 0:
                 return res
             else:
                 return res[0]
-        except Exception as e:
+        except Exception:
             raise
-    
+
     def _adapt_control_tensors(self, control_tensors, sample):
         """Adapt control tensor shapes to match UNet expectations"""
         if not control_tensors:
             return control_tensors
-            
+
         adapted_tensors = []
         sample_height, sample_width = sample.shape[-2:]
-        
+
         # Updated factors to match the corrected control tensor generation
         # SDXL: 9 tensors [88x88, 88x88, 88x88, 44x44, 44x44, 44x44, 22x22, 22x22, 22x22]
         # Factors: [1, 1, 1, 2, 2, 2, 4, 4, 4] to match UNet down_block_res_samples structure
@@ -146,30 +147,31 @@ class ControlNetUNetExportWrapper(torch.nn.Module):
             expected_downsample_factors = [1, 1, 1, 2, 2, 2, 4, 4, 4]  # 9 tensors for SDXL
         else:
             expected_downsample_factors = [1, 1, 1, 2, 2, 2, 4, 4, 4, 8, 8, 8]  # 12 tensors for SD1.5
-        
+
         for i, control_tensor in enumerate(control_tensors):
             if control_tensor is None:
                 adapted_tensors.append(control_tensor)
                 continue
-                
+
             # Check if tensor needs spatial adaptation
             if len(control_tensor.shape) >= 4:
                 control_height, control_width = control_tensor.shape[-2:]
-                
+
                 # Use the correct downsampling factor for this tensor index
                 if i < len(expected_downsample_factors):
                     downsample_factor = expected_downsample_factors[i]
                     expected_height = sample_height // downsample_factor
                     expected_width = sample_width // downsample_factor
-                    
+
                     if control_height != expected_height or control_width != expected_width:
                         # Use interpolation to adapt size
                         import torch.nn.functional as F
+
                         adapted_tensor = F.interpolate(
-                            control_tensor, 
+                            control_tensor,
                             size=(expected_height, expected_width),
-                            mode='bilinear', 
-                            align_corners=False
+                            mode="bilinear",
+                            align_corners=False,
                         )
                         adapted_tensors.append(adapted_tensor)
                     else:
@@ -179,94 +181,94 @@ class ControlNetUNetExportWrapper(torch.nn.Module):
                     adapted_tensors.append(control_tensor)
             else:
                 adapted_tensors.append(control_tensor)
-                
+
         return adapted_tensors
-    
+
     def _adapt_middle_control_tensor(self, mid_control, sample):
         """Adapt middle control tensor shape to match UNet expectations"""
         if mid_control is None:
             return mid_control
-            
+
         # Middle control is typically at the bottleneck, so heavily downsampled
         if len(mid_control.shape) >= 4 and len(sample.shape) >= 4:
             sample_height, sample_width = sample.shape[-2:]
             control_height, control_width = mid_control.shape[-2:]
-            
+
             # For SDXL: middle block is at 4x downsampling (22x22 from 88x88)
             # For SD1.5: middle block is at 8x downsampling
             expected_factor = 4 if self.is_sdxl else 8
             expected_height = sample_height // expected_factor
             expected_width = sample_width // expected_factor
-            
+
             if control_height != expected_height or control_width != expected_width:
                 import torch.nn.functional as F
+
                 adapted_tensor = F.interpolate(
-                    mid_control,
-                    size=(expected_height, expected_width),
-                    mode='bilinear',
-                    align_corners=False
+                    mid_control, size=(expected_height, expected_width), mode="bilinear", align_corners=False
                 )
                 return adapted_tensor
-                
+
         return mid_control
 
 
 class MultiControlNetUNetExportWrapper(torch.nn.Module):
     """Advanced wrapper for multiple ControlNets with different scales"""
-    
-    def __init__(self, 
-                 unet: UNet2DConditionModel, 
-                 control_input_names: List[str],
-                 kvo_cache_structure: List[int],
-                 num_controlnets: int = 1,
-                 conditioning_scales: Optional[List[float]] = None):
+
+    def __init__(
+        self,
+        unet: UNet2DConditionModel,
+        control_input_names: List[str],
+        kvo_cache_structure: List[int],
+        num_controlnets: int = 1,
+        conditioning_scales: Optional[List[float]] = None,
+    ):
         super().__init__()
         self.unet = unet
         self.control_input_names = control_input_names
         self.num_controlnets = num_controlnets
         self.conditioning_scales = conditioning_scales or [1.0] * num_controlnets
         self.kvo_cache_structure = kvo_cache_structure
-        
+
         self.control_names = []
         for name in control_input_names:
             if "input_control" in name or "output_control" in name or "middle_control" in name:
                 self.control_names.append(name)
-        
+
         self.num_controlnet_args = len(self.control_names)
 
         self.controlnet_indices = []
         controls_per_net = self.num_controlnet_args // num_controlnets
-        
+
         for cn_idx in range(num_controlnets):
             start_idx = cn_idx * controls_per_net
             end_idx = start_idx + controls_per_net
             self.controlnet_indices.append(list(range(start_idx, end_idx)))
-    
+
     def forward(self, sample, timestep, encoder_hidden_states, *args):
         """Forward pass for multiple ControlNets"""
-        control_args = args[:self.num_controlnet_args]
-        kvo_cache = args[self.num_controlnet_args:]
+        control_args = args[: self.num_controlnet_args]
+        kvo_cache = args[self.num_controlnet_args :]
 
         combined_down_controls = None
         combined_mid_control = None
-        
+
         for cn_idx, indices in enumerate(self.controlnet_indices):
             scale = self.conditioning_scales[cn_idx]
             if scale == 0:
                 continue
-            
+
             cn_controls = [control_args[i] for i in indices if i < len(control_args)]
-            
+
             if not cn_controls:
                 continue
-            
+
             num_down = len(cn_controls) - 1
             down_controls = cn_controls[:num_down]
             mid_control = cn_controls[num_down] if num_down < len(cn_controls) else None
-            
+
             scaled_down = [ctrl * scale for ctrl in down_controls]
             scaled_mid = mid_control * scale if mid_control is not None else None
-            
+
             if combined_down_controls is None:
                 combined_down_controls = scaled_down
                 combined_mid_control = scaled_mid
@@ -275,24 +277,24 @@ class MultiControlNetUNetExportWrapper(torch.nn.Module):
                     combined_down_controls[i] += scaled_down[i]
                 if scaled_mid is not None and combined_mid_control is not None:
                     combined_mid_control += scaled_mid
-        
+
         formatted_kvo_cache = []
         if len(kvo_cache) > 0:
             formatted_kvo_cache = convert_list_to_structure(kvo_cache, self.kvo_cache_structure)
 
         unet_kwargs = {
-            'sample': sample,
-            'timestep': timestep,
-            'encoder_hidden_states': encoder_hidden_states,
-            'kvo_cache': formatted_kvo_cache,
-            'return_dict': False,
+            "sample": sample,
+            "timestep": timestep,
+            "encoder_hidden_states": encoder_hidden_states,
+            "kvo_cache": formatted_kvo_cache,
+            "return_dict": False,
         }
-        
+
         if combined_down_controls:
-            unet_kwargs['down_block_additional_residuals'] = list(reversed(combined_down_controls))
+            unet_kwargs["down_block_additional_residuals"] = list(reversed(combined_down_controls))
         if combined_mid_control is not None:
-            unet_kwargs['mid_block_additional_residual'] = combined_mid_control
-        
+            unet_kwargs["mid_block_additional_residual"] = combined_mid_control
+
         res = self.unet(**unet_kwargs)
         if len(kvo_cache) > 0:
             return res
@@ -301,11 +303,13 @@ class MultiControlNetUNetExportWrapper(torch.nn.Module):
         return res
 
 
-def create_controlnet_wrapper(unet: UNet2DConditionModel, 
-                            control_input_names: List[str],
-                            kvo_cache_structure: List[int],
-                            num_controlnets: int = 1,
-                            conditioning_scales: Optional[List[float]] = None) -> torch.nn.Module:
+def create_controlnet_wrapper(
+    unet: UNet2DConditionModel,
+    control_input_names: List[str],
+    kvo_cache_structure: List[int],
+    num_controlnets: int = 1,
+    conditioning_scales: Optional[List[float]] = None,
+) -> torch.nn.Module:
     """Factory function to create appropriate ControlNet wrapper"""
     if num_controlnets == 1:
         return ControlNetUNetExportWrapper(unet, control_input_names, kvo_cache_structure)
@@ -315,17 +319,18 @@ def create_controlnet_wrapper(unet: UNet2DConditionModel,
         )
 
 
-def organize_control_tensors(control_tensors: List[torch.Tensor], 
-                           control_input_names: List[str]) -> Dict[str, List[torch.Tensor]]:
+def organize_control_tensors(
+    control_tensors: List[torch.Tensor], control_input_names: List[str]
+) -> Dict[str, List[torch.Tensor]]:
     """Organize control tensors by type (input, output, middle)"""
-    organized = {'input': [], 'output': [], 'middle': []}
-    
+    organized = {"input": [], "output": [], "middle": []}
+
     for tensor, name in zip(control_tensors, control_input_names):
         if "input_control" in name:
-            organized['input'].append(tensor)
+            organized["input"].append(tensor)
         elif "output_control" in name:
-            organized['output'].append(tensor)
+            organized["output"].append(tensor)
         elif "middle_control" in name:
-            organized['middle'].append(tensor)
-    
-    return organized 
+            organized["middle"].append(tensor)
+
+    return organized

--- a/src/streamdiffusion/acceleration/tensorrt/export_wrappers/unet_ipadapter_export.py
+++ b/src/streamdiffusion/acceleration/tensorrt/export_wrappers/unet_ipadapter_export.py
@@ -1,30 +1,37 @@
+from typing import List
+
 import torch
 from diffusers import UNet2DConditionModel
-from typing import Optional, Dict, Any, List
-
-from ....model_detection import detect_model, detect_model_from_diffusers_unet
 from diffusers_ipadapter.ip_adapter.attention_processor import TRTIPAttnProcessor, TRTIPAttnProcessor2_0
+
+from ....model_detection import detect_model_from_diffusers_unet
 
 
 class IPAdapterUNetExportWrapper(torch.nn.Module):
     """
     Wrapper that bakes IPAdapter attention processors into the UNet for ONNX export.
-    
+
     This approach installs IPAdapter attention processors before ONNX export,
     allowing the specialized attention logic to be compiled into TensorRT.
     The UNet expects concatenated embeddings (text + image) as encoder_hidden_states.
     """
-    
-    def __init__(self, unet: UNet2DConditionModel, cross_attention_dim: int, num_tokens: int = 4, install_processors: bool = True):
+
+    def __init__(
+        self,
+        unet: UNet2DConditionModel,
+        cross_attention_dim: int,
+        num_tokens: int = 4,
+        install_processors: bool = True,
+    ):
         super().__init__()
         self.unet = unet
         self.num_image_tokens = num_tokens  # 4 for standard, 16 for plus
         self.cross_attention_dim = cross_attention_dim  # 768 for SD1.5, 2048 for SDXL
         self.install_processors = install_processors
-        
+
         # Convert to float32 BEFORE installing processors (to avoid resetting them)
         self.unet = self.unet.to(dtype=torch.float32)
-        
+
         # Track installed TRT processors
         self._ip_trt_processors: List[torch.nn.Module] = []
         self.num_ip_layers: int = 0
@@ -36,8 +43,10 @@ class IPAdapterUNetExportWrapper(torch.nn.Module):
             # Install IPAdapter processors AFTER dtype conversion
             self._install_ipadapter_processors()
         else:
-            print("IPAdapterUNetExportWrapper: WARNING - UNet will not have IPAdapter functionality without processors!")
-    
+            print(
+                "IPAdapterUNetExportWrapper: WARNING - UNet will not have IPAdapter functionality without processors!"
+            )
+
     def _has_ipadapter_processors(self) -> bool:
         """Check if the UNet already has IPAdapter processors installed"""
         try:
@@ -45,44 +54,48 @@ class IPAdapterUNetExportWrapper(torch.nn.Module):
             for name, processor in processors.items():
                 # Check for IPAdapter processor class names
                 processor_class = processor.__class__.__name__
-                if 'IPAttn' in processor_class or 'IPAttnProcessor' in processor_class:
+                if "IPAttn" in processor_class or "IPAttnProcessor" in processor_class:
                     return True
             return False
         except Exception as e:
             print(f"IPAdapterUNetExportWrapper: Error checking existing processors: {e}")
             return False
-    
+
     def _ensure_processor_dtype_consistency(self):
         """Ensure existing IPAdapter processors have correct dtype for ONNX export"""
         if hasattr(torch.nn.functional, "scaled_dot_product_attention"):
             from diffusers.models.attention_processor import AttnProcessor2_0 as AttnProcessor
+
             IPProcClass = TRTIPAttnProcessor2_0
         else:
             from diffusers.models.attention_processor import AttnProcessor
+
             IPProcClass = TRTIPAttnProcessor
         try:
             processors = self.unet.attn_processors
             updated_processors = {}
             self._ip_trt_processors = []
             ip_layer_index = 0
-            
+
             for name, processor in processors.items():
                 processor_class = processor.__class__.__name__
-                if 'TRTIPAttn' in processor_class:
+                if "TRTIPAttn" in processor_class:
                     # Already TRT processors: ensure dtype and record
                     proc = processor.to(dtype=torch.float32)
                     proc._scale_index = ip_layer_index
                     self._ip_trt_processors.append(proc)
                     ip_layer_index += 1
                     updated_processors[name] = proc
-                elif 'IPAttn' in processor_class or 'IPAttnProcessor' in processor_class:
+                elif "IPAttn" in processor_class or "IPAttnProcessor" in processor_class:
                     # Replace standard processors with TRT variants, preserving weights where applicable
-                    hidden_size = getattr(processor, 'hidden_size', None)
-                    cross_attention_dim = getattr(processor, 'cross_attention_dim', None)
-                    num_tokens = getattr(processor, 'num_tokens', self.num_image_tokens)
-                    proc = IPProcClass(hidden_size=hidden_size, cross_attention_dim=cross_attention_dim, num_tokens=num_tokens)
+                    hidden_size = getattr(processor, "hidden_size", None)
+                    cross_attention_dim = getattr(processor, "cross_attention_dim", None)
+                    num_tokens = getattr(processor, "num_tokens", self.num_image_tokens)
+                    proc = IPProcClass(
+                        hidden_size=hidden_size, cross_attention_dim=cross_attention_dim, num_tokens=num_tokens
+                    )
                     # Copy IP projection weights if present
-                    if hasattr(processor, 'to_k_ip') and hasattr(processor, 'to_v_ip') and hasattr(proc, 'to_k_ip'):
+                    if hasattr(processor, "to_k_ip") and hasattr(processor, "to_v_ip") and hasattr(proc, "to_k_ip"):
                         with torch.no_grad():
                             proc.to_k_ip.weight.copy_(processor.to_k_ip.weight.to(dtype=torch.float32))
                             proc.to_v_ip.weight.copy_(processor.to_v_ip.weight.to(dtype=torch.float32))
@@ -93,16 +106,17 @@ class IPAdapterUNetExportWrapper(torch.nn.Module):
                     updated_processors[name] = proc
                 else:
                     updated_processors[name] = AttnProcessor()
-            
+
             # Update all processors to ensure consistency
             self.unet.set_attn_processor(updated_processors)
             self.num_ip_layers = len(self._ip_trt_processors)
-                
+
         except Exception as e:
             print(f"IPAdapterUNetExportWrapper: Error updating processor dtypes: {e}")
             import traceback
+
             traceback.print_exc()
-    
+
     def _install_ipadapter_processors(self):
         """
         Install IPAdapter attention processors that will be baked into ONNX.
@@ -112,19 +126,23 @@ class IPAdapterUNetExportWrapper(torch.nn.Module):
         try:
             if hasattr(torch.nn.functional, "scaled_dot_product_attention"):
                 from diffusers.models.attention_processor import AttnProcessor2_0 as AttnProcessor
+
                 IPProcClass = TRTIPAttnProcessor2_0
             else:
                 from diffusers.models.attention_processor import AttnProcessor
+
                 IPProcClass = TRTIPAttnProcessor
-            
+
             # Install attention processors with proper configuration
             processor_names = list(self.unet.attn_processors.keys())
-            
+
             attn_procs = {}
             ip_layer_index = 0
             for name in processor_names:
-                cross_attention_dim = None if name.endswith("attn1.processor") else self.unet.config.cross_attention_dim
-                
+                cross_attention_dim = (
+                    None if name.endswith("attn1.processor") else self.unet.config.cross_attention_dim
+                )
+
                 # Determine hidden_size based on processor location
                 hidden_size = None
                 if name.startswith("mid_block"):
@@ -138,7 +156,7 @@ class IPAdapterUNetExportWrapper(torch.nn.Module):
                 else:
                     # Fallback for any unexpected processor names
                     hidden_size = self.unet.config.block_out_channels[0]  # Use first block size as fallback
-                
+
                 if cross_attention_dim is None:
                     # Self-attention layers use standard processors
                     attn_procs[name] = AttnProcessor()
@@ -154,38 +172,46 @@ class IPAdapterUNetExportWrapper(torch.nn.Module):
                     self._ip_trt_processors.append(proc)
                     ip_layer_index += 1
                     attn_procs[name] = proc
-            
+
             self.unet.set_attn_processor(attn_procs)
             self.num_ip_layers = len(self._ip_trt_processors)
-            
 
-            
         except Exception as e:
             print(f"IPAdapterUNetExportWrapper: ERROR - Could not install IPAdapter processors: {e}")
             print(f"IPAdapterUNetExportWrapper: Exception type: {type(e).__name__}")
             print("IPAdapterUNetExportWrapper: IPAdapter functionality will not work without processors!")
             import traceback
+
             traceback.print_exc()
             raise e
-    
+
     def set_ipadapter_scale(self, ipadapter_scale: torch.Tensor) -> None:
         """Assign per-layer scale tensor to installed TRTIPAttn processors."""
         if not isinstance(ipadapter_scale, torch.Tensor):
             import logging
-            logging.getLogger(__name__).error(f"IPAdapterUNetExportWrapper: ipadapter_scale wrong type: {type(ipadapter_scale)}")
+
+            logging.getLogger(__name__).error(
+                f"IPAdapterUNetExportWrapper: ipadapter_scale wrong type: {type(ipadapter_scale)}"
+            )
             raise TypeError("ipadapter_scale must be a torch.Tensor")
         if self.num_ip_layers <= 0 or not self._ip_trt_processors:
             raise RuntimeError("No TRTIPAttn processors installed")
         if ipadapter_scale.ndim != 1 or ipadapter_scale.shape[0] != self.num_ip_layers:
             import logging
-            logging.getLogger(__name__).error(f"IPAdapterUNetExportWrapper: ipadapter_scale has wrong shape {tuple(ipadapter_scale.shape)}, expected=({self.num_ip_layers},)")
+
+            logging.getLogger(__name__).error(
+                f"IPAdapterUNetExportWrapper: ipadapter_scale has wrong shape {tuple(ipadapter_scale.shape)}, expected=({self.num_ip_layers},)"
+            )
             raise ValueError(f"ipadapter_scale must have shape [{self.num_ip_layers}]")
 
         # Ensure float32 for ONNX export stability
         scale_vec = ipadapter_scale.to(dtype=torch.float32)
         try:
             import logging
-            logging.getLogger(__name__).debug(f"IPAdapterUNetExportWrapper: scale_vec min={scale_vec.min()}, max={scale_vec.max()}")
+
+            logging.getLogger(__name__).debug(
+                f"IPAdapterUNetExportWrapper: scale_vec min={scale_vec.min()}, max={scale_vec.max()}"
+            )
         except Exception:
             pass
         for proc in self._ip_trt_processors:
@@ -194,27 +220,27 @@ class IPAdapterUNetExportWrapper(torch.nn.Module):
     def forward(self, sample, timestep, encoder_hidden_states, ipadapter_scale: torch.Tensor = None):
         """
         Forward pass with concatenated embeddings (text + image).
-        
+
         The IPAdapter processors installed in the UNet will automatically:
         1. Split the concatenated embeddings into text and image parts
         2. Process image tokens with separate attention computation
         3. Apply scaling and blending between text and image attention
-        
+
         Args:
             sample: Latent input tensor
-            timestep: Timestep tensor  
+            timestep: Timestep tensor
             encoder_hidden_states: Concatenated embeddings [text_tokens + image_tokens, cross_attention_dim]
-            
+
         Returns:
             UNet output (noise prediction)
         """
         # Validate input shapes
         batch_size, seq_len, embed_dim = encoder_hidden_states.shape
-        
+
         # Check that we have the expected number of image tokens
         if embed_dim != self.cross_attention_dim:
             raise ValueError(f"Embedding dimension {embed_dim} doesn't match expected {self.cross_attention_dim}")
-        
+
         # Ensure dtype consistency for ONNX export
         if encoder_hidden_states.dtype != torch.float32:
             encoder_hidden_states = encoder_hidden_states.to(torch.float32)
@@ -223,29 +249,28 @@ class IPAdapterUNetExportWrapper(torch.nn.Module):
         if ipadapter_scale is None:
             raise RuntimeError("IPAdapterUNetExportWrapper.forward requires ipadapter_scale tensor")
         self.set_ipadapter_scale(ipadapter_scale)
-        
+
         # Pass concatenated embeddings to UNet with baked-in IPAdapter processors
         return self.unet(
-            sample=sample,
-            timestep=timestep,
-            encoder_hidden_states=encoder_hidden_states,
-            return_dict=False
+            sample=sample, timestep=timestep, encoder_hidden_states=encoder_hidden_states, return_dict=False
         )
 
 
-def create_ipadapter_wrapper(unet: UNet2DConditionModel, num_tokens: int = 4, install_processors: bool = True) -> IPAdapterUNetExportWrapper:
+def create_ipadapter_wrapper(
+    unet: UNet2DConditionModel, num_tokens: int = 4, install_processors: bool = True
+) -> IPAdapterUNetExportWrapper:
     """
     Create an IPAdapter wrapper with automatic architecture detection and baked-in processors.
-    
+
     Handles both cases:
     1. UNet with pre-loaded IPAdapter processors (preserves existing weights)
     2. UNet without IPAdapter processors (installs new ones if install_processors=True)
-    
+
     Args:
         unet: UNet2DConditionModel to wrap
         num_tokens: Number of image tokens (4 for standard, 16 for plus)
         install_processors: Whether to install IPAdapter processors if none exist
-        
+
     Returns:
         IPAdapterUNetExportWrapper with baked-in IPAdapter attention processors
     """
@@ -253,23 +278,21 @@ def create_ipadapter_wrapper(unet: UNet2DConditionModel, num_tokens: int = 4, in
     try:
         model_type = detect_model_from_diffusers_unet(unet)
         cross_attention_dim = unet.config.cross_attention_dim
-        
+
         # Check if UNet already has IPAdapter processors installed
         existing_processors = unet.attn_processors
-        has_ipadapter = any('IPAttn' in proc.__class__.__name__ or 'IPAttnProcessor' in proc.__class__.__name__ 
-                           for proc in existing_processors.values())
-        
+        has_ipadapter = any(
+            "IPAttn" in proc.__class__.__name__ or "IPAttnProcessor" in proc.__class__.__name__
+            for proc in existing_processors.values()
+        )
+
         # Validate expected dimensions
-        expected_dims = {
-            "SD15": 768,
-            "SDXL": 2048, 
-            "SD21": 1024
-        }
-        
+        expected_dims = {"SD15": 768, "SDXL": 2048, "SD21": 1024}
+
         expected_dim = expected_dims.get(model_type)
-        
+
         return IPAdapterUNetExportWrapper(unet, cross_attention_dim, num_tokens, install_processors)
-        
+
     except Exception as e:
         print(f"create_ipadapter_wrapper: Error during model detection: {e}")
-        return IPAdapterUNetExportWrapper(unet, 768, num_tokens, install_processors) 
+        return IPAdapterUNetExportWrapper(unet, 768, num_tokens, install_processors)

--- a/src/streamdiffusion/acceleration/tensorrt/export_wrappers/unet_sdxl_export.py
+++ b/src/streamdiffusion/acceleration/tensorrt/export_wrappers/unet_sdxl_export.py
@@ -4,13 +4,17 @@ Handles the complexities of SDXL models with TensorRT including dual encoders,
 conditioning parameters, and Turbo variants
 """
 
+import logging
+from typing import Any, Dict
+
 import torch
-from typing import Dict, List, Optional, Tuple, Any, Union
 from diffusers import UNet2DConditionModel
+
 from ....model_detection import (
     detect_model,
 )
-import logging
+
+
 logger = logging.getLogger(__name__)
 
 # Handle different diffusers versions for CLIPTextModel import
@@ -18,7 +22,7 @@ try:
     from diffusers.models.transformers.clip_text_model import CLIPTextModel
 except ImportError:
     try:
-        from diffusers.models.clip_text_model import CLIPTextModel  
+        from diffusers.models.clip_text_model import CLIPTextModel
     except ImportError:
         try:
             from transformers import CLIPTextModel
@@ -29,79 +33,81 @@ except ImportError:
 
 class SDXLExportWrapper(torch.nn.Module):
     """Wrapper for SDXL UNet to handle optional conditioning in legacy TensorRT"""
-    
+
     def __init__(self, unet):
         super().__init__()
         self.unet = unet
         self.base_unet = self._get_base_unet(unet)
         self.supports_added_cond = self._test_added_cond_support()
-        
+
     def _get_base_unet(self, unet):
         """Extract the base UNet from wrappers"""
         # Handle ControlNet wrapper
-        if hasattr(unet, 'unet_model') and hasattr(unet.unet_model, 'config'):
+        if hasattr(unet, "unet_model") and hasattr(unet.unet_model, "config"):
             return unet.unet_model
-        elif hasattr(unet, 'unet') and hasattr(unet.unet, 'config'):
+        elif hasattr(unet, "unet") and hasattr(unet.unet, "config"):
             return unet.unet
-        elif hasattr(unet, 'config'):
+        elif hasattr(unet, "config"):
             return unet
         else:
             # Fallback: try to find any attribute that has config
             for attr_name in dir(unet):
-                if not attr_name.startswith('_'):
+                if not attr_name.startswith("_"):
                     attr = getattr(unet, attr_name, None)
-                    if hasattr(attr, 'config') and hasattr(attr.config, 'addition_embed_type'):
+                    if hasattr(attr, "config") and hasattr(attr.config, "addition_embed_type"):
                         return attr
             return unet
-        
+
     def _test_added_cond_support(self):
         """Test if this SDXL model supports added_cond_kwargs"""
         try:
             # Create minimal test inputs
-            sample = torch.randn(1, 4, 8, 8, device='cuda', dtype=torch.float16)
-            timestep = torch.tensor([0.5], device='cuda', dtype=torch.float32)
-            encoder_hidden_states = torch.randn(1, 77, 2048, device='cuda', dtype=torch.float16)
-            
+            sample = torch.randn(1, 4, 8, 8, device="cuda", dtype=torch.float16)
+            timestep = torch.tensor([0.5], device="cuda", dtype=torch.float32)
+            encoder_hidden_states = torch.randn(1, 77, 2048, device="cuda", dtype=torch.float16)
+
             # Test with added_cond_kwargs
             test_added_cond = {
-                'text_embeds': torch.randn(1, 1280, device='cuda', dtype=torch.float16),
-                'time_ids': torch.randn(1, 6, device='cuda', dtype=torch.float16)
+                "text_embeds": torch.randn(1, 1280, device="cuda", dtype=torch.float16),
+                "time_ids": torch.randn(1, 6, device="cuda", dtype=torch.float16),
             }
-            
+
             with torch.no_grad():
                 _ = self.unet(sample, timestep, encoder_hidden_states, added_cond_kwargs=test_added_cond)
-            
+
             logger.info("SDXL model supports added_cond_kwargs")
             return True
-            
+
         except Exception as e:
             logger.error(f"SDXL model does not support added_cond_kwargs: {e}")
             return False
-        
+
     def forward(self, *args, **kwargs):
         """Forward pass that handles SDXL conditioning gracefully"""
         try:
             # Ensure added_cond_kwargs is never None to prevent TypeError
-            if 'added_cond_kwargs' in kwargs and kwargs['added_cond_kwargs'] is None:
-                kwargs['added_cond_kwargs'] = {}
-            
+            if "added_cond_kwargs" in kwargs and kwargs["added_cond_kwargs"] is None:
+                kwargs["added_cond_kwargs"] = {}
+
             # Auto-generate SDXL conditioning if missing and model needs it
-            if (len(args) >= 3 and 'added_cond_kwargs' not in kwargs and 
-                hasattr(self.base_unet.config, 'addition_embed_type') and 
-                self.base_unet.config.addition_embed_type == 'text_time'):
-                
+            if (
+                len(args) >= 3
+                and "added_cond_kwargs" not in kwargs
+                and hasattr(self.base_unet.config, "addition_embed_type")
+                and self.base_unet.config.addition_embed_type == "text_time"
+            ):
                 sample = args[0]
                 device = sample.device
                 batch_size = sample.shape[0]
-                
+
                 logger.info("Auto-generating required SDXL conditioning...")
-                kwargs['added_cond_kwargs'] = {
-                    'text_embeds': torch.zeros(batch_size, 1280, device=device, dtype=sample.dtype),
-                    'time_ids': torch.zeros(batch_size, 6, device=device, dtype=sample.dtype)
+                kwargs["added_cond_kwargs"] = {
+                    "text_embeds": torch.zeros(batch_size, 1280, device=device, dtype=sample.dtype),
+                    "time_ids": torch.zeros(batch_size, 6, device=device, dtype=sample.dtype),
                 }
-                
+
             # If model supports added conditioning and we have the kwargs, use them
-            if self.supports_added_cond and 'added_cond_kwargs' in kwargs:
+            if self.supports_added_cond and "added_cond_kwargs" in kwargs:
                 result = self.unet(*args, **kwargs)
                 return result
             elif len(args) >= 3:
@@ -110,7 +116,7 @@ class SDXLExportWrapper(torch.nn.Module):
             else:
                 # Fallback
                 return self.unet(*args, **kwargs)
-                
+
         except (TypeError, AttributeError) as e:
             logger.error(f"[SDXL_WRAPPER] forward: Exception caught: {e}")
             if "NoneType" in str(e) or "iterable" in str(e) or "text_embeds" in str(e):
@@ -120,15 +126,17 @@ class SDXLExportWrapper(torch.nn.Module):
                     sample, timestep, encoder_hidden_states = args[0], args[1], args[2]
                     device = sample.device
                     batch_size = sample.shape[0]
-                    
+
                     # Create minimal valid SDXL conditioning
                     minimal_conditioning = {
-                        'text_embeds': torch.zeros(batch_size, 1280, device=device, dtype=sample.dtype),
-                        'time_ids': torch.zeros(batch_size, 6, device=device, dtype=sample.dtype)
+                        "text_embeds": torch.zeros(batch_size, 1280, device=device, dtype=sample.dtype),
+                        "time_ids": torch.zeros(batch_size, 6, device=device, dtype=sample.dtype),
                     }
-                    
+
                     try:
-                        return self.unet(sample, timestep, encoder_hidden_states, added_cond_kwargs=minimal_conditioning)
+                        return self.unet(
+                            sample, timestep, encoder_hidden_states, added_cond_kwargs=minimal_conditioning
+                        )
                     except Exception as final_e:
                         logger.info(f"Final fallback to basic call: {final_e}")
                         return self.unet(sample, timestep, encoder_hidden_states)
@@ -136,181 +144,180 @@ class SDXLExportWrapper(torch.nn.Module):
                     return self.unet(*args)
             else:
                 raise e
-            
+
+
 class SDXLConditioningHandler:
     """Handles SDXL conditioning parameters and dual text encoders"""
-    
+
     def __init__(self, unet_info: Dict[str, Any]):
         self.unet_info = unet_info
-        self.is_sdxl = unet_info['is_sdxl']
-        self.has_time_cond = unet_info['has_time_cond']
-        self.has_addition_embed = unet_info['has_addition_embed']
-    
+        self.is_sdxl = unet_info["is_sdxl"]
+        self.has_time_cond = unet_info["has_time_cond"]
+        self.has_addition_embed = unet_info["has_addition_embed"]
+
     def get_conditioning_spec(self) -> Dict[str, Any]:
         """Get conditioning specification for ONNX export and TensorRT"""
         spec = {
-            'text_encoder_dim': 768,  # CLIP ViT-L
-            'context_dim': 768,       # Default SD1.5
-            'pooled_embeds': False,
-            'time_ids': False,
-            'dual_encoders': False
+            "text_encoder_dim": 768,  # CLIP ViT-L
+            "context_dim": 768,  # Default SD1.5
+            "pooled_embeds": False,
+            "time_ids": False,
+            "dual_encoders": False,
         }
-        
+
         if self.is_sdxl:
-            spec.update({
-                'text_encoder_dim': 768,      # CLIP ViT-L  
-                'text_encoder_2_dim': 1280,   # OpenCLIP ViT-bigG
-                'context_dim': 2048,          # Concatenated 768 + 1280
-                'pooled_embeds': True,        # Pooled text embeddings
-                'time_ids': self.has_time_cond,  # Size/crop conditioning
-                'dual_encoders': True
-            })
-        
+            spec.update(
+                {
+                    "text_encoder_dim": 768,  # CLIP ViT-L
+                    "text_encoder_2_dim": 1280,  # OpenCLIP ViT-bigG
+                    "context_dim": 2048,  # Concatenated 768 + 1280
+                    "pooled_embeds": True,  # Pooled text embeddings
+                    "time_ids": self.has_time_cond,  # Size/crop conditioning
+                    "dual_encoders": True,
+                }
+            )
+
         return spec
-    
-    def create_sample_conditioning(self, batch_size: int = 1, device: str = 'cuda') -> Dict[str, torch.Tensor]:
+
+    def create_sample_conditioning(self, batch_size: int = 1, device: str = "cuda") -> Dict[str, torch.Tensor]:
         """Create sample conditioning tensors for testing/export"""
         spec = self.get_conditioning_spec()
         dtype = torch.float16
-        
+
         conditioning = {
-            'encoder_hidden_states': torch.randn(
-                batch_size, 77, spec['context_dim'], 
-                device=device, dtype=dtype
-            )
+            "encoder_hidden_states": torch.randn(batch_size, 77, spec["context_dim"], device=device, dtype=dtype)
         }
-        
-        if spec['pooled_embeds']:
-            conditioning['text_embeds'] = torch.randn(
-                batch_size, spec['text_encoder_2_dim'],
-                device=device, dtype=dtype
+
+        if spec["pooled_embeds"]:
+            conditioning["text_embeds"] = torch.randn(
+                batch_size, spec["text_encoder_2_dim"], device=device, dtype=dtype
             )
-        
-        if spec['time_ids']:
-            conditioning['time_ids'] = torch.randn(
-                batch_size, 6,  # [height, width, crop_h, crop_w, target_height, target_width]
-                device=device, dtype=dtype
+
+        if spec["time_ids"]:
+            conditioning["time_ids"] = torch.randn(
+                batch_size,
+                6,  # [height, width, crop_h, crop_w, target_height, target_width]
+                device=device,
+                dtype=dtype,
             )
-        
+
         return conditioning
-    
+
     def test_unet_conditioning(self, unet: UNet2DConditionModel) -> Dict[str, bool]:
         """Test what conditioning the UNet actually supports"""
-        results = {
-            'basic': False,
-            'added_cond_kwargs': False,
-            'separate_args': False
-        }
-        
+        results = {"basic": False, "added_cond_kwargs": False, "separate_args": False}
+
         try:
             # Ensure model is on CUDA and in eval mode for testing
-            device = 'cuda' if torch.cuda.is_available() else 'cpu'
+            device = "cuda" if torch.cuda.is_available() else "cpu"
             unet_test = unet.to(device).eval()
-            
+
             # Create test inputs on the same device
             sample = torch.randn(1, 4, 8, 8, device=device, dtype=torch.float16)
             timestep = torch.tensor([0.5], device=device, dtype=torch.float32)
             conditioning = self.create_sample_conditioning(1, device=device)
-            
+
             # Test basic call
             try:
                 with torch.no_grad():
-                    _ = unet_test(sample, timestep, conditioning['encoder_hidden_states'])
-                results['basic'] = True
+                    _ = unet_test(sample, timestep, conditioning["encoder_hidden_states"])
+                results["basic"] = True
             except Exception:
                 pass
-            
+
             # Test added_cond_kwargs (standard SDXL)
             if self.is_sdxl:
                 try:
                     added_cond = {}
-                    if 'text_embeds' in conditioning:
-                        added_cond['text_embeds'] = conditioning['text_embeds']
-                    if 'time_ids' in conditioning:
-                        added_cond['time_ids'] = conditioning['time_ids']
-                    
+                    if "text_embeds" in conditioning:
+                        added_cond["text_embeds"] = conditioning["text_embeds"]
+                    if "time_ids" in conditioning:
+                        added_cond["time_ids"] = conditioning["time_ids"]
+
                     with torch.no_grad():
-                        _ = unet_test(sample, timestep, conditioning['encoder_hidden_states'], 
-                               added_cond_kwargs=added_cond)
-                    results['added_cond_kwargs'] = True
+                        _ = unet_test(
+                            sample, timestep, conditioning["encoder_hidden_states"], added_cond_kwargs=added_cond
+                        )
+                    results["added_cond_kwargs"] = True
                 except Exception:
                     pass
-                
+
                 # Test separate arguments (some implementations)
                 try:
-                    args = [sample, timestep, conditioning['encoder_hidden_states']]
-                    if 'text_embeds' in conditioning:
-                        args.append(conditioning['text_embeds'])
-                    if 'time_ids' in conditioning:
-                        args.append(conditioning['time_ids'])
-                    
+                    args = [sample, timestep, conditioning["encoder_hidden_states"]]
+                    if "text_embeds" in conditioning:
+                        args.append(conditioning["text_embeds"])
+                    if "time_ids" in conditioning:
+                        args.append(conditioning["time_ids"])
+
                     with torch.no_grad():
                         _ = unet_test(*args)
-                    results['separate_args'] = True
+                    results["separate_args"] = True
                 except Exception:
                     pass
-                    
+
         except Exception as e:
             # If testing fails completely, provide safe defaults
             print(f"⚠️ UNet conditioning test setup failed: {e}")
             results = {
-                'basic': True,  # Assume basic call works
-                'added_cond_kwargs': self.is_sdxl,  # Assume SDXL models support this
-                'separate_args': False
+                "basic": True,  # Assume basic call works
+                "added_cond_kwargs": self.is_sdxl,  # Assume SDXL models support this
+                "separate_args": False,
             }
-        
+
         return results
 
     def get_onnx_export_spec(self) -> Dict[str, Any]:
         """Get specification for ONNX export"""
         spec = self.conditioning_handler.get_conditioning_spec()
-        
-        # Add export-specific details
-        spec.update({
-            'input_names': ['sample', 'timestep', 'encoder_hidden_states'],
-            'output_names': ['noise_pred'],
-            'dynamic_axes': {
-                'sample': {0: 'batch_size'},
-                'timestep': {0: 'batch_size'},
-                'encoder_hidden_states': {0: 'batch_size'},
-                'noise_pred': {0: 'batch_size'}
-            }
-        })
-        
-        # Add SDXL-specific inputs if supported
-        if self.is_sdxl and self.supported_calls['added_cond_kwargs']:
-            if spec['pooled_embeds']:
-                spec['input_names'].append('text_embeds')
-                spec['dynamic_axes']['text_embeds'] = {0: 'batch_size'}
-            
-            if spec['time_ids']:
-                spec['input_names'].append('time_ids')
-                spec['dynamic_axes']['time_ids'] = {0: 'batch_size'}
-        
-        return spec
 
+        # Add export-specific details
+        spec.update(
+            {
+                "input_names": ["sample", "timestep", "encoder_hidden_states"],
+                "output_names": ["noise_pred"],
+                "dynamic_axes": {
+                    "sample": {0: "batch_size"},
+                    "timestep": {0: "batch_size"},
+                    "encoder_hidden_states": {0: "batch_size"},
+                    "noise_pred": {0: "batch_size"},
+                },
+            }
+        )
+
+        # Add SDXL-specific inputs if supported
+        if self.is_sdxl and self.supported_calls["added_cond_kwargs"]:
+            if spec["pooled_embeds"]:
+                spec["input_names"].append("text_embeds")
+                spec["dynamic_axes"]["text_embeds"] = {0: "batch_size"}
+
+            if spec["time_ids"]:
+                spec["input_names"].append("time_ids")
+                spec["dynamic_axes"]["time_ids"] = {0: "batch_size"}
+
+        return spec
 
 
 def get_sdxl_tensorrt_config(model_path: str, unet: UNet2DConditionModel) -> Dict[str, Any]:
     """Get complete TensorRT configuration for SDXL model"""
     # Use the new detection function
     detection_result = detect_model(unet)
-    
+
     # Create a config dict compatible with SDXLConditioningHandler
     config = {
-        'is_sdxl': detection_result['is_sdxl'],
-        'has_time_cond': detection_result['architecture_details']['has_time_conditioning'],
-        'has_addition_embed': detection_result['architecture_details']['has_addition_embeds'],
-        'model_type': detection_result['model_type'],
-        'is_turbo': detection_result['is_turbo'],
-        'is_sd3': detection_result['is_sd3'],
-        'confidence': detection_result['confidence'],
-        'architecture_details': detection_result['architecture_details'],
-        'compatibility_info': detection_result['compatibility_info']
+        "is_sdxl": detection_result["is_sdxl"],
+        "has_time_cond": detection_result["architecture_details"]["has_time_conditioning"],
+        "has_addition_embed": detection_result["architecture_details"]["has_addition_embeds"],
+        "model_type": detection_result["model_type"],
+        "is_turbo": detection_result["is_turbo"],
+        "is_sd3": detection_result["is_sd3"],
+        "confidence": detection_result["confidence"],
+        "architecture_details": detection_result["architecture_details"],
+        "compatibility_info": detection_result["compatibility_info"],
     }
-    
+
     # Add conditioning specification
     conditioning_handler = SDXLConditioningHandler(config)
-    config['conditioning_spec'] = conditioning_handler.get_conditioning_spec()
-    
+    config["conditioning_spec"] = conditioning_handler.get_conditioning_spec()
+
     return config

--- a/src/streamdiffusion/acceleration/tensorrt/export_wrappers/unet_unified_export.py
+++ b/src/streamdiffusion/acceleration/tensorrt/export_wrappers/unet_unified_export.py
@@ -1,23 +1,28 @@
+from typing import List, Optional
+
 import torch
 from diffusers import UNet2DConditionModel
-from typing import Optional, List
+
+from ..models.utils import convert_list_to_structure
 from .unet_controlnet_export import create_controlnet_wrapper
 from .unet_ipadapter_export import create_ipadapter_wrapper
-from ..models.utils import convert_list_to_structure
+
 
 class UnifiedExportWrapper(torch.nn.Module):
     """
-    Unified wrapper that composes wrappers for conditioning modules. 
+    Unified wrapper that composes wrappers for conditioning modules.
     """
-    
-    def __init__(self, 
-                 unet: UNet2DConditionModel, 
-                 use_controlnet: bool = False,
-                 use_ipadapter: bool = False,
-                 control_input_names: Optional[List[str]] = None,
-                 num_tokens: int = 4,
-                 kvo_cache_structure: List[int] = [],
-                 **kwargs):
+
+    def __init__(
+        self,
+        unet: UNet2DConditionModel,
+        use_controlnet: bool = False,
+        use_ipadapter: bool = False,
+        control_input_names: Optional[List[str]] = None,
+        num_tokens: int = 4,
+        kvo_cache_structure: List[int] = [],
+        **kwargs,
+    ):
         super().__init__()
         self.use_controlnet = use_controlnet
         self.use_ipadapter = use_ipadapter
@@ -25,23 +30,24 @@ class UnifiedExportWrapper(torch.nn.Module):
         self.ipadapter_wrapper = None
         self.unet = unet
         self.kvo_cache_structure = kvo_cache_structure
-        
+
         # Apply IPAdapter first (installs processors into UNet)
         if use_ipadapter:
-            ipadapter_kwargs = {k: v for k, v in kwargs.items() if k in ['install_processors']}
-            if 'install_processors' not in ipadapter_kwargs:
-                ipadapter_kwargs['install_processors'] = True
-            
+            ipadapter_kwargs = {k: v for k, v in kwargs.items() if k in ["install_processors"]}
+            if "install_processors" not in ipadapter_kwargs:
+                ipadapter_kwargs["install_processors"] = True
 
             self.ipadapter_wrapper = create_ipadapter_wrapper(unet, num_tokens=num_tokens, **ipadapter_kwargs)
             self.unet = self.ipadapter_wrapper.unet
-        
+
         # Apply ControlNet second (wraps whatever UNet we have)
         if use_controlnet and control_input_names:
-            controlnet_kwargs = {k: v for k, v in kwargs.items() if k in ['num_controlnets', 'conditioning_scales']}
+            controlnet_kwargs = {k: v for k, v in kwargs.items() if k in ["num_controlnets", "conditioning_scales"]}
 
-            self.controlnet_wrapper = create_controlnet_wrapper(self.unet, control_input_names, kvo_cache_structure, **controlnet_kwargs)
-        
+            self.controlnet_wrapper = create_controlnet_wrapper(
+                self.unet, control_input_names, kvo_cache_structure, **controlnet_kwargs
+            )
+
     def _basic_unet_forward(self, sample, timestep, encoder_hidden_states, *kvo_cache, **kwargs):
         """Basic UNet forward that passes through all parameters to handle any model type"""
         formatted_kvo_cache = []
@@ -49,52 +55,57 @@ class UnifiedExportWrapper(torch.nn.Module):
             formatted_kvo_cache = convert_list_to_structure(kvo_cache, self.kvo_cache_structure)
 
         # Auto-generate SDXL conditioning if missing and UNet requires it
-        if 'added_cond_kwargs' not in kwargs or kwargs.get('added_cond_kwargs') is None:
+        if "added_cond_kwargs" not in kwargs or kwargs.get("added_cond_kwargs") is None:
             base_unet = self.unet
-            if (hasattr(base_unet, 'config') and
-                    getattr(base_unet.config, 'addition_embed_type', None) == 'text_time'):
+            if hasattr(base_unet, "config") and getattr(base_unet.config, "addition_embed_type", None) == "text_time":
                 batch_size = sample.shape[0]
-                kwargs['added_cond_kwargs'] = {
-                    'text_embeds': torch.zeros(batch_size, 1280, device=sample.device, dtype=sample.dtype),
-                    'time_ids': torch.zeros(batch_size, 6, device=sample.device, dtype=sample.dtype),
+                kwargs["added_cond_kwargs"] = {
+                    "text_embeds": torch.zeros(batch_size, 1280, device=sample.device, dtype=sample.dtype),
+                    "time_ids": torch.zeros(batch_size, 6, device=sample.device, dtype=sample.dtype),
                 }
 
         unet_kwargs = {
-            'sample': sample,
-            'timestep': timestep,
-            'encoder_hidden_states': encoder_hidden_states,
-            'return_dict': False,
-            'kvo_cache': formatted_kvo_cache,
-            **kwargs  # Pass through all additional parameters (SDXL, future model types, etc.)
+            "sample": sample,
+            "timestep": timestep,
+            "encoder_hidden_states": encoder_hidden_states,
+            "return_dict": False,
+            "kvo_cache": formatted_kvo_cache,
+            **kwargs,  # Pass through all additional parameters (SDXL, future model types, etc.)
         }
         res = self.unet(**unet_kwargs)
         if len(kvo_cache) > 0:
             return res
         else:
             return res[0]
-        
-    def forward(self, 
-                sample: torch.Tensor,
-                timestep: torch.Tensor, 
-                encoder_hidden_states: torch.Tensor,
-                *args,
-                **kwargs) -> torch.Tensor:
+
+    def forward(
+        self, sample: torch.Tensor, timestep: torch.Tensor, encoder_hidden_states: torch.Tensor, *args, **kwargs
+    ) -> torch.Tensor:
         """Forward pass that handles any UNet parameters via **kwargs passthrough"""
         # Handle IP-Adapter runtime scale vector as a positional argument placed before control tensors
         if self.use_ipadapter and self.ipadapter_wrapper is not None:
             # ipadapter_scale is appended as the first extra positional input after the 3 base inputs
             if len(args) == 0:
                 import logging
-                logging.getLogger(__name__).error("UnifiedExportWrapper: ipadapter_scale missing; required when use_ipadapter=True")
+
+                logging.getLogger(__name__).error(
+                    "UnifiedExportWrapper: ipadapter_scale missing; required when use_ipadapter=True"
+                )
                 raise RuntimeError("UnifiedExportWrapper: ipadapter_scale tensor is required when use_ipadapter=True")
             ipadapter_scale = args[0]
             if not isinstance(ipadapter_scale, torch.Tensor):
                 import logging
-                logging.getLogger(__name__).error(f"UnifiedExportWrapper: ipadapter_scale wrong type: {type(ipadapter_scale)}")
+
+                logging.getLogger(__name__).error(
+                    f"UnifiedExportWrapper: ipadapter_scale wrong type: {type(ipadapter_scale)}"
+                )
                 raise TypeError("ipadapter_scale must be a torch.Tensor")
             try:
                 import logging
-                logging.getLogger(__name__).debug(f"UnifiedExportWrapper: ipadapter_scale shape={tuple(ipadapter_scale.shape)}, dtype={ipadapter_scale.dtype}")
+
+                logging.getLogger(__name__).debug(
+                    f"UnifiedExportWrapper: ipadapter_scale shape={tuple(ipadapter_scale.shape)}, dtype={ipadapter_scale.dtype}"
+                )
             except Exception:
                 pass
             # assign per-layer scale tensors into processors
@@ -107,4 +118,4 @@ class UnifiedExportWrapper(torch.nn.Module):
             return self.controlnet_wrapper(sample, timestep, encoder_hidden_states, *args, **kwargs)
         else:
             # Basic UNet call with all parameters passed through
-            return self._basic_unet_forward(sample, timestep, encoder_hidden_states, *args, **kwargs) 
+            return self._basic_unet_forward(sample, timestep, encoder_hidden_states, *args, **kwargs)

--- a/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
+++ b/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
@@ -223,9 +223,10 @@ def quantize_onnx_fp8(
         onnx_fp8_path: Output FP8 quantized ONNX path (*.fp8.onnx).
         calibration_data: Unused. Kept for backward compatibility.
         quantize_mha: Enable FP8 quantization of multi-head attention ops.
-                      Recommended: True. Requires TRT 10+ and compute 8.9+.
-        percentile: Percentile for activation range calibration.
-                    1.0 = no clipping (safest for first run).
+                      Kept False — MHA analysis via ORT inference adds ~3 hours to build.
+                      Non-MHA ops (Conv, Gemm, MatMul outside MHA) are still FP8.
+        percentile: Unused. Kept for backward compatibility (entropy calibration
+                    does not use percentile clipping).
         alpha: SmoothQuant alpha — balances quantization difficulty between
                activations (alpha→0) and weights (alpha→1). 0.8 is optimal
                for transformer attention layers.
@@ -256,7 +257,7 @@ def quantize_onnx_fp8(
     logger.info(f"[FP8] Starting ONNX FP8 quantization")
     logger.info(f"[FP8]   Input:  {onnx_opt_path} ({input_size_mb:.0f} MB)")
     logger.info(f"[FP8]   Output: {onnx_fp8_path}")
-    logger.info(f"[FP8]   Config: quantize_mha={quantize_mha}, percentile={percentile}, alpha={alpha}")
+    logger.info(f"[FP8]   Config: quantize_mha={quantize_mha}, calibration=entropy, alpha={alpha}")
     logger.info(f"[FP8]   Calibration: RandomDataProvider with calibration_shapes (model_data={'provided' if model_data is not None else 'none'})")
 
     # Patch ByteSize() for >2GB ONNX models: modelopt calls onnx_model.ByteSize()
@@ -373,8 +374,10 @@ def quantize_onnx_fp8(
     quantize_kwargs = {
         "quantize_mode": "fp8",
         "output_path": onnx_fp8_path,
-        "calibration_method": "percentile",
-        "percentile": percentile,
+        # entropy: minimizes KL divergence to find optimal clipping point for each tensor.
+        # Better than percentile=1.0 (no clipping) which allows outliers to stretch the
+        # quantization range, reducing precision for the bulk of activations.
+        "calibration_method": "entropy",
         "alpha": alpha,
         "use_external_data_format": True,
         # override_shapes replaces dynamic dims in the ONNX model itself with static
@@ -388,20 +391,23 @@ def quantize_onnx_fp8(
         # Use default EPs ["cpu","cuda:0","trt"] — CPU-only would fail on this FP16 SDXL
         # model because ORT's mandatory CastFloat16Transformer inserts Cast nodes that
         # conflict with existing Cast nodes in the upsampler conv.
-        # disable_mha_qdq controls modelopt's MHA analysis. When True, MHA MatMul
-        # nodes are excluded from FP8 quantization WITHOUT running ORT inference.
-        # Non-MHA ops (Conv, Linear, LayerNorm) still get FP8 Q/DQ nodes.
+        # disable_mha_qdq=True: skip MHA pattern analysis (avoids 3-hour ORT inference
+        # pass over the full model graph). Non-MHA ops (Conv, Gemm, MatMul outside MHA)
+        # still get FP8 Q/DQ nodes via the normal KGEN/CASK path.
         "disable_mha_qdq": not quantize_mha,
+        # calibrate_per_node: calibrate one node at a time to reduce peak VRAM during
+        # calibration. Essential for large UNets (83 inputs, 7993 nodes) to avoid OOM.
+        "calibrate_per_node": True,
     }
 
     try:
         modelopt_quantize(onnx_opt_path, **quantize_kwargs)
     except TypeError as e:
-        # Older nvidia-modelopt versions may not support alpha/disable_mha_qdq.
-        # Retry with base parameters only.
-        logger.warning(f"[FP8] Retrying without alpha/disable_mha_qdq (TypeError: {e})")
-        quantize_kwargs.pop("alpha", None)
-        quantize_kwargs.pop("disable_mha_qdq", None)
+        # Older nvidia-modelopt versions may not support newer kwargs.
+        # Strip down to base parameters and retry.
+        logger.warning(f"[FP8] Retrying with reduced kwargs (TypeError: {e})")
+        for _k in ("alpha", "disable_mha_qdq", "calibrate_per_node"):
+            quantize_kwargs.pop(_k, None)
         modelopt_quantize(onnx_opt_path, **quantize_kwargs)
     except Exception as e:
         # MHA analysis (disable_mha_qdq=False) requires an ORT inference run that

--- a/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
+++ b/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
@@ -26,7 +26,7 @@ def generate_unet_calibration_data(
     opt_batch_size: int,
     opt_image_height: int,
     opt_image_width: int,
-    num_batches: int = 128,
+    num_batches: int = 8,
 ) -> List[Dict[str, np.ndarray]]:
     """
     Generate calibration data for SDXL-Turbo UNet FP8 quantization.
@@ -42,7 +42,10 @@ def generate_unet_calibration_data(
                         because cond + uncond are batched together.
         opt_image_height: Optimal image height in pixels (e.g. 512).
         opt_image_width: Optimal image width in pixels (e.g. 512).
-        num_batches: Number of calibration batches. NVIDIA recommends 128.
+        num_batches: Number of calibration batches. Capped at 8 for SDXL-scale
+                     models: each batch contains 70 KVO cache tensors (~2.2 GB),
+                     so 128 batches would require ~281 GB RAM. FP8 is less
+                     sensitive to calibration size than INT8 (wider dynamic range).
 
     Returns:
         List of dicts: [{input_name: np.ndarray}, ...] — one dict per batch.

--- a/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
+++ b/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
@@ -1,0 +1,221 @@
+"""
+FP8 Quantization for StreamDiffusion TensorRT UNet engine.
+
+Uses nvidia-modelopt for ONNX-level FP8 quantization via Q/DQ node insertion.
+The quantized ONNX is then compiled to TRT with STRONGLY_TYPED + FP8 builder flags.
+
+Requirements:
+    nvidia-modelopt[onnx] >= 0.35.0
+    TensorRT >= 10.0 (FP8 support)
+    RTX 4090+ (Ada Lovelace, compute 8.9, FP8 E4M3 hardware support)
+
+This module is called from builder.py when fp8=True is passed to EngineBuilder.build().
+"""
+
+import logging
+import os
+from typing import Dict, List, Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def generate_unet_calibration_data(
+    model_data,
+    opt_batch_size: int,
+    opt_image_height: int,
+    opt_image_width: int,
+    num_batches: int = 128,
+) -> List[Dict[str, np.ndarray]]:
+    """
+    Generate calibration data for SDXL-Turbo UNet FP8 quantization.
+
+    Returns a list of input dicts matching the ONNX model's input names,
+    with values as numpy arrays shaped to the TRT optimization profile's opt shapes.
+
+    Args:
+        model_data: UNet BaseModel instance (provides input names, kvo_cache_shapes,
+                    text_maxlen, embedding_dim, cache_maxframes).
+        opt_batch_size: Optimal batch size from TRT profile (typically 1 for
+                        frame_buffer_size=1). The UNet input dim is 2*opt_batch_size
+                        because cond + uncond are batched together.
+        opt_image_height: Optimal image height in pixels (e.g. 512).
+        opt_image_width: Optimal image width in pixels (e.g. 512).
+        num_batches: Number of calibration batches. NVIDIA recommends 128.
+
+    Returns:
+        List of dicts: [{input_name: np.ndarray}, ...] — one dict per batch.
+    """
+    latent_h = opt_image_height // 8
+    latent_w = opt_image_width // 8
+    # UNet always receives 2× the batch (cond + uncond paired)
+    effective_batch = 2 * opt_batch_size
+
+    input_names = model_data.get_input_names()
+
+    # Fixed seed for reproducible calibration
+    rng = np.random.default_rng(seed=42)
+
+    # Pre-read model_data properties once to avoid repeated attribute access
+    text_maxlen = getattr(model_data, "text_maxlen", 77)
+    embedding_dim = getattr(model_data, "embedding_dim", 2048)
+    cache_maxframes = getattr(model_data, "cache_maxframes", 4)
+    kvo_cache_shapes = getattr(model_data, "kvo_cache_shapes", [])
+    num_ip_layers = getattr(model_data, "num_ip_layers", 1)
+    control_inputs = getattr(model_data, "control_inputs", {})
+
+    calibration_dataset = []
+
+    for i in range(num_batches):
+        batch_data = {}
+
+        for name in input_names:
+            if name == "sample":
+                # Noisy latents in float32 (UNet ingests fp32 sample before internal autocast)
+                # VAE latent scale: 0.18215 for SDXL
+                data = (rng.standard_normal((effective_batch, 4, latent_h, latent_w)) * 0.18215)
+                batch_data[name] = data.astype(np.float32)
+
+            elif name == "timestep":
+                # Timesteps: float32, shape (effective_batch,)
+                # Sample broadly across [0, 999] to cover full activation range.
+                t = rng.integers(0, 1000, size=(effective_batch,))
+                batch_data[name] = t.astype(np.float32)
+
+            elif name == "encoder_hidden_states":
+                # CLIP/OpenCLIP text embeddings: float16 for fp16 SDXL models
+                # Scale 0.01 approximates typical normalized text embedding magnitude.
+                data = (rng.standard_normal((effective_batch, text_maxlen, embedding_dim)) * 0.01)
+                batch_data[name] = data.astype(np.float16)
+
+            elif name == "ipadapter_scale":
+                # IP-Adapter per-layer scale: float32, shape (num_ip_layers,)
+                batch_data[name] = np.ones((num_ip_layers,), dtype=np.float32)
+
+            elif name.startswith("input_control_"):
+                # ControlNet residual tensors: float16
+                if name in control_inputs:
+                    spec = control_inputs[name]
+                    data = rng.standard_normal(
+                        (effective_batch, spec["channels"], spec["height"], spec["width"])
+                    )
+                    batch_data[name] = data.astype(np.float16)
+
+            elif name.startswith("kvo_cache_in_"):
+                # KVO cached attention inputs: float16
+                # shape = (2, cache_maxframes, effective_batch, seq_len, hidden_dim)
+                # Zeros = cold cache. Conservative but avoids over-fitting calibration
+                # ranges to cached-attention activation patterns.
+                idx = int(name.rsplit("_", 1)[-1])
+                if idx < len(kvo_cache_shapes):
+                    seq_len, hidden_dim = kvo_cache_shapes[idx]
+                    batch_data[name] = np.zeros(
+                        (2, cache_maxframes, effective_batch, seq_len, hidden_dim),
+                        dtype=np.float16,
+                    )
+
+        calibration_dataset.append(batch_data)
+
+    logger.info(
+        f"[FP8] Generated {num_batches} calibration batches "
+        f"(effective_batch={effective_batch}, latent={latent_h}x{latent_w}, "
+        f"inputs={len(input_names)}, kvo_count={len(kvo_cache_shapes)})"
+    )
+    return calibration_dataset
+
+
+def quantize_onnx_fp8(
+    onnx_opt_path: str,
+    onnx_fp8_path: str,
+    calibration_data: List[Dict[str, np.ndarray]],
+    quantize_mha: bool = True,
+    percentile: float = 1.0,
+    alpha: float = 0.8,
+) -> None:
+    """
+    Insert FP8 Q/DQ nodes into an optimized ONNX model via nvidia-modelopt.
+
+    Takes the FP16-optimized ONNX (*.opt.onnx), runs calibration to collect
+    activation ranges, and writes a new ONNX with QuantizeLinear/DequantizeLinear
+    nodes annotated for FP8 E4M3 precision. TRT compiles this with
+    STRONGLY_TYPED + FP8 builder flags.
+
+    Args:
+        onnx_opt_path: Input FP16 optimized ONNX path (*.opt.onnx).
+        onnx_fp8_path: Output FP8 quantized ONNX path (*.fp8.onnx).
+        calibration_data: List of input dicts from generate_unet_calibration_data().
+        quantize_mha: Enable FP8 quantization of multi-head attention ops.
+                      Recommended: True. Requires TRT 10+ and compute 8.9+.
+        percentile: Percentile for activation range calibration.
+                    1.0 = no clipping (safest for first run).
+        alpha: SmoothQuant alpha — balances quantization difficulty between
+               activations (alpha→0) and weights (alpha→1). 0.8 is optimal
+               for transformer attention layers.
+    """
+    try:
+        from modelopt.onnx.quantization import quantize as modelopt_quantize
+    except ImportError as e:
+        raise ImportError(
+            "nvidia-modelopt is required for FP8 quantization. "
+            "Install with: pip install 'nvidia-modelopt[onnx]'"
+        ) from e
+
+    input_size_mb = os.path.getsize(onnx_opt_path) / (1024 * 1024)
+    logger.info(f"[FP8] Starting ONNX FP8 quantization")
+    logger.info(f"[FP8]   Input:  {onnx_opt_path} ({input_size_mb:.0f} MB)")
+    logger.info(f"[FP8]   Output: {onnx_fp8_path}")
+    logger.info(f"[FP8]   Config: quantize_mha={quantize_mha}, percentile={percentile}, alpha={alpha}")
+    logger.info(f"[FP8]   Calibration batches: {len(calibration_data)}")
+
+    # Patch ByteSize() for >2GB ONNX models: modelopt calls onnx_model.ByteSize()
+    # to auto-detect external data format, but protobuf cannot serialize >2GB protos.
+    # Return a large value on failure so modelopt correctly uses external data format.
+    import onnx as _onnx
+    from google.protobuf.message import EncodeError as _EncodeError
+
+    _orig_byte_size = _onnx.ModelProto.ByteSize
+
+    def _safe_byte_size(self):
+        try:
+            return _orig_byte_size(self)
+        except _EncodeError:
+            return 3 * (1024**3)  # >2GB → triggers external data format
+
+    _onnx.ModelProto.ByteSize = _safe_byte_size
+
+    quantize_kwargs = {
+        "quantize_mode": "fp8",
+        "output_path": onnx_fp8_path,
+        "calibration_data": calibration_data,
+        "calibration_method": "percentile",
+        "percentile": percentile,
+        "alpha": alpha,
+        "use_external_data_format": True,
+    }
+    if quantize_mha:
+        quantize_kwargs["quantize_mha"] = True
+
+    try:
+        modelopt_quantize(onnx_opt_path, **quantize_kwargs)
+    except TypeError as e:
+        # Older nvidia-modelopt versions may not support alpha / quantize_mha.
+        # Retry with base parameters only.
+        logger.warning(f"[FP8] Retrying without alpha/quantize_mha (API error: {e})")
+        quantize_kwargs.pop("alpha", None)
+        quantize_kwargs.pop("quantize_mha", None)
+        modelopt_quantize(onnx_opt_path, **quantize_kwargs)
+    finally:
+        _onnx.ModelProto.ByteSize = _orig_byte_size  # Restore original method
+
+    if not os.path.exists(onnx_fp8_path):
+        raise RuntimeError(
+            f"[FP8] Quantization completed but output file not found: {onnx_fp8_path}"
+        )
+
+    output_size_mb = os.path.getsize(onnx_fp8_path) / (1024 * 1024)
+    ratio = output_size_mb / input_size_mb if input_size_mb > 0 else 0
+    logger.info(
+        f"[FP8] Quantization complete: {input_size_mb:.0f} MB → {output_size_mb:.0f} MB "
+        f"(ratio: {ratio:.2f}x)"
+    )

--- a/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
+++ b/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
@@ -21,6 +21,71 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 
+def _restore_dynamic_axes(onnx_fp8_path: str, model_data) -> None:
+    """Restore dynamic dim_param symbols in FP8 ONNX after ModelOpt quantization.
+
+    ModelOpt's override_shapes replaces dim_param with static dim_value for
+    calibration. TRT requires dynamic dims (dim_param) on inputs/outputs to
+    accept optimization profiles (min/opt/max ranges). This reads the original
+    dynamic_axes from model_data and restores them in the FP8 ONNX.
+
+    Uses load_external_data=False so only the small protobuf is loaded/modified,
+    leaving the ~23GB external weight file untouched.
+    """
+    import onnx
+
+    try:
+        dynamic_axes = model_data.get_dynamic_axes()
+    except Exception as e:
+        logger.warning(f"[FP8] Could not get dynamic_axes from model_data: {e}. Skipping restore.")
+        return
+
+    if not dynamic_axes:
+        logger.warning("[FP8] dynamic_axes is empty — skipping dynamic dim restore.")
+        return
+
+    model = onnx.load(onnx_fp8_path, load_external_data=False)
+
+    restored_count = 0
+    for graph_input in model.graph.input:
+        name = graph_input.name
+        if name not in dynamic_axes:
+            continue
+        axes = dynamic_axes[name]
+        dims = graph_input.type.tensor_type.shape.dim
+        for dim_idx, symbolic_name in axes.items():
+            if dim_idx < len(dims):
+                dim = dims[dim_idx]
+                dim.ClearField("dim_value")
+                dim.dim_param = symbolic_name
+                restored_count += 1
+
+    for graph_output in model.graph.output:
+        name = graph_output.name
+        if name not in dynamic_axes:
+            continue
+        axes = dynamic_axes[name]
+        dims = graph_output.type.tensor_type.shape.dim
+        for dim_idx, symbolic_name in axes.items():
+            if dim_idx < len(dims):
+                dim = dims[dim_idx]
+                dim.ClearField("dim_value")
+                dim.dim_param = symbolic_name
+                restored_count += 1
+
+    if restored_count == 0:
+        logger.warning("[FP8] No dynamic dimensions restored — graph inputs may already be dynamic.")
+        return
+
+    # Save only the protobuf (weight data stays in existing external file).
+    # load_external_data=False keeps tensor data_location=EXTERNAL references intact,
+    # so onnx.save() writes a small protobuf that still points to the existing _data file.
+    onnx.save(model, onnx_fp8_path)
+    logger.info(
+        f"[FP8] Restored {restored_count} dynamic dimensions in {os.path.basename(onnx_fp8_path)}"
+    )
+
+
 def generate_unet_calibration_data(
     model_data,
     opt_batch_size: int,
@@ -107,14 +172,19 @@ def generate_unet_calibration_data(
 
             elif name.startswith("kvo_cache_in_"):
                 # KVO cached attention inputs: float16
-                # shape = (2, cache_maxframes, effective_batch, seq_len, hidden_dim)
+                # shape = (2, cache_maxframes, kvo_calib_batch, seq_len, hidden_dim)
+                # dim[0]=2: K/V pair (must match ONNX trace, which always uses 2).
+                # dim[2]: Must equal sample's batch dimension (effective_batch = 2 * opt_batch_size)
+                # because both share the ONNX dynamic axis "2B". Using a different value
+                # causes Concat dimension mismatches in attention layers during calibration.
                 # Zeros = cold cache. Conservative but avoids over-fitting calibration
                 # ranges to cached-attention activation patterns.
                 idx = int(name.rsplit("_", 1)[-1])
                 if idx < len(kvo_cache_shapes):
                     seq_len, hidden_dim = kvo_cache_shapes[idx]
+                    kvo_calib_batch = effective_batch  # Must match sample batch (ONNX axis "2B")
                     batch_data[name] = np.zeros(
-                        (2, cache_maxframes, effective_batch, seq_len, hidden_dim),
+                        (2, cache_maxframes, kvo_calib_batch, seq_len, hidden_dim),
                         dtype=np.float16,
                     )
 
@@ -131,10 +201,14 @@ def generate_unet_calibration_data(
 def quantize_onnx_fp8(
     onnx_opt_path: str,
     onnx_fp8_path: str,
-    calibration_data: List[Dict[str, np.ndarray]],
-    quantize_mha: bool = True,
+    calibration_data: Optional[List[Dict[str, np.ndarray]]] = None,
+    quantize_mha: bool = False,
     percentile: float = 1.0,
     alpha: float = 0.8,
+    model_data=None,
+    opt_batch_size: int = 1,
+    opt_image_height: int = 512,
+    opt_image_width: int = 512,
 ) -> None:
     """
     Insert FP8 Q/DQ nodes into an optimized ONNX model via nvidia-modelopt.
@@ -147,7 +221,7 @@ def quantize_onnx_fp8(
     Args:
         onnx_opt_path: Input FP16 optimized ONNX path (*.opt.onnx).
         onnx_fp8_path: Output FP8 quantized ONNX path (*.fp8.onnx).
-        calibration_data: List of input dicts from generate_unet_calibration_data().
+        calibration_data: Unused. Kept for backward compatibility.
         quantize_mha: Enable FP8 quantization of multi-head attention ops.
                       Recommended: True. Requires TRT 10+ and compute 8.9+.
         percentile: Percentile for activation range calibration.
@@ -155,6 +229,11 @@ def quantize_onnx_fp8(
         alpha: SmoothQuant alpha — balances quantization difficulty between
                activations (alpha→0) and weights (alpha→1). 0.8 is optimal
                for transformer attention layers.
+        model_data: UNet BaseModel instance for building calibration_shapes.
+                    If None, RandomDataProvider defaults all dynamic dims to 1.
+        opt_batch_size: Optimal batch size from TRT profile.
+        opt_image_height: Optimal image height in pixels.
+        opt_image_width: Optimal image width in pixels.
     """
     try:
         from modelopt.onnx.quantization import quantize as modelopt_quantize
@@ -164,12 +243,21 @@ def quantize_onnx_fp8(
             "Install with: pip install 'nvidia-modelopt[onnx]'"
         ) from e
 
+    # Enable verbose ORT logging so Memcpy node details are visible before the
+    # summary warning. Severity 1 = INFO (shows per-node placement decisions).
+    try:
+        import onnxruntime as _ort
+        _ort.set_default_logger_severity(1)
+        logger.info("[FP8] ORT log_severity_level set to 1 (INFO) for Memcpy diagnostics")
+    except Exception:
+        pass
+
     input_size_mb = os.path.getsize(onnx_opt_path) / (1024 * 1024)
     logger.info(f"[FP8] Starting ONNX FP8 quantization")
     logger.info(f"[FP8]   Input:  {onnx_opt_path} ({input_size_mb:.0f} MB)")
     logger.info(f"[FP8]   Output: {onnx_fp8_path}")
     logger.info(f"[FP8]   Config: quantize_mha={quantize_mha}, percentile={percentile}, alpha={alpha}")
-    logger.info(f"[FP8]   Calibration batches: {len(calibration_data)}")
+    logger.info(f"[FP8]   Calibration: RandomDataProvider with calibration_shapes (model_data={'provided' if model_data is not None else 'none'})")
 
     # Patch ByteSize() for >2GB ONNX models: modelopt calls onnx_model.ByteSize()
     # to auto-detect external data format, but protobuf cannot serialize >2GB protos.
@@ -212,68 +300,161 @@ def quantize_onnx_fp8(
             os.environ["PATH"] = os.pathsep.join(_bin_dirs) + os.pathsep + os.environ.get("PATH", "")
             logger.info(f"[FP8] Added {len(_bin_dirs)} NVIDIA DLL dirs to PATH")
 
-    # modelopt's CalibrationDataProvider expects a single dict {name: ndarray} where
-    # each value has exactly the model's input rank. np.stack would add an extra
-    # calibration-sample dimension (rank+1), causing ORT "Invalid rank" errors.
-    # Use first batch — one batch with effective_batch samples is sufficient for FP8
-    # (wider dynamic range than INT8, less sensitive to calibration volume).
-    if isinstance(calibration_data, list) and calibration_data:
-        logger.info(f"[FP8] Using first calibration batch of {len(calibration_data)} ({len(calibration_data[0])} inputs)")
-        calibration_data = calibration_data[0]
+    # Build calibration_shapes string for modelopt's RandomDataProvider.
+    # RandomDataProvider calls _get_tensor_shape() which sets ALL dynamic dims to 1.
+    # For a 512x512 UNet, sample becomes (1,4,1,1) instead of (2,4,64,64), causing
+    # spatial dimension mismatches at UNet skip-connection Concat nodes (up_blocks).
+    # calibration_shapes overrides _get_tensor_shape() per input — only specified
+    # inputs bypass the default-to-1 fallback.
+    #
+    # Format: "input0:d0xd1x...,input1:d0xd1x..." (modelopt parse_shapes_spec format)
+    calibration_shapes_str: Optional[str] = None
+    if model_data is not None:
+        latent_h = opt_image_height // 8
+        latent_w = opt_image_width // 8
+        effective_batch = 2 * opt_batch_size
+        text_maxlen = getattr(model_data, "text_maxlen", 77)
+        embedding_dim = getattr(model_data, "embedding_dim", 2048)
+        # Use cache_maxframes=1 for calibration. The attention processor does:
+        #   kvo_cache[0] → (cache_maxframes, batch, S, H)
+        #   .transpose(0,1).flatten(1,2) → (batch, cache_maxframes*S, H)
+        # With cache_maxframes=4, ONNX shape-computation nodes create Concat ops
+        # that mix dim=4 (cache_maxframes) with dim=2 (batch), causing Concat axis
+        # mismatch errors in ORT. cache_maxframes=1 is valid (within TRT profile
+        # min range) and avoids the conflict. FP8 only needs valid activation ranges.
+        calib_cache_maxframes = 1
+        kvo_cache_shapes = getattr(model_data, "kvo_cache_shapes", [])
+        num_ip_layers = getattr(model_data, "num_ip_layers", 1)
+        control_inputs = getattr(model_data, "control_inputs", {})
+        kvo_calib_batch = effective_batch  # Must match sample batch (ONNX axis "2B")
+
+        shape_parts = []
+        try:
+            input_names = model_data.get_input_names()
+        except Exception:
+            input_names = []
+
+        for name in input_names:
+            if name == "sample":
+                shape_parts.append(f"{name}:{effective_batch}x4x{latent_h}x{latent_w}")
+            elif name == "timestep":
+                shape_parts.append(f"{name}:{effective_batch}")
+            elif name == "encoder_hidden_states":
+                shape_parts.append(f"{name}:{effective_batch}x{text_maxlen}x{embedding_dim}")
+            elif name == "ipadapter_scale":
+                shape_parts.append(f"{name}:{num_ip_layers}")
+            elif name.startswith("input_control_") and name in control_inputs:
+                spec = control_inputs[name]
+                shape_parts.append(
+                    f"{name}:{effective_batch}x{spec['channels']}x{spec['height']}x{spec['width']}"
+                )
+            elif name.startswith("kvo_cache_in_"):
+                idx = int(name.rsplit("_", 1)[-1])
+                if idx < len(kvo_cache_shapes):
+                    seq_len, hidden_dim = kvo_cache_shapes[idx]
+                    shape_parts.append(
+                        f"{name}:2x{calib_cache_maxframes}x{kvo_calib_batch}x{seq_len}x{hidden_dim}"
+                    )
+
+        if shape_parts:
+            calibration_shapes_str = ",".join(shape_parts)
+            logger.info(
+                f"[FP8] calibration_shapes: {len(shape_parts)} inputs "
+                f"(sample={effective_batch}x4x{latent_h}x{latent_w}, "
+                f"kvo={len([p for p in shape_parts if 'kvo_cache_in' in p])} caches "
+                f"calib_frames={calib_cache_maxframes})"
+            )
+    else:
+        logger.warning(
+            "[FP8] model_data not provided — RandomDataProvider will default all "
+            "dynamic dims to 1. UNet Concat nodes may fail for non-trivial models."
+        )
 
     quantize_kwargs = {
         "quantize_mode": "fp8",
         "output_path": onnx_fp8_path,
-        "calibration_data": calibration_data,
         "calibration_method": "percentile",
         "percentile": percentile,
         "alpha": alpha,
         "use_external_data_format": True,
+        # override_shapes replaces dynamic dims in the ONNX model itself with static
+        # values BEFORE any ORT sessions (MHA analysis or calibration) are created.
+        # Without this, ORT's internal shape inference with dynamic dims causes
+        # Concat failures (e.g. KVO cache dims vs sample batch dims).
+        # calibration_shapes additionally tells RandomDataProvider what shapes to
+        # generate for the calibration data.
+        "override_shapes": calibration_shapes_str,
+        "calibration_shapes": calibration_shapes_str,
+        # Use default EPs ["cpu","cuda:0","trt"] — CPU-only would fail on this FP16 SDXL
+        # model because ORT's mandatory CastFloat16Transformer inserts Cast nodes that
+        # conflict with existing Cast nodes in the upsampler conv.
+        # disable_mha_qdq controls modelopt's MHA analysis. When True, MHA MatMul
+        # nodes are excluded from FP8 quantization WITHOUT running ORT inference.
+        # Non-MHA ops (Conv, Linear, LayerNorm) still get FP8 Q/DQ nodes.
+        "disable_mha_qdq": not quantize_mha,
     }
-    if quantize_mha:
-        quantize_kwargs["quantize_mha"] = True
 
     try:
         modelopt_quantize(onnx_opt_path, **quantize_kwargs)
     except TypeError as e:
-        # Older nvidia-modelopt versions may not support alpha / quantize_mha.
+        # Older nvidia-modelopt versions may not support alpha/disable_mha_qdq.
         # Retry with base parameters only.
-        logger.warning(f"[FP8] Retrying without alpha/quantize_mha (TypeError: {e})")
+        logger.warning(f"[FP8] Retrying without alpha/disable_mha_qdq (TypeError: {e})")
         quantize_kwargs.pop("alpha", None)
-        quantize_kwargs.pop("quantize_mha", None)
+        quantize_kwargs.pop("disable_mha_qdq", None)
         modelopt_quantize(onnx_opt_path, **quantize_kwargs)
     except Exception as e:
-        # quantize_mha=True requires an ORT inference run to analyze MHA patterns.
-        # This can fail with rank mismatches (KVO caches have custom shapes) or
-        # when CUDA EP is unavailable. Retry with quantize_mha disabled.
-        if quantize_kwargs.pop("quantize_mha", None):
+        # MHA analysis (disable_mha_qdq=False) requires an ORT inference run that
+        # fails with KVO cached attention models. Retry with disable_mha_qdq=True
+        # to skip the ORT session entirely — MHA layers use FP16, rest uses FP8.
+        if not quantize_kwargs.get("disable_mha_qdq", True):
             # Delete intermediate files written during the failed attempt to free
             # disk space before the retry (each set is ~23GB for SDXL-scale models).
-            _eng_dir = os.path.dirname(onnx_opt_path)
             _base = os.path.splitext(onnx_opt_path)[0]  # strip .onnx
             for _suffix in (
+                "_static.onnx", "_static.onnx_data",          # from override_shapes
                 "_named.onnx", "_named.onnx_data",
                 "_named_extended.onnx", "_named_extended.onnx_data",
                 "_ir10.onnx", "_ir10.onnx_data",
+                "_static_named.onnx", "_static_named.onnx_data",
+                "_static_ir10.onnx", "_static_ir10.onnx_data",
             ):
                 _f = _base + _suffix
                 if os.path.exists(_f):
                     os.remove(_f)
                     logger.info(f"[FP8] Cleaned up intermediate: {os.path.basename(_f)}")
             logger.warning(
-                f"[FP8] quantize_mha=True failed ({type(e).__name__}: {e}). "
-                "Retrying with quantize_mha disabled (MHA layers will use default precision)."
+                f"[FP8] MHA analysis failed ({type(e).__name__}: {e}). "
+                "Retrying with disable_mha_qdq=True (MHA layers will use FP16 precision)."
             )
+            quantize_kwargs["disable_mha_qdq"] = True
             modelopt_quantize(onnx_opt_path, **quantize_kwargs)
         else:
             raise
     finally:
         _onnx.ModelProto.ByteSize = _orig_byte_size  # Restore original method
+        try:
+            import onnxruntime as _ort
+            _ort.set_default_logger_severity(2)  # Restore to WARNING
+        except Exception:
+            pass
 
     if not os.path.exists(onnx_fp8_path):
         raise RuntimeError(
             f"[FP8] Quantization completed but output file not found: {onnx_fp8_path}"
         )
+
+    # --- Restore dynamic axes ---
+    # ModelOpt's override_shapes baked static dim_value into graph inputs for calibration.
+    # TRT needs dynamic dim_param on inputs/outputs to accept optimization profiles.
+    if model_data is not None:
+        try:
+            _restore_dynamic_axes(onnx_fp8_path, model_data)
+        except Exception as restore_err:
+            logger.warning(
+                f"[FP8] Failed to restore dynamic axes: {restore_err}. "
+                "TRT engine build may fail with static shape profile mismatch."
+            )
 
     output_size_mb = os.path.getsize(onnx_fp8_path) / (1024 * 1024)
     ratio = output_size_mb / input_size_mb if input_size_mb > 0 else 0

--- a/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
+++ b/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
@@ -187,6 +187,15 @@ def quantize_onnx_fp8(
 
     _onnx.ModelProto.ByteSize = _safe_byte_size
 
+    # modelopt expects {name: ndarray} with calibration samples stacked along axis 0,
+    # not a list of dicts. Merge: [(name: shape)...] → {name: (N, *shape)}
+    if isinstance(calibration_data, list) and calibration_data:
+        merged = {}
+        for name in calibration_data[0]:
+            merged[name] = np.stack([batch[name] for batch in calibration_data if name in batch])
+        calibration_data = merged
+        logger.info(f"[FP8] Merged calibration data: {len(merged)} inputs, {next(iter(merged.values())).shape[0]} samples")
+
     quantize_kwargs = {
         "quantize_mode": "fp8",
         "output_path": onnx_fp8_path,

--- a/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
+++ b/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
@@ -187,6 +187,31 @@ def quantize_onnx_fp8(
 
     _onnx.ModelProto.ByteSize = _safe_byte_size
 
+    # Ensure NVIDIA DLLs (cuDNN, cuBLAS, CUDA runtime) are on PATH so modelopt's
+    # ORT sessions can use CUDA/TensorRT EPs instead of CPU EP (which is stricter
+    # about mixed-precision Cast nodes and fails on FP16 models).
+    _nvidia_pkg_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))), os.pardir, "venv", "Lib",
+        "site-packages", "nvidia")
+    _nvidia_pkg_dir = os.path.normpath(_nvidia_pkg_dir)
+    if not os.path.isdir(_nvidia_pkg_dir):
+        # Fallback: find via importlib
+        try:
+            import nvidia.cudnn
+            _nvidia_pkg_dir = os.path.dirname(os.path.dirname(nvidia.cudnn.__file__))
+        except ImportError:
+            _nvidia_pkg_dir = None
+
+    if _nvidia_pkg_dir and os.path.isdir(_nvidia_pkg_dir):
+        _bin_dirs = []
+        for _subpkg in ("cudnn", "cublas", "cuda_runtime", "cufft", "curand"):
+            _bdir = os.path.join(_nvidia_pkg_dir, _subpkg, "bin")
+            if os.path.isdir(_bdir) and _bdir not in os.environ.get("PATH", ""):
+                _bin_dirs.append(_bdir)
+        if _bin_dirs:
+            os.environ["PATH"] = os.pathsep.join(_bin_dirs) + os.pathsep + os.environ.get("PATH", "")
+            logger.info(f"[FP8] Added {len(_bin_dirs)} NVIDIA DLL dirs to PATH")
+
     # modelopt expects {name: ndarray} with calibration samples stacked along axis 0,
     # not a list of dicts. Merge: [(name: shape)...] → {name: (N, *shape)}
     if isinstance(calibration_data, list) and calibration_data:
@@ -213,10 +238,23 @@ def quantize_onnx_fp8(
     except TypeError as e:
         # Older nvidia-modelopt versions may not support alpha / quantize_mha.
         # Retry with base parameters only.
-        logger.warning(f"[FP8] Retrying without alpha/quantize_mha (API error: {e})")
+        logger.warning(f"[FP8] Retrying without alpha/quantize_mha (TypeError: {e})")
         quantize_kwargs.pop("alpha", None)
         quantize_kwargs.pop("quantize_mha", None)
         modelopt_quantize(onnx_opt_path, **quantize_kwargs)
+    except Exception as e:
+        # quantize_mha=True requires ORT CUDA/TRT EP to analyze MHA patterns.
+        # If CUDA EP is unavailable (e.g. cuDNN not on PATH), ORT falls back to CPU
+        # EP which is stricter about fp32/fp16 Cast type mismatches in the FP16 graph.
+        # Retry with quantize_mha disabled so the MHA analysis path is skipped.
+        if quantize_kwargs.pop("quantize_mha", None):
+            logger.warning(
+                f"[FP8] quantize_mha=True failed ({type(e).__name__}: {e}). "
+                "Retrying with quantize_mha disabled (MHA layers will use default precision)."
+            )
+            modelopt_quantize(onnx_opt_path, **quantize_kwargs)
+        else:
+            raise
     finally:
         _onnx.ModelProto.ByteSize = _orig_byte_size  # Restore original method
 

--- a/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
+++ b/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
@@ -212,14 +212,14 @@ def quantize_onnx_fp8(
             os.environ["PATH"] = os.pathsep.join(_bin_dirs) + os.pathsep + os.environ.get("PATH", "")
             logger.info(f"[FP8] Added {len(_bin_dirs)} NVIDIA DLL dirs to PATH")
 
-    # modelopt expects {name: ndarray} with calibration samples stacked along axis 0,
-    # not a list of dicts. Merge: [(name: shape)...] → {name: (N, *shape)}
+    # modelopt's CalibrationDataProvider expects a single dict {name: ndarray} where
+    # each value has exactly the model's input rank. np.stack would add an extra
+    # calibration-sample dimension (rank+1), causing ORT "Invalid rank" errors.
+    # Use first batch — one batch with effective_batch samples is sufficient for FP8
+    # (wider dynamic range than INT8, less sensitive to calibration volume).
     if isinstance(calibration_data, list) and calibration_data:
-        merged = {}
-        for name in calibration_data[0]:
-            merged[name] = np.stack([batch[name] for batch in calibration_data if name in batch])
-        calibration_data = merged
-        logger.info(f"[FP8] Merged calibration data: {len(merged)} inputs, {next(iter(merged.values())).shape[0]} samples")
+        logger.info(f"[FP8] Using first calibration batch of {len(calibration_data)} ({len(calibration_data[0])} inputs)")
+        calibration_data = calibration_data[0]
 
     quantize_kwargs = {
         "quantize_mode": "fp8",
@@ -243,11 +243,23 @@ def quantize_onnx_fp8(
         quantize_kwargs.pop("quantize_mha", None)
         modelopt_quantize(onnx_opt_path, **quantize_kwargs)
     except Exception as e:
-        # quantize_mha=True requires ORT CUDA/TRT EP to analyze MHA patterns.
-        # If CUDA EP is unavailable (e.g. cuDNN not on PATH), ORT falls back to CPU
-        # EP which is stricter about fp32/fp16 Cast type mismatches in the FP16 graph.
-        # Retry with quantize_mha disabled so the MHA analysis path is skipped.
+        # quantize_mha=True requires an ORT inference run to analyze MHA patterns.
+        # This can fail with rank mismatches (KVO caches have custom shapes) or
+        # when CUDA EP is unavailable. Retry with quantize_mha disabled.
         if quantize_kwargs.pop("quantize_mha", None):
+            # Delete intermediate files written during the failed attempt to free
+            # disk space before the retry (each set is ~23GB for SDXL-scale models).
+            _eng_dir = os.path.dirname(onnx_opt_path)
+            _base = os.path.splitext(onnx_opt_path)[0]  # strip .onnx
+            for _suffix in (
+                "_named.onnx", "_named.onnx_data",
+                "_named_extended.onnx", "_named_extended.onnx_data",
+                "_ir10.onnx", "_ir10.onnx_data",
+            ):
+                _f = _base + _suffix
+                if os.path.exists(_f):
+                    os.remove(_f)
+                    logger.info(f"[FP8] Cleaned up intermediate: {os.path.basename(_f)}")
             logger.warning(
                 f"[FP8] quantize_mha=True failed ({type(e).__name__}: {e}). "
                 "Retrying with quantize_mha disabled (MHA layers will use default precision)."

--- a/src/streamdiffusion/acceleration/tensorrt/models/__init__.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/__init__.py
@@ -1,13 +1,14 @@
-from .models import Optimizer, BaseModel, CLIP, UNet, VAE, VAEEncoder
-from .controlnet_models import ControlNetTRT, ControlNetSDXLTRT
+from .controlnet_models import ControlNetSDXLTRT, ControlNetTRT
+from .models import CLIP, VAE, BaseModel, Optimizer, UNet, VAEEncoder
+
 
 __all__ = [
     "Optimizer",
-    "BaseModel", 
+    "BaseModel",
     "CLIP",
     "UNet",
     "VAE",
     "VAEEncoder",
     "ControlNetTRT",
     "ControlNetSDXLTRT",
-] 
+]

--- a/src/streamdiffusion/acceleration/tensorrt/models/attention_processors.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/attention_processors.py
@@ -18,6 +18,10 @@ class CachedSTAttnProcessor2_0:
         self._curr_key_buf: Optional[torch.Tensor] = None
         self._curr_value_buf: Optional[torch.Tensor] = None
         self._kv_out_buf: Optional[torch.Tensor] = None  # shape: (2, 1, B, seq, inner_dim)
+        # When False (default): ONNX-safe .clone() path — used during torch.onnx.export() tracing.
+        # When True: zero-alloc .copy_() path — set after ONNX export for non-TRT runtime inference.
+        # NOTE: aten::copy has no ONNX symbolic and cannot be traced; never set True before export.
+        self._use_prealloc: bool = False
 
     def __call__(
         self,
@@ -72,16 +76,21 @@ class CachedSTAttnProcessor2_0:
             cached_key, cached_value = None, None
 
         if is_selfattn:
-            # Lazy-init per-layer buffers (shape is model-dependent, known only on first call)
-            if self._curr_key_buf is None or self._curr_key_buf.shape != key.shape:
-                self._curr_key_buf = torch.empty_like(key)
-                self._curr_value_buf = torch.empty_like(value)
-                self._kv_out_buf = torch.empty((2, 1, *key.shape), dtype=key.dtype, device=key.device)
-            # In-place copy: eliminates 2 clone() mallocs per layer per denoising step
-            self._curr_key_buf.copy_(key)
-            self._curr_value_buf.copy_(value)
-            curr_key = self._curr_key_buf
-            curr_value = self._curr_value_buf
+            if self._use_prealloc:
+                # Zero-alloc path: .copy_() into pre-allocated buffers eliminates 2 mallocs per layer.
+                # NOT ONNX-traceable — only active after export (aten::copy has no ONNX symbolic).
+                if self._curr_key_buf is None or self._curr_key_buf.shape != key.shape:
+                    self._curr_key_buf = torch.empty_like(key)
+                    self._curr_value_buf = torch.empty_like(value)
+                    self._kv_out_buf = torch.empty((2, 1, *key.shape), dtype=key.dtype, device=key.device)
+                self._curr_key_buf.copy_(key)
+                self._curr_value_buf.copy_(value)
+                curr_key = self._curr_key_buf
+                curr_value = self._curr_value_buf
+            else:
+                # ONNX-safe path: .clone() exports cleanly to aten::clone (has ONNX symbolic).
+                curr_key = key.clone()
+                curr_value = value.clone()
 
             if cached_key is not None:
                 cached_key_reshaped = cached_key.transpose(0, 1).contiguous().flatten(1, 2)
@@ -120,9 +129,13 @@ class CachedSTAttnProcessor2_0:
         hidden_states = hidden_states / attn.rescale_output_factor
 
         if is_selfattn:
-            # In-place fill pre-allocated output buffer: eliminates torch.stack malloc per layer
-            self._kv_out_buf[0, 0].copy_(curr_key)
-            self._kv_out_buf[1, 0].copy_(curr_value)
-            kvo_cache = self._kv_out_buf
+            if self._use_prealloc:
+                # In-place fill pre-allocated output buffer: eliminates torch.stack malloc per layer.
+                self._kv_out_buf[0, 0].copy_(curr_key)
+                self._kv_out_buf[1, 0].copy_(curr_value)
+                kvo_cache = self._kv_out_buf
+            else:
+                # ONNX-safe fallback: torch.stack is exportable.
+                kvo_cache = torch.stack([curr_key.unsqueeze(0), curr_value.unsqueeze(0)])
 
         return hidden_states, kvo_cache

--- a/src/streamdiffusion/acceleration/tensorrt/models/attention_processors.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/attention_processors.py
@@ -2,10 +2,10 @@ from typing import Optional
 
 import torch
 import torch.nn.functional as F
-
 from diffusers.models.attention_processor import Attention
 from diffusers.utils import USE_PEFT_BACKEND
-    
+
+
 class CachedSTAttnProcessor2_0:
     r"""
     Processor for implementing scaled dot-product attention (enabled by default if you're using PyTorch 2.0).
@@ -14,7 +14,7 @@ class CachedSTAttnProcessor2_0:
     def __init__(self):
         if not hasattr(F, "scaled_dot_product_attention"):
             raise ImportError("AttnProcessor2_0 requires PyTorch 2.0, to use it, please upgrade PyTorch to 2.0.")
-        
+
     def __call__(
         self,
         attn: Attention,
@@ -106,8 +106,8 @@ class CachedSTAttnProcessor2_0:
             hidden_states = hidden_states + residual
 
         hidden_states = hidden_states / attn.rescale_output_factor
-            
+
         if is_selfattn:
             kvo_cache = torch.stack([curr_key.unsqueeze(0), curr_value.unsqueeze(0)], dim=0)
-                
+
         return hidden_states, kvo_cache

--- a/src/streamdiffusion/acceleration/tensorrt/models/attention_processors.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/attention_processors.py
@@ -14,6 +14,10 @@ class CachedSTAttnProcessor2_0:
     def __init__(self):
         if not hasattr(F, "scaled_dot_product_attention"):
             raise ImportError("AttnProcessor2_0 requires PyTorch 2.0, to use it, please upgrade PyTorch to 2.0.")
+        # Per-layer pre-allocated buffers (lazy-init on first call — shape is model-dependent)
+        self._curr_key_buf: Optional[torch.Tensor] = None
+        self._curr_value_buf: Optional[torch.Tensor] = None
+        self._kv_out_buf: Optional[torch.Tensor] = None  # shape: (2, 1, B, seq, inner_dim)
 
     def __call__(
         self,
@@ -68,8 +72,16 @@ class CachedSTAttnProcessor2_0:
             cached_key, cached_value = None, None
 
         if is_selfattn:
-            curr_key = key.clone()
-            curr_value = value.clone()
+            # Lazy-init per-layer buffers (shape is model-dependent, known only on first call)
+            if self._curr_key_buf is None or self._curr_key_buf.shape != key.shape:
+                self._curr_key_buf = torch.empty_like(key)
+                self._curr_value_buf = torch.empty_like(value)
+                self._kv_out_buf = torch.empty((2, 1, *key.shape), dtype=key.dtype, device=key.device)
+            # In-place copy: eliminates 2 clone() mallocs per layer per denoising step
+            self._curr_key_buf.copy_(key)
+            self._curr_value_buf.copy_(value)
+            curr_key = self._curr_key_buf
+            curr_value = self._curr_value_buf
 
             if cached_key is not None:
                 cached_key_reshaped = cached_key.transpose(0, 1).contiguous().flatten(1, 2)
@@ -108,6 +120,9 @@ class CachedSTAttnProcessor2_0:
         hidden_states = hidden_states / attn.rescale_output_factor
 
         if is_selfattn:
-            kvo_cache = torch.stack([curr_key.unsqueeze(0), curr_value.unsqueeze(0)], dim=0)
+            # In-place fill pre-allocated output buffer: eliminates torch.stack malloc per layer
+            self._kv_out_buf[0, 0].copy_(curr_key)
+            self._kv_out_buf[1, 0].copy_(curr_value)
+            kvo_cache = self._kv_out_buf
 
         return hidden_states, kvo_cache

--- a/src/streamdiffusion/acceleration/tensorrt/models/controlnet_models.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/controlnet_models.py
@@ -1,50 +1,49 @@
 """ControlNet TensorRT model definitions for compilation"""
 
-from typing import List, Dict, Optional
-from .models import BaseModel
-from ..export_wrappers.unet_sdxl_export import SDXLConditioningHandler, get_sdxl_tensorrt_config
-from ....model_detection import detect_model
+from typing import Dict, List
+
 import torch
+
+from ....model_detection import detect_model
+from ..export_wrappers.unet_sdxl_export import SDXLConditioningHandler
+from .models import BaseModel
 
 
 class ControlNetTRT(BaseModel):
     """TensorRT model definition for ControlNet compilation"""
-    
-    def __init__(self, 
-                 fp16: bool = True,
-                 device: str = "cuda",
-                 min_batch_size: int = 1,
-                 max_batch_size: int = 4,
-                 embedding_dim: int = 768,
-                 unet_dim: int = 4,
-                 conditioning_channels: int = 3,
-                 **kwargs):
+
+    def __init__(
+        self,
+        fp16: bool = True,
+        device: str = "cuda",
+        min_batch_size: int = 1,
+        max_batch_size: int = 4,
+        embedding_dim: int = 768,
+        unet_dim: int = 4,
+        conditioning_channels: int = 3,
+        **kwargs,
+    ):
         super().__init__(
             fp16=fp16,
             device=device,
             max_batch_size=max_batch_size,
             min_batch_size=min_batch_size,
             embedding_dim=embedding_dim,
-            **kwargs
+            **kwargs,
         )
         self.unet_dim = unet_dim
         self.conditioning_channels = conditioning_channels if conditioning_channels is not None else 3
         self.name = "ControlNet"
-        
+
     def get_input_names(self) -> List[str]:
         """Get input names for ControlNet TensorRT engine"""
-        return [
-            "sample",
-            "timestep",
-            "encoder_hidden_states",
-            "controlnet_cond"
-        ]
-        
+        return ["sample", "timestep", "encoder_hidden_states", "controlnet_cond"]
+
     def get_output_names(self) -> List[str]:
         """Get output names for ControlNet TensorRT engine"""
         down_names = [f"down_block_{i:02d}" for i in range(12)]
         return down_names + ["mid_block"]
-        
+
     def get_dynamic_axes(self) -> Dict[str, Dict[int, str]]:
         """Get dynamic axes configuration for variable input shapes"""
         return {
@@ -53,26 +52,25 @@ class ControlNetTRT(BaseModel):
             "timestep": {0: "B"},
             "controlnet_cond": {0: "B", 2: "H_ctrl", 3: "W_ctrl"},
             **{f"down_block_{i:02d}": {0: "B", 2: "H", 3: "W"} for i in range(12)},
-            "mid_block": {0: "B", 2: "H", 3: "W"}
+            "mid_block": {0: "B", 2: "H", 3: "W"},
         }
-    
-    def get_input_profile(self, batch_size, image_height, image_width, 
-                         static_batch, static_shape):
+
+    def get_input_profile(self, batch_size, image_height, image_width, static_batch, static_shape):
         """Generate TensorRT input profiles for ControlNet with dynamic 384-1024 range"""
         min_batch = batch_size if static_batch else self.min_batch
         max_batch = batch_size if static_batch else self.max_batch
-        
+
         # Force dynamic shapes for universal engines (384-1024 range)
         min_ctrl_h = 384  # Changed from 256 to 512 to match min resolution
         max_ctrl_h = 1024
         min_ctrl_w = 384  # Changed from 256 to 512 to match min resolution
         max_ctrl_w = 1024
-        
+
         # Use a flexible optimal resolution that's in the middle of the range
         # This allows the engine to handle both smaller and larger resolutions
         opt_ctrl_h = 704  # Middle of 512-1024 range
         opt_ctrl_w = 704  # Middle of 512-1024 range
-        
+
         # Calculate latent dimensions
         min_latent_h = min_ctrl_h // 8  # 64
         max_latent_h = max_ctrl_h // 8  # 128
@@ -80,16 +78,14 @@ class ControlNetTRT(BaseModel):
         max_latent_w = max_ctrl_w // 8  # 128
         opt_latent_h = opt_ctrl_h // 8  # 96
         opt_latent_w = opt_ctrl_w // 8  # 96
-        
+
         profile = {
             "sample": [
                 (min_batch, self.unet_dim, min_latent_h, min_latent_w),
                 (batch_size, self.unet_dim, opt_latent_h, opt_latent_w),
                 (max_batch, self.unet_dim, max_latent_h, max_latent_w),
             ],
-            "timestep": [
-                (min_batch,), (batch_size,), (max_batch,)
-            ],
+            "timestep": [(min_batch,), (batch_size,), (max_batch,)],
             "encoder_hidden_states": [
                 (min_batch, 77, self.embedding_dim),
                 (batch_size, 77, self.embedding_dim),
@@ -101,29 +97,28 @@ class ControlNetTRT(BaseModel):
                 (max_batch, self.conditioning_channels, max_ctrl_h, max_ctrl_w),
             ],
         }
-        
+
         return profile
-    
+
     def get_sample_input(self, batch_size, image_height, image_width):
         """Generate sample inputs for ONNX export"""
         latent_height = image_height // 8
         latent_width = image_width // 8
         dtype = torch.float16 if self.fp16 else torch.float32
-        
+
         return (
-            torch.randn(batch_size, self.unet_dim, latent_height, latent_width, 
-                       dtype=dtype, device=self.device),
+            torch.randn(batch_size, self.unet_dim, latent_height, latent_width, dtype=dtype, device=self.device),
             torch.ones(batch_size, dtype=torch.float32, device=self.device),
-            torch.randn(batch_size, 77, self.embedding_dim, 
-                       dtype=dtype, device=self.device),
-            torch.randn(batch_size, self.conditioning_channels, image_height, image_width, 
-                       dtype=dtype, device=self.device)
+            torch.randn(batch_size, 77, self.embedding_dim, dtype=dtype, device=self.device),
+            torch.randn(
+                batch_size, self.conditioning_channels, image_height, image_width, dtype=dtype, device=self.device
+            ),
         )
 
 
 class ControlNetSDXLTRT(ControlNetTRT):
     """SDXL-specific ControlNet TensorRT model definition"""
-    
+
     def __init__(self, unet=None, model_path="", **kwargs):
         # Use new model detection if UNet provided
         if unet is not None:
@@ -132,113 +127,133 @@ class ControlNetSDXLTRT(ControlNetTRT):
 
             # Create a config dict compatible with SDXLConditioningHandler
             config = {
-                'is_sdxl': detection_result['is_sdxl'],
-                'has_time_cond': detection_result['architecture_details']['has_time_conditioning'],
-                'has_addition_embed': detection_result['architecture_details']['has_addition_embeds'],
-                'model_type': detection_result['model_type'],
-                'is_turbo': detection_result['is_turbo'],
-                'is_sd3': detection_result['is_sd3'],
-                'confidence': detection_result['confidence'],
-                'architecture_details': detection_result['architecture_details'],
-                'compatibility_info': detection_result['compatibility_info']
+                "is_sdxl": detection_result["is_sdxl"],
+                "has_time_cond": detection_result["architecture_details"]["has_time_conditioning"],
+                "has_addition_embed": detection_result["architecture_details"]["has_addition_embeds"],
+                "model_type": detection_result["model_type"],
+                "is_turbo": detection_result["is_turbo"],
+                "is_sd3": detection_result["is_sd3"],
+                "confidence": detection_result["confidence"],
+                "architecture_details": detection_result["architecture_details"],
+                "compatibility_info": detection_result["compatibility_info"],
             }
             conditioning_handler = SDXLConditioningHandler(config)
             conditioning_spec = conditioning_handler.get_conditioning_spec()
-            
+
             # Set embedding_dim from sophisticated detection
-            kwargs.setdefault('embedding_dim', conditioning_spec['context_dim'])
-        
+            kwargs.setdefault("embedding_dim", conditioning_spec["context_dim"])
+
         # Set SDXL-specific defaults
-        kwargs.setdefault('embedding_dim', 2048)  # SDXL uses 2048-dim embeddings
-        kwargs.setdefault('unet_dim', 4)          # SDXL latent channels
-        
+        kwargs.setdefault("embedding_dim", 2048)  # SDXL uses 2048-dim embeddings
+        kwargs.setdefault("unet_dim", 4)  # SDXL latent channels
+
         super().__init__(**kwargs)
-        
+
         # SDXL ControlNet output specifications - 9 down blocks + 1 mid block
         # Following the pattern from UNet implementation:
         self.sdxl_output_channels = {
             # Initial sample
-            'down_block_00': 320,   # Initial: 320 channels
-            # Block 0 residuals  
-            'down_block_01': 320,   # Block0: 320 channels
-            'down_block_02': 320,   # Block0: 320 channels
-            'down_block_03': 320,   # Block0: 320 channels
+            "down_block_00": 320,  # Initial: 320 channels
+            # Block 0 residuals
+            "down_block_01": 320,  # Block0: 320 channels
+            "down_block_02": 320,  # Block0: 320 channels
+            "down_block_03": 320,  # Block0: 320 channels
             # Block 1 residuals
-            'down_block_04': 640,   # Block1: 640 channels
-            'down_block_05': 640,   # Block1: 640 channels
-            'down_block_06': 640,   # Block1: 640 channels
+            "down_block_04": 640,  # Block1: 640 channels
+            "down_block_05": 640,  # Block1: 640 channels
+            "down_block_06": 640,  # Block1: 640 channels
             # Block 2 residuals
-            'down_block_07': 1280,  # Block2: 1280 channels
-            'down_block_08': 1280,  # Block2: 1280 channels
+            "down_block_07": 1280,  # Block2: 1280 channels
+            "down_block_08": 1280,  # Block2: 1280 channels
             # Mid block
-            'mid_block': 1280       # Mid: 1280 channels
+            "mid_block": 1280,  # Mid: 1280 channels
         }
-    
+
     def get_shape_dict(self, batch_size, image_height, image_width):
         """Override to provide SDXL-specific output shapes for 9 down blocks"""
         # Get base input shapes
         base_shapes = super().get_shape_dict(batch_size, image_height, image_width)
-        
+
         # Add conditioning_scale to input shapes (scalar tensor)
         base_shapes["conditioning_scale"] = ()  # Scalar tensor has empty shape
-        
+
         # Calculate latent dimensions
         latent_height, latent_width = self.check_dims(batch_size, image_height, image_width)
-        
+
         # SDXL output shapes matching UNet pattern:
         # Pattern: [88x88] + [88x88, 88x88, 44x44] + [44x44, 44x44, 22x22] + [22x22, 22x22]
         sdxl_output_shapes = {
             # Initial sample (no downsampling)
-            'down_block_00': (batch_size, 320, latent_height, latent_width),        # 88x88
+            "down_block_00": (batch_size, 320, latent_height, latent_width),  # 88x88
             # Block 0 residuals
-            'down_block_01': (batch_size, 320, latent_height, latent_width),        # 88x88  
-            'down_block_02': (batch_size, 320, latent_height, latent_width),        # 88x88
-            'down_block_03': (batch_size, 320, latent_height // 2, latent_width // 2),  # 44x44 (downsampled)
+            "down_block_01": (batch_size, 320, latent_height, latent_width),  # 88x88
+            "down_block_02": (batch_size, 320, latent_height, latent_width),  # 88x88
+            "down_block_03": (batch_size, 320, latent_height // 2, latent_width // 2),  # 44x44 (downsampled)
             # Block 1 residuals
-            'down_block_04': (batch_size, 640, latent_height // 2, latent_width // 2),  # 44x44
-            'down_block_05': (batch_size, 640, latent_height // 2, latent_width // 2),  # 44x44
-            'down_block_06': (batch_size, 640, latent_height // 4, latent_width // 4),  # 22x22 (downsampled)
-            # Block 2 residuals  
-            'down_block_07': (batch_size, 1280, latent_height // 4, latent_width // 4), # 22x22
-            'down_block_08': (batch_size, 1280, latent_height // 4, latent_width // 4), # 22x22
+            "down_block_04": (batch_size, 640, latent_height // 2, latent_width // 2),  # 44x44
+            "down_block_05": (batch_size, 640, latent_height // 2, latent_width // 2),  # 44x44
+            "down_block_06": (batch_size, 640, latent_height // 4, latent_width // 4),  # 22x22 (downsampled)
+            # Block 2 residuals
+            "down_block_07": (batch_size, 1280, latent_height // 4, latent_width // 4),  # 22x22
+            "down_block_08": (batch_size, 1280, latent_height // 4, latent_width // 4),  # 22x22
             # Mid block
-            'mid_block': (batch_size, 1280, latent_height // 4, latent_width // 4),     # 22x22
+            "mid_block": (batch_size, 1280, latent_height // 4, latent_width // 4),  # 22x22
         }
-        
+
         # Combine base inputs with SDXL outputs
         base_shapes.update(sdxl_output_shapes)
         return base_shapes
-    
+
     def get_sample_input(self, batch_size, image_height, image_width):
         """Override to provide SDXL-specific sample tensors with correct input format"""
         latent_height, latent_width = self.check_dims(batch_size, image_height, image_width)
         dtype = torch.float16 if self.fp16 else torch.float32
-        
+
         # SDXL ControlNet inputs (wrapper expects 7 inputs including SDXL conditioning)
         base_inputs = (
-            torch.randn(batch_size, self.unet_dim, latent_height, latent_width, 
-                       dtype=dtype, device=self.device),  # sample
+            torch.randn(
+                batch_size, self.unet_dim, latent_height, latent_width, dtype=dtype, device=self.device
+            ),  # sample
             torch.ones(batch_size, dtype=torch.float32, device=self.device),  # timestep
-            torch.randn(batch_size, self.text_maxlen, self.embedding_dim, 
-                       dtype=dtype, device=self.device),  # encoder_hidden_states
-            torch.randn(batch_size, self.conditioning_channels, image_height, image_width, 
-                       dtype=dtype, device=self.device),  # controlnet_cond
+            torch.randn(
+                batch_size, self.text_maxlen, self.embedding_dim, dtype=dtype, device=self.device
+            ),  # encoder_hidden_states
+            torch.randn(
+                batch_size, self.conditioning_channels, image_height, image_width, dtype=dtype, device=self.device
+            ),  # controlnet_cond
             torch.tensor(1.0, dtype=torch.float32, device=self.device),  # conditioning_scale
             torch.randn(batch_size, 1280, dtype=dtype, device=self.device),  # text_embeds
-            torch.randn(batch_size, 6, dtype=dtype, device=self.device),     # time_ids
+            torch.randn(batch_size, 6, dtype=dtype, device=self.device),  # time_ids
         )
-        
+
         return base_inputs
-    
+
     def get_input_names(self):
         """Override to provide SDXL-specific input names"""
-        return ["sample", "timestep", "encoder_hidden_states", "controlnet_cond", "conditioning_scale", "text_embeds", "time_ids"]
-    
+        return [
+            "sample",
+            "timestep",
+            "encoder_hidden_states",
+            "controlnet_cond",
+            "conditioning_scale",
+            "text_embeds",
+            "time_ids",
+        ]
+
     def get_output_names(self):
         """Override to provide SDXL-specific output names that match wrapper return format"""
-        return ["down_block_00", "down_block_01", "down_block_02", "down_block_03", 
-                "down_block_04", "down_block_05", "down_block_06", "down_block_07", 
-                "down_block_08", "mid_block"]
+        return [
+            "down_block_00",
+            "down_block_01",
+            "down_block_02",
+            "down_block_03",
+            "down_block_04",
+            "down_block_05",
+            "down_block_06",
+            "down_block_07",
+            "down_block_08",
+            "mid_block",
+        ]
 
     def get_dynamic_axes(self) -> Dict[str, Dict[int, str]]:
         """Get dynamic axes configuration for variable input shapes"""
@@ -250,51 +265,49 @@ class ControlNetSDXLTRT(ControlNetTRT):
             "text_embeds": {0: "B"},
             "time_ids": {0: "B"},
             **{f"down_block_{i:02d}": {0: "B", 2: "H", 3: "W"} for i in range(9)},
-            "mid_block": {0: "B", 2: "H", 3: "W"}
+            "mid_block": {0: "B", 2: "H", 3: "W"},
         }
-    
-    def get_input_profile(self, batch_size, image_height, image_width, 
-                         static_batch, static_shape):
+
+    def get_input_profile(self, batch_size, image_height, image_width, static_batch, static_shape):
         """Override to provide SDXL-specific input profiles including text_embeds and time_ids"""
         # Get base profiles from parent class
-        profile = super().get_input_profile(batch_size, image_height, image_width, 
-                                           static_batch, static_shape)
-        
+        profile = super().get_input_profile(batch_size, image_height, image_width, static_batch, static_shape)
+
         # Add SDXL-specific input profiles with dynamic batch dimension
         min_batch = batch_size if static_batch else self.min_batch
         max_batch = batch_size if static_batch else self.max_batch
-        
+
         # conditioning_scale is a scalar (empty shape)
         profile["conditioning_scale"] = [
             (),  # min
             (),  # opt
             (),  # max
         ]
-        
+
         # text_embeds has shape (batch, 1280)
         profile["text_embeds"] = [
-            (min_batch, 1280),      # min
-            (batch_size, 1280),     # opt
-            (max_batch, 1280),      # max
+            (min_batch, 1280),  # min
+            (batch_size, 1280),  # opt
+            (max_batch, 1280),  # max
         ]
-        
+
         # time_ids has shape (batch, 6)
         profile["time_ids"] = [
-            (min_batch, 6),         # min
-            (batch_size, 6),        # opt
-            (max_batch, 6),         # max
+            (min_batch, 6),  # min
+            (batch_size, 6),  # opt
+            (max_batch, 6),  # max
         ]
-        
+
         return profile
 
 
-def create_controlnet_model(model_type: str = "sd15", 
-                           unet=None, model_path: str = "",
-                           conditioning_channels: int = 3,
-                           **kwargs) -> ControlNetTRT:
+def create_controlnet_model(
+    model_type: str = "sd15", unet=None, model_path: str = "", conditioning_channels: int = 3, **kwargs
+) -> ControlNetTRT:
     """Factory function to create appropriate ControlNet TensorRT model"""
     if model_type.lower() in ["sdxl"]:
-        return ControlNetSDXLTRT(unet=unet, model_path=model_path, 
-                                conditioning_channels=conditioning_channels, **kwargs)
+        return ControlNetSDXLTRT(
+            unet=unet, model_path=model_path, conditioning_channels=conditioning_channels, **kwargs
+        )
     else:
-        return ControlNetTRT(conditioning_channels=conditioning_channels, **kwargs) 
+        return ControlNetTRT(conditioning_channels=conditioning_channels, **kwargs)

--- a/src/streamdiffusion/acceleration/tensorrt/models/controlnet_models.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/controlnet_models.py
@@ -56,28 +56,28 @@ class ControlNetTRT(BaseModel):
         }
 
     def get_input_profile(self, batch_size, image_height, image_width, static_batch, static_shape):
-        """Generate TensorRT input profiles for ControlNet with dynamic 384-1024 range"""
+        """Generate TensorRT input profiles for ControlNet."""
         min_batch = batch_size if static_batch else self.min_batch
         max_batch = batch_size if static_batch else self.max_batch
 
-        # Force dynamic shapes for universal engines (384-1024 range)
-        min_ctrl_h = 384  # Changed from 256 to 512 to match min resolution
-        max_ctrl_h = 1024
-        min_ctrl_w = 384  # Changed from 256 to 512 to match min resolution
-        max_ctrl_w = 1024
+        if static_shape:
+            # Static: min=opt=max at exact resolution — enables L2 tiling & geometry kernels
+            min_ctrl_h = max_ctrl_h = opt_ctrl_h = image_height
+            min_ctrl_w = max_ctrl_w = opt_ctrl_w = image_width
+        else:
+            min_ctrl_h = 384
+            max_ctrl_h = 1024
+            opt_ctrl_h = 704
+            min_ctrl_w = 384
+            max_ctrl_w = 1024
+            opt_ctrl_w = 704
 
-        # Use a flexible optimal resolution that's in the middle of the range
-        # This allows the engine to handle both smaller and larger resolutions
-        opt_ctrl_h = 704  # Middle of 512-1024 range
-        opt_ctrl_w = 704  # Middle of 512-1024 range
-
-        # Calculate latent dimensions
-        min_latent_h = min_ctrl_h // 8  # 64
-        max_latent_h = max_ctrl_h // 8  # 128
-        min_latent_w = min_ctrl_w // 8  # 64
-        max_latent_w = max_ctrl_w // 8  # 128
-        opt_latent_h = opt_ctrl_h // 8  # 96
-        opt_latent_w = opt_ctrl_w // 8  # 96
+        min_latent_h = min_ctrl_h // 8
+        max_latent_h = max_ctrl_h // 8
+        min_latent_w = min_ctrl_w // 8
+        max_latent_w = max_ctrl_w // 8
+        opt_latent_h = opt_ctrl_h // 8
+        opt_latent_w = opt_ctrl_w // 8
 
         profile = {
             "sample": [

--- a/src/streamdiffusion/acceleration/tensorrt/models/models.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/models.py
@@ -558,6 +558,8 @@ class UNet(BaseModel):
                 base_axes[name] = {0: "2B", 2: f"H_{spatial_suffix}", 3: f"W_{spatial_suffix}"}
         if self.use_cached_attn:
             # hardcoded resolution for now due to VRAM limitations
+            # NOTE: dim[0]=2 (K/V pair) must stay static — attention Gather nodes
+            # index into it at idx=0 and idx=1, so dim[0]<2 causes OOB errors.
             for i in range(self.kvo_cache_count):
                 base_axes[f"kvo_cache_in_{i}"] = {1: "C", 2: "2B"}
                 base_axes[f"kvo_cache_out_{i}"] = {2: "2B"}
@@ -692,7 +694,7 @@ class UNet(BaseModel):
 
         if self.use_cached_attn:
             for in_name, out_name, shape in zip(
-                self.get_kvo_cache_names("in"), self.get_kvo_cache_names("out"), self.get_kvo_cache_shapes
+                self.get_kvo_cache_names("in"), self.get_kvo_cache_names("out"), self.kvo_cache_shapes
             ):
                 shape_dict[in_name] = (2, self.cache_maxframes, batch_size, shape[0], shape[1])
                 shape_dict[out_name] = (2, 1, batch_size, shape[0], shape[1])

--- a/src/streamdiffusion/acceleration/tensorrt/models/models.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/models.py
@@ -19,9 +19,9 @@
 
 import onnx_graphsurgeon as gs
 import torch
+from diffusers.models.unets.unet_2d_condition import UNet2DConditionModel
 from onnx import shape_inference
 from polygraphy.backend.onnx.loader import fold_constants
-from diffusers.models.unets.unet_2d_condition import UNet2DConditionModel
 
 
 class Optimizer:
@@ -55,7 +55,9 @@ class Optimizer:
     def infer_shapes(self, return_onnx=False):
         onnx_graph = gs.export_onnx(self.graph)
         if onnx_graph.ByteSize() > 2147483648:
-            print(f"⚠️ Model size ({onnx_graph.ByteSize() / (1024**3):.2f} GB) exceeds 2GB - this is normal for SDXL models")
+            print(
+                f"⚠️ Model size ({onnx_graph.ByteSize() / (1024**3):.2f} GB) exceeds 2GB - this is normal for SDXL models"
+            )
             print("🔧 ONNX shape inference will be skipped for large models to avoid memory issues")
             # For large models like SDXL, skip shape inference to avoid memory/size issues
             # The model will still work with TensorRT's own shape inference during engine building
@@ -129,16 +131,17 @@ class BaseModel:
 
     def check_dims(self, batch_size, image_height, image_width):
         # Make batch size check more flexible for ONNX export
-        if hasattr(self, '_allow_export_batch_override') and self._allow_export_batch_override:
+        if hasattr(self, "_allow_export_batch_override") and self._allow_export_batch_override:
             # During ONNX export, allow different batch sizes
             effective_min_batch = min(self.min_batch, batch_size)
             effective_max_batch = max(self.max_batch, batch_size)
         else:
             effective_min_batch = self.min_batch
             effective_max_batch = self.max_batch
-            
-        assert batch_size >= effective_min_batch and batch_size <= effective_max_batch, \
+
+        assert batch_size >= effective_min_batch and batch_size <= effective_max_batch, (
             f"Batch size {batch_size} not in range [{effective_min_batch}, {effective_max_batch}]"
+        )
         assert image_height % 8 == 0 or image_width % 8 == 0
         latent_height = image_height // 8
         latent_width = image_width // 8
@@ -149,7 +152,7 @@ class BaseModel:
     def get_minmax_dims(self, batch_size, image_height, image_width, static_batch, static_shape):
         # Following ComfyUI TensorRT approach: ensure proper min ≤ opt ≤ max constraints
         # Even with static_batch=True, we need different min/max to avoid TensorRT constraint violations
-        
+
         if static_batch:
             # For static batch, still provide range to avoid min=opt=max constraint violation
             min_batch = max(1, batch_size - 1)  # At least 1, but allow some range
@@ -157,10 +160,10 @@ class BaseModel:
         else:
             min_batch = self.min_batch
             max_batch = self.max_batch
-        
+
         latent_height = image_height // 8
         latent_width = image_width // 8
-        
+
         # Force dynamic shapes for height/width to enable runtime resolution changes
         # Always use 384-1024 range regardless of static_shape flag
         min_image_height = self.min_image_shape
@@ -171,7 +174,7 @@ class BaseModel:
         max_latent_height = self.max_latent_shape
         min_latent_width = self.min_latent_shape
         max_latent_width = self.max_latent_shape
-        
+
         return (
             min_batch,
             max_batch,
@@ -247,7 +250,7 @@ class CLIP(BaseModel):
 
 
 class SafetyChecker(BaseModel):
-    def __init__(self, device, max_batch_size = 1, min_batch_size = 1):
+    def __init__(self, device, max_batch_size=1, min_batch_size=1):
         super(SafetyChecker, self).__init__(
             device=device,
             max_batch_size=max_batch_size,
@@ -280,28 +283,27 @@ class SafetyChecker(BaseModel):
         }
 
     def get_sample_input(self, batch_size, *args, **kwargs):
-        return (
-            torch.randn(batch_size, 3, 224, 224, dtype=torch.float16, device=self.device),
-        )
+        return (torch.randn(batch_size, 3, 224, 224, dtype=torch.float16, device=self.device),)
+
 
 class NSFWDetector(BaseModel):
-    def __init__(self, device, max_batch_size = 1, min_batch_size = 1):
+    def __init__(self, device, max_batch_size=1, min_batch_size=1):
         super(NSFWDetector, self).__init__(
             device=device,
             max_batch_size=max_batch_size,
             min_batch_size=min_batch_size,
         )
         self.name = "nsfw_detector"
-    
+
     def get_input_names(self):
         return ["pixel_values"]
-    
+
     def get_output_names(self):
         return ["logits"]
-    
+
     def get_dynamic_axes(self):
         return {"pixel_values": {0: "B"}}
-    
+
     def get_input_profile(self, batch_size, *args, **kwargs):
         return {
             "pixel_values": [
@@ -310,17 +312,16 @@ class NSFWDetector(BaseModel):
                 (self.max_batch, 3, 448, 448),
             ],
         }
-    
+
     def get_shape_dict(self, batch_size, *args, **kwargs):
         return {
             "pixel_values": (batch_size, 3, 448, 448),
             "logits": (batch_size, 2),
         }
-    
+
     def get_sample_input(self, batch_size, *args, **kwargs):
-        return (
-            torch.randn(batch_size, 3, 448, 448, dtype=torch.float16, device=self.device),
-        )
+        return (torch.randn(batch_size, 3, 448, 448, dtype=torch.float16, device=self.device),)
+
 
 class UNet(BaseModel):
     def __init__(
@@ -358,13 +359,13 @@ class UNet(BaseModel):
         self.name = "UNet"
         self.image_height = image_height
         self.image_width = image_width
-        
+
         self.use_control = use_control
         self.unet_arch = unet_arch or {}
         self.use_ipadapter = use_ipadapter
         self.num_image_tokens = num_image_tokens
         self.num_ip_layers = num_ip_layers
-        
+
         # Baked-in IPAdapter configuration
         if self.use_ipadapter:
             # With baked-in processors, we extend text_maxlen to include image tokens
@@ -375,7 +376,6 @@ class UNet(BaseModel):
             if self.num_ip_layers is None:
                 raise ValueError("UNet model requires num_ip_layers when use_ipadapter=True")
 
-        
         if self.use_control and self.unet_arch:
             self.control_inputs = self.get_control(image_height, image_width)
             self._add_control_inputs()
@@ -388,21 +388,24 @@ class UNet(BaseModel):
         self.max_cache_maxframes = max_cache_maxframes
         if self.use_cached_attn and self.unet is not None:
             from .utils import get_kvo_cache_info
-            self.kvo_cache_shapes, self.kvo_cache_structure, self.kvo_cache_count = get_kvo_cache_info(self.unet, image_height, image_width)
-            
+
+            self.kvo_cache_shapes, self.kvo_cache_structure, self.kvo_cache_count = get_kvo_cache_info(
+                self.unet, image_height, image_width
+            )
+
             self.min_kvo_cache_shapes, _, _ = get_kvo_cache_info(self.unet, image_height, image_width)
             self.max_kvo_cache_shapes, _, _ = get_kvo_cache_info(self.unet, image_height, image_width)
 
     def get_control(self, image_height: int = 512, image_width: int = 512) -> dict:
         """Generate ControlNet input configurations with dynamic spatial dimensions based on input resolution."""
-        block_out_channels = self.unet_arch.get('block_out_channels', (320, 640, 1280, 1280))
-        
+        block_out_channels = self.unet_arch.get("block_out_channels", (320, 640, 1280, 1280))
+
         # Calculate latent space dimensions
         latent_height = image_height // 8
         latent_width = image_width // 8
-        
+
         control_inputs = {}
-        
+
         if len(block_out_channels) == 3:
             # SDXL architecture: Match UNet's exact down_block_res_samples structure
             # UNet down_block_res_samples = [initial_sample] + [block0_residuals] + [block1_residuals] + [block2_residuals]
@@ -411,17 +414,14 @@ class UNet(BaseModel):
             control_tensors = [
                 # Initial sample (after conv_in: 4->320 channels, no downsampling)
                 (block_out_channels[0], 1),  # 320 channels, 88x88
-                
                 # Block 0 residuals (320 channels)
-                (block_out_channels[0], 1),  # 320 channels, 88x88 
+                (block_out_channels[0], 1),  # 320 channels, 88x88
                 (block_out_channels[0], 1),  # 320 channels, 88x88
                 (block_out_channels[0], 2),  # 320 channels, 44x44 (downsampled)
-                
-                # Block 1 residuals (640 channels) 
+                # Block 1 residuals (640 channels)
                 (block_out_channels[1], 2),  # 640 channels, 44x44
                 (block_out_channels[1], 2),  # 640 channels, 44x44
                 (block_out_channels[1], 4),  # 640 channels, 22x22 (downsampled)
-                
                 # Block 2 residuals (1280 channels)
                 (block_out_channels[2], 4),  # 1280 channels, 22x22
                 (block_out_channels[2], 4),  # 1280 channels, 22x22
@@ -430,31 +430,39 @@ class UNet(BaseModel):
             # SD1.5/SD2.1 architecture: 4 down blocks with 12 control tensors
             control_tensors = [
                 # Block 0: No downsampling from latent space (factor = 1)
-                (320, 1), (320, 1), (320, 1),
-                # Block 1: 2x downsampling from latent space (factor = 2) 
-                (320, 2), (640, 2), (640, 2),
+                (320, 1),
+                (320, 1),
+                (320, 1),
+                # Block 1: 2x downsampling from latent space (factor = 2)
+                (320, 2),
+                (640, 2),
+                (640, 2),
                 # Block 2: 4x downsampling from latent space (factor = 4)
-                (640, 4), (1280, 4), (1280, 4),
+                (640, 4),
+                (1280, 4),
+                (1280, 4),
                 # Block 3: 8x downsampling from latent space (factor = 8)
-                (1280, 8), (1280, 8), (1280, 8)
+                (1280, 8),
+                (1280, 8),
+                (1280, 8),
             ]
-        
+
         # Generate control inputs with proper spatial dimensions
         for i, (channels, downsample_factor) in enumerate(control_tensors):
             input_name = f"input_control_{i:02d}"
-            
+
             # Calculate spatial dimensions for this level
             control_height = max(1, latent_height // downsample_factor)
             control_width = max(1, latent_width // downsample_factor)
-            
+
             control_inputs[input_name] = {
-                'batch': self.min_batch,
-                'channels': channels,
-                'height': control_height,
-                'width': control_width,
-                'downsampling_factor': downsample_factor
+                "batch": self.min_batch,
+                "channels": channels,
+                "height": control_height,
+                "width": control_width,
+                "downsampling_factor": downsample_factor,
             }
-        
+
         # Middle block uses the most downsampled resolution based on architecture
         if len(block_out_channels) == 3:
             # SDXL: middle block at 4x downsampling (after 3 down blocks)
@@ -462,15 +470,15 @@ class UNet(BaseModel):
         else:
             # SD1.5: middle block at 8x downsampling (after 4 down blocks)
             middle_downsample_factor = 8
-            
+
         control_inputs["input_control_middle"] = {
-            'batch': self.min_batch,
-            'channels': 1280,
-            'height': max(1, latent_height // middle_downsample_factor),
-            'width': max(1, latent_width // middle_downsample_factor),
-            'downsampling_factor': middle_downsample_factor
+            "batch": self.min_batch,
+            "channels": 1280,
+            "height": max(1, latent_height // middle_downsample_factor),
+            "width": max(1, latent_width // middle_downsample_factor),
+            "downsampling_factor": middle_downsample_factor,
         }
-        
+
         return control_inputs
 
     def get_kvo_cache_names(self, in_out: str):
@@ -480,7 +488,7 @@ class UNet(BaseModel):
         """Add ControlNet inputs to the model's input/output specifications"""
         if not self.control_inputs:
             return
-        
+
         self._original_get_input_names = self.get_input_names
         self._original_get_dynamic_axes = self.get_dynamic_axes
         self._original_get_input_profile = self.get_input_profile
@@ -494,6 +502,7 @@ class UNet(BaseModel):
             base_names.append("ipadapter_scale")
             try:
                 import logging
+
                 logging.getLogger(__name__).debug(f"TRT Models: get_input_names with ipadapter -> {base_names}")
             except Exception:
                 pass
@@ -512,8 +521,14 @@ class UNet(BaseModel):
 
     def get_kvo_cache_input_profile(self, min_batch, batch_size, max_batch):
         profiles = []
-        for min_shape, shape, max_shape in zip(self.min_kvo_cache_shapes, self.kvo_cache_shapes, self.max_kvo_cache_shapes):
-            profile = [(2, self.min_cache_maxframes, min_batch, min_shape[0], min_shape[1]), (2, self.cache_maxframes, batch_size, shape[0], shape[1]), (2, self.max_cache_maxframes, max_batch, max_shape[0], max_shape[1])]
+        for min_shape, shape, max_shape in zip(
+            self.min_kvo_cache_shapes, self.kvo_cache_shapes, self.max_kvo_cache_shapes
+        ):
+            profile = [
+                (2, self.min_cache_maxframes, min_batch, min_shape[0], min_shape[1]),
+                (2, self.cache_maxframes, batch_size, shape[0], shape[1]),
+                (2, self.max_cache_maxframes, max_batch, max_shape[0], max_shape[1]),
+            ]
             profiles.append(profile)
         return profiles
 
@@ -528,26 +543,25 @@ class UNet(BaseModel):
             base_axes["ipadapter_scale"] = {0: "L_ip"}
             try:
                 import logging
-                logging.getLogger(__name__).debug(f"TRT Models: dynamic axes include ipadapter_scale with L_ip={getattr(self, 'num_ip_layers', None)}")
+
+                logging.getLogger(__name__).debug(
+                    f"TRT Models: dynamic axes include ipadapter_scale with L_ip={getattr(self, 'num_ip_layers', None)}"
+                )
             except Exception:
                 pass
-        
+
         if self.use_control and self.control_inputs:
             for name, shape_spec in self.control_inputs.items():
                 height = shape_spec["height"]
                 width = shape_spec["width"]
                 spatial_suffix = f"{height}x{width}"
-                base_axes[name] = {
-                    0: "2B", 
-                    2: f"H_{spatial_suffix}", 
-                    3: f"W_{spatial_suffix}"
-                }
+                base_axes[name] = {0: "2B", 2: f"H_{spatial_suffix}", 3: f"W_{spatial_suffix}"}
         if self.use_cached_attn:
             # hardcoded resolution for now due to VRAM limitations
             for i in range(self.kvo_cache_count):
                 base_axes[f"kvo_cache_in_{i}"] = {1: "C", 2: "2B"}
                 base_axes[f"kvo_cache_out_{i}"] = {2: "2B"}
-        
+
         return base_axes
 
     def get_input_profile(self, batch_size, image_height, image_width, static_batch, static_shape):
@@ -564,30 +578,30 @@ class UNet(BaseModel):
             min_latent_width,
             max_latent_width,
         ) = self.get_minmax_dims(batch_size, image_height, image_width, static_batch, static_shape)
-        
+
         # Following TensorRT documentation: ensure proper min ≤ opt ≤ max constraints for ALL dimensions
         # Calculate optimal latent dimensions that fall within min/max range
         opt_latent_height = min(max(latent_height, min_latent_height), max_latent_height)
         opt_latent_width = min(max(latent_width, min_latent_width), max_latent_width)
-        
+
         # Ensure no dimension equality that causes constraint violations
         if opt_latent_height == min_latent_height and min_latent_height < max_latent_height:
             opt_latent_height = min(min_latent_height + 8, max_latent_height)  # Add 8 pixels for separation
         if opt_latent_width == min_latent_width and min_latent_width < max_latent_width:
             opt_latent_width = min(min_latent_width + 8, max_latent_width)
-        
+
         # Image dimensions for ControlNet inputs
         min_image_h, max_image_h = self.min_image_shape, self.max_image_shape
         min_image_w, max_image_w = self.min_image_shape, self.max_image_shape
         opt_image_height = min(max(image_height, min_image_h), max_image_h)
         opt_image_width = min(max(image_width, min_image_w), max_image_w)
-        
+
         # Ensure image dimension separation as well
         if opt_image_height == min_image_h and min_image_h < max_image_h:
             opt_image_height = min(min_image_h + 64, max_image_h)  # Add 64 pixels for separation
         if opt_image_width == min_image_w and min_image_w < max_image_w:
             opt_image_width = min(min_image_w + 64, max_image_w)
-        
+
         profile = {
             "sample": [
                 (min_batch, self.unet_dim, min_latent_height, min_latent_width),
@@ -610,10 +624,13 @@ class UNet(BaseModel):
             ]
             try:
                 import logging
-                logging.getLogger(__name__).debug(f"TRT Models: profile ipadapter_scale min/opt/max={(1,),(self.num_ip_layers,),(self.num_ip_layers,)}")
+
+                logging.getLogger(__name__).debug(
+                    f"TRT Models: profile ipadapter_scale min/opt/max={(1,), (self.num_ip_layers,), (self.num_ip_layers,)}"
+                )
             except Exception:
                 pass
-        
+
         if self.use_control and self.control_inputs:
             # Use the actual calculated spatial dimensions for each ControlNet input
             # Each control input has its own specific spatial resolution based on UNet architecture
@@ -621,29 +638,31 @@ class UNet(BaseModel):
                 channels = shape_spec["channels"]
                 control_height = shape_spec["height"]
                 control_width = shape_spec["width"]
-                
+
                 # Create optimization profile with proper spatial dimension scaling
                 # Scale the spatial dimensions proportionally with the main latent dimensions
                 scale_h = opt_latent_height / latent_height if latent_height > 0 else 1.0
                 scale_w = opt_latent_width / latent_width if latent_width > 0 else 1.0
-                
+
                 min_control_h = max(1, int(control_height * min_latent_height / latent_height))
                 max_control_h = max(min_control_h + 1, int(control_height * max_latent_height / latent_height))
                 opt_control_h = max(min_control_h, min(int(control_height * scale_h), max_control_h))
-                
+
                 min_control_w = max(1, int(control_width * min_latent_width / latent_width))
                 max_control_w = max(min_control_w + 1, int(control_width * max_latent_width / latent_width))
                 opt_control_w = max(min_control_w, min(int(control_width * scale_w), max_control_w))
-                
+
                 profile[name] = [
-                    (min_batch, channels, min_control_h, min_control_w),    # min
-                    (batch_size, channels, opt_control_h, opt_control_w),   # opt  
-                    (max_batch, channels, max_control_h, max_control_w),    # max
+                    (min_batch, channels, min_control_h, min_control_w),  # min
+                    (batch_size, channels, opt_control_h, opt_control_w),  # opt
+                    (max_batch, channels, max_control_h, max_control_w),  # max
                 ]
         if self.use_cached_attn:
-            for name, _profile in zip(self.get_kvo_cache_names("in"), self.get_kvo_cache_input_profile(min_batch, batch_size, max_batch)):
+            for name, _profile in zip(
+                self.get_kvo_cache_names("in"), self.get_kvo_cache_input_profile(min_batch, batch_size, max_batch)
+            ):
                 profile[name] = _profile
-        
+
         return profile
 
     def get_shape_dict(self, batch_size, image_height, image_width):
@@ -658,10 +677,11 @@ class UNet(BaseModel):
             shape_dict["ipadapter_scale"] = (self.num_ip_layers,)
             try:
                 import logging
+
                 logging.getLogger(__name__).debug(f"TRT Models: shape_dict ipadapter_scale={(self.num_ip_layers,)}")
             except Exception:
                 pass
-        
+
         if self.use_control and self.control_inputs:
             # Use the actual calculated spatial dimensions for each ControlNet input
             for name, shape_spec in self.control_inputs.items():
@@ -671,68 +691,78 @@ class UNet(BaseModel):
                 shape_dict[name] = (2 * batch_size, channels, control_height, control_width)
 
         if self.use_cached_attn:
-            for in_name, out_name, shape in zip(self.get_kvo_cache_names("in"), self.get_kvo_cache_names("out"), self.get_kvo_cache_shapes):
+            for in_name, out_name, shape in zip(
+                self.get_kvo_cache_names("in"), self.get_kvo_cache_names("out"), self.get_kvo_cache_shapes
+            ):
                 shape_dict[in_name] = (2, self.cache_maxframes, batch_size, shape[0], shape[1])
                 shape_dict[out_name] = (2, 1, batch_size, shape[0], shape[1])
-        
+
         return shape_dict
 
     def get_sample_input(self, batch_size, image_height, image_width):
         # Enable flexible batch size checking for ONNX export
         self._allow_export_batch_override = True
-        
+
         try:
             latent_height, latent_width = self.check_dims(batch_size, image_height, image_width)
         finally:
             # Clean up the override flag
-            if hasattr(self, '_allow_export_batch_override'):
-                delattr(self, '_allow_export_batch_override')
-        
+            if hasattr(self, "_allow_export_batch_override"):
+                delattr(self, "_allow_export_batch_override")
+
         dtype = torch.float16 if self.fp16 else torch.float32
-        
+
         # Use smaller batch size for memory efficiency during ONNX export
         export_batch_size = min(batch_size, 1)  # Use batch size 1 for ONNX export to save memory
-        
+
         base_inputs = [
             torch.randn(
-                2 * export_batch_size, self.unet_dim, latent_height, latent_width, 
-                dtype=torch.float32, device=self.device
+                2 * export_batch_size,
+                self.unet_dim,
+                latent_height,
+                latent_width,
+                dtype=torch.float32,
+                device=self.device,
             ),
             torch.ones((2 * export_batch_size,), dtype=torch.float32, device=self.device),
             torch.randn(2 * export_batch_size, self.text_maxlen, self.embedding_dim, dtype=dtype, device=self.device),
         ]
-        
+
         if self.use_ipadapter:
             base_inputs.append(torch.ones(self.num_ip_layers, dtype=torch.float32, device=self.device))
-        
+
         if self.use_control and self.control_inputs:
             control_inputs = []
-            
+
             # Use the ACTUAL calculated spatial dimensions for each control input
             # This ensures each control input matches its expected UNet feature map resolution
-            
+
             for name in sorted(self.control_inputs.keys()):
                 shape_spec = self.control_inputs[name]
                 channels = shape_spec["channels"]
-                
+
                 # KEY FIX: Use the specific spatial dimensions calculated for this control input
                 control_height = shape_spec["height"]
                 control_width = shape_spec["width"]
-                
+
                 control_input = torch.randn(
-                    2 * export_batch_size, channels, control_height, control_width, 
-                    dtype=dtype, device=self.device
+                    2 * export_batch_size, channels, control_height, control_width, dtype=dtype, device=self.device
                 )
                 control_inputs.append(control_input)
-                
+
                 # Clear cache periodically to prevent memory buildup
                 if len(control_inputs) % 4 == 0:
                     torch.cuda.empty_cache()
-            
+
             base_inputs = base_inputs + control_inputs
-        
+
         if self.use_cached_attn:
-            base_inputs = base_inputs + [torch.randn(2, self.cache_maxframes, 2 * export_batch_size, shape[0], shape[1], dtype=torch.float16).to(self.device) for shape in self.kvo_cache_shapes]
+            base_inputs = base_inputs + [
+                torch.randn(
+                    2, self.cache_maxframes, 2 * export_batch_size, shape[0], shape[1], dtype=torch.float16
+                ).to(self.device)
+                for shape in self.kvo_cache_shapes
+            ]
         return tuple(base_inputs)
 
 

--- a/src/streamdiffusion/acceleration/tensorrt/models/models.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/models.py
@@ -150,12 +150,8 @@ class BaseModel:
         return (latent_height, latent_width)
 
     def get_minmax_dims(self, batch_size, image_height, image_width, static_batch, static_shape):
-        # Following ComfyUI TensorRT approach: ensure proper min ≤ opt ≤ max constraints
-        # Even with static_batch=True, we need different min/max to avoid TensorRT constraint violations
-
         if static_batch:
-            # For static batch, still provide range to avoid min=opt=max constraint violation
-            min_batch = max(1, batch_size - 1)  # At least 1, but allow some range
+            min_batch = max(1, batch_size - 1)
             max_batch = batch_size
         else:
             min_batch = self.min_batch
@@ -164,16 +160,23 @@ class BaseModel:
         latent_height = image_height // 8
         latent_width = image_width // 8
 
-        # Force dynamic shapes for height/width to enable runtime resolution changes
-        # Always use 384-1024 range regardless of static_shape flag
-        min_image_height = self.min_image_shape
-        max_image_height = self.max_image_shape
-        min_image_width = self.min_image_shape
-        max_image_width = self.max_image_shape
-        min_latent_height = self.min_latent_shape
-        max_latent_height = self.max_latent_shape
-        min_latent_width = self.min_latent_shape
-        max_latent_width = self.max_latent_shape
+        if static_shape:
+            # Static: min=opt=max — TRT selects geometry-specific kernels,
+            # enables L2 tiling, and CUDA graphs avoid worst-case allocation.
+            min_image_height = max_image_height = image_height
+            min_image_width = max_image_width = image_width
+            min_latent_height = max_latent_height = latent_height
+            min_latent_width = max_latent_width = latent_width
+        else:
+            # Dynamic: full range for runtime resolution flexibility
+            min_image_height = self.min_image_shape
+            max_image_height = self.max_image_shape
+            min_image_width = self.min_image_shape
+            max_image_width = self.max_image_shape
+            min_latent_height = self.min_latent_shape
+            max_latent_height = self.max_latent_shape
+            min_latent_width = self.min_latent_shape
+            max_latent_width = self.max_latent_shape
 
         return (
             min_batch,
@@ -586,23 +589,29 @@ class UNet(BaseModel):
         opt_latent_height = min(max(latent_height, min_latent_height), max_latent_height)
         opt_latent_width = min(max(latent_width, min_latent_width), max_latent_width)
 
-        # Ensure no dimension equality that causes constraint violations
-        if opt_latent_height == min_latent_height and min_latent_height < max_latent_height:
-            opt_latent_height = min(min_latent_height + 8, max_latent_height)  # Add 8 pixels for separation
-        if opt_latent_width == min_latent_width and min_latent_width < max_latent_width:
-            opt_latent_width = min(min_latent_width + 8, max_latent_width)
+        # For dynamic shapes, ensure opt != min to satisfy TRT constraint (min < opt <= max).
+        # For static shapes min == opt == max is correct and intentional — skip separation.
+        if not static_shape:
+            if opt_latent_height == min_latent_height and min_latent_height < max_latent_height:
+                opt_latent_height = min(min_latent_height + 8, max_latent_height)
+            if opt_latent_width == min_latent_width and min_latent_width < max_latent_width:
+                opt_latent_width = min(min_latent_width + 8, max_latent_width)
 
         # Image dimensions for ControlNet inputs
-        min_image_h, max_image_h = self.min_image_shape, self.max_image_shape
-        min_image_w, max_image_w = self.min_image_shape, self.max_image_shape
-        opt_image_height = min(max(image_height, min_image_h), max_image_h)
-        opt_image_width = min(max(image_width, min_image_w), max_image_w)
-
-        # Ensure image dimension separation as well
-        if opt_image_height == min_image_h and min_image_h < max_image_h:
-            opt_image_height = min(min_image_h + 64, max_image_h)  # Add 64 pixels for separation
-        if opt_image_width == min_image_w and min_image_w < max_image_w:
-            opt_image_width = min(min_image_w + 64, max_image_w)
+        if static_shape:
+            min_image_h = max_image_h = image_height
+            min_image_w = max_image_w = image_width
+            opt_image_height = image_height
+            opt_image_width = image_width
+        else:
+            min_image_h, max_image_h = self.min_image_shape, self.max_image_shape
+            min_image_w, max_image_w = self.min_image_shape, self.max_image_shape
+            opt_image_height = min(max(image_height, min_image_h), max_image_h)
+            opt_image_width = min(max(image_width, min_image_w), max_image_w)
+            if opt_image_height == min_image_h and min_image_h < max_image_h:
+                opt_image_height = min(min_image_h + 64, max_image_h)
+            if opt_image_width == min_image_w and min_image_w < max_image_w:
+                opt_image_width = min(min_image_w + 64, max_image_w)
 
         profile = {
             "sample": [
@@ -641,18 +650,22 @@ class UNet(BaseModel):
                 control_height = shape_spec["height"]
                 control_width = shape_spec["width"]
 
-                # Create optimization profile with proper spatial dimension scaling
-                # Scale the spatial dimensions proportionally with the main latent dimensions
-                scale_h = opt_latent_height / latent_height if latent_height > 0 else 1.0
-                scale_w = opt_latent_width / latent_width if latent_width > 0 else 1.0
+                if static_shape:
+                    # Static: all three identical — exact resolution, no padding
+                    min_control_h = max_control_h = opt_control_h = control_height
+                    min_control_w = max_control_w = opt_control_w = control_width
+                else:
+                    # Dynamic: scale proportionally with latent range
+                    scale_h = opt_latent_height / latent_height if latent_height > 0 else 1.0
+                    scale_w = opt_latent_width / latent_width if latent_width > 0 else 1.0
 
-                min_control_h = max(1, int(control_height * min_latent_height / latent_height))
-                max_control_h = max(min_control_h + 1, int(control_height * max_latent_height / latent_height))
-                opt_control_h = max(min_control_h, min(int(control_height * scale_h), max_control_h))
+                    min_control_h = max(1, int(control_height * min_latent_height / latent_height))
+                    max_control_h = max(min_control_h + 1, int(control_height * max_latent_height / latent_height))
+                    opt_control_h = max(min_control_h, min(int(control_height * scale_h), max_control_h))
 
-                min_control_w = max(1, int(control_width * min_latent_width / latent_width))
-                max_control_w = max(min_control_w + 1, int(control_width * max_latent_width / latent_width))
-                opt_control_w = max(min_control_w, min(int(control_width * scale_w), max_control_w))
+                    min_control_w = max(1, int(control_width * min_latent_width / latent_width))
+                    max_control_w = max(min_control_w + 1, int(control_width * max_latent_width / latent_width))
+                    opt_control_w = max(min_control_w, min(int(control_width * scale_w), max_control_w))
 
                 profile[name] = [
                     (min_batch, channels, min_control_h, min_control_w),  # min

--- a/src/streamdiffusion/acceleration/tensorrt/models/models.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/models.py
@@ -151,7 +151,9 @@ class BaseModel:
 
     def get_minmax_dims(self, batch_size, image_height, image_width, static_batch, static_shape):
         if static_batch:
-            min_batch = max(1, batch_size - 1)
+            # Fully static: min=opt=max so TRT sees no symbolic batch dim.
+            # Required for l2tc (L2 tiling) which checks that ALL dims are concrete.
+            min_batch = batch_size
             max_batch = batch_size
         else:
             min_batch = self.min_batch

--- a/src/streamdiffusion/acceleration/tensorrt/models/utils.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/utils.py
@@ -1,16 +1,17 @@
 import torch
 from diffusers.models.unets.unet_2d_condition import UNet2DConditionModel
 
+
 def get_kvo_cache_info(unet: UNet2DConditionModel, height=512, width=512):
     latent_height = height // 8
     latent_width = width // 8
-    
+
     kvo_cache_shapes = []
     kvo_cache_structure = []
     current_h, current_w = latent_height, latent_width
-    
+
     for _, block in enumerate(unet.down_blocks):
-        if hasattr(block, 'attentions') and block.attentions is not None:
+        if hasattr(block, "attentions") and block.attentions is not None:
             block_structure = []
             for attn_block in block.attentions:
                 attn_count = 0
@@ -22,12 +23,12 @@ def get_kvo_cache_info(unet: UNet2DConditionModel, height=512, width=512):
                     attn_count += 1
                 block_structure.append(attn_count)
             kvo_cache_structure.append(block_structure)
-        
-        if hasattr(block, 'downsamplers') and block.downsamplers is not None:
+
+        if hasattr(block, "downsamplers") and block.downsamplers is not None:
             current_h //= 2
             current_w //= 2
-    
-    if hasattr(unet.mid_block, 'attentions') and unet.mid_block.attentions is not None:
+
+    if hasattr(unet.mid_block, "attentions") and unet.mid_block.attentions is not None:
         block_structure = []
         for attn_block in unet.mid_block.attentions:
             attn_count = 0
@@ -39,9 +40,9 @@ def get_kvo_cache_info(unet: UNet2DConditionModel, height=512, width=512):
                 attn_count += 1
             block_structure.append(attn_count)
         kvo_cache_structure.append(block_structure)
-    
+
     for _, block in enumerate(unet.up_blocks):
-        if hasattr(block, 'attentions') and block.attentions is not None:
+        if hasattr(block, "attentions") and block.attentions is not None:
             block_structure = []
             for attn_block in block.attentions:
                 attn_count = 0
@@ -53,13 +54,13 @@ def get_kvo_cache_info(unet: UNet2DConditionModel, height=512, width=512):
                     attn_count += 1
                 block_structure.append(attn_count)
             kvo_cache_structure.append(block_structure)
-        
-        if hasattr(block, 'upsamplers') and block.upsamplers is not None:
+
+        if hasattr(block, "upsamplers") and block.upsamplers is not None:
             current_h *= 2
             current_w *= 2
 
     kvo_cache_count = sum(sum(block) for block in kvo_cache_structure)
-    
+
     return kvo_cache_shapes, kvo_cache_structure, kvo_cache_count
 
 
@@ -89,16 +90,14 @@ def convert_structure_to_list(structured_list):
     return flat_list
 
 
-def create_kvo_cache(unet: UNet2DConditionModel, batch_size, cache_maxframes, height=512, width=512, 
-                     device='cuda', dtype=torch.float16):
+def create_kvo_cache(
+    unet: UNet2DConditionModel, batch_size, cache_maxframes, height=512, width=512, device="cuda", dtype=torch.float16
+):
     kvo_cache_shapes, kvo_cache_structure, _ = get_kvo_cache_info(unet, height, width)
-    
+
     kvo_cache = []
     for seq_length, hidden_dim in kvo_cache_shapes:
-        cache_tensor = torch.zeros(
-            2, cache_maxframes, batch_size, seq_length, hidden_dim,
-            dtype=dtype, device=device
-        )
+        cache_tensor = torch.zeros(2, cache_maxframes, batch_size, seq_length, hidden_dim, dtype=dtype, device=device)
         kvo_cache.append(cache_tensor)
-    
+
     return kvo_cache, kvo_cache_structure

--- a/src/streamdiffusion/acceleration/tensorrt/runtime_engines/__init__.py
+++ b/src/streamdiffusion/acceleration/tensorrt/runtime_engines/__init__.py
@@ -1,12 +1,13 @@
 """Runtime TensorRT engine wrappers."""
 
-from .unet_engine import UNet2DConditionModelEngine, AutoencoderKLEngine
-from .controlnet_engine import ControlNetModelEngine
 from ..engine_manager import EngineManager
+from .controlnet_engine import ControlNetModelEngine
+from .unet_engine import AutoencoderKLEngine, UNet2DConditionModelEngine
+
 
 __all__ = [
     "UNet2DConditionModelEngine",
-    "AutoencoderKLEngine", 
+    "AutoencoderKLEngine",
     "ControlNetModelEngine",
     "EngineManager",
-] 
+]

--- a/src/streamdiffusion/acceleration/tensorrt/runtime_engines/controlnet_engine.py
+++ b/src/streamdiffusion/acceleration/tensorrt/runtime_engines/controlnet_engine.py
@@ -145,6 +145,13 @@ class ControlNetModelEngine:
 
         return down_blocks, mid_block
 
+    def dump_profile(self, last_n: int = 10) -> None:
+        """Delegate per-layer profiling summary to the underlying TRT Engine.
+
+        No-op when STREAMDIFFUSION_PROFILE_TRT is not set.
+        """
+        self.engine.dump_profile(last_n)
+
     def _extract_controlnet_outputs(self, outputs: Dict[str, torch.Tensor]) -> Tuple[List[torch.Tensor], torch.Tensor]:
         """Extract and organize ControlNet outputs from engine results"""
         down_blocks = []

--- a/src/streamdiffusion/acceleration/tensorrt/runtime_engines/controlnet_engine.py
+++ b/src/streamdiffusion/acceleration/tensorrt/runtime_engines/controlnet_engine.py
@@ -1,11 +1,13 @@
 """ControlNet TensorRT Engine with PyTorch fallback"""
 
-import torch
 import logging
-from typing import List, Optional, Tuple, Dict
+from typing import Dict, List, Optional, Tuple
+
+import torch
 from polygraphy import cuda
 
 from ..utilities import Engine
+
 
 # Set up logger for this module
 logger = logging.getLogger(__name__)
@@ -13,103 +15,123 @@ logger = logging.getLogger(__name__)
 
 class ControlNetModelEngine:
     """TensorRT-accelerated ControlNet inference engine"""
-    
-    def __init__(self, engine_path: str, stream: 'cuda.Stream', use_cuda_graph: bool = False, model_type: str = "sd15"):
+
+    def __init__(
+        self, engine_path: str, stream: "cuda.Stream", use_cuda_graph: bool = False, model_type: str = "sd15"
+    ):
         """Initialize ControlNet TensorRT engine"""
         self.engine = Engine(engine_path)
         self.stream = stream
         self.use_cuda_graph = use_cuda_graph
         self.model_type = model_type.lower()
-        
+
         self.engine.load()
         self.engine.activate()
-        
+
         self._input_names = None
         self._output_names = None
-        
+
         # Pre-compute model-specific values to eliminate runtime branching
         if self.model_type in ["sdxl", "sdxl_turbo"]:
             self.max_blocks = 9
             self.down_block_configs = [
-                (320, 1), (320, 1), (320, 1), (320, 2),
-                (640, 2), (640, 2), (640, 4),
-                (1280, 4), (1280, 4)
+                (320, 1),
+                (320, 1),
+                (320, 1),
+                (320, 2),
+                (640, 2),
+                (640, 2),
+                (640, 4),
+                (1280, 4),
+                (1280, 4),
             ]
             self.mid_block_channels = 1280
             self.mid_downsample_factor = 4
         else:
             self.max_blocks = 12
             self.down_block_configs = [
-                (320, 1), (320, 1), (320, 1), (320, 2), (640, 2), (640, 2),
-                (640, 4), (1280, 4), (1280, 4), (1280, 8), (1280, 8), (1280, 8)
+                (320, 1),
+                (320, 1),
+                (320, 1),
+                (320, 2),
+                (640, 2),
+                (640, 2),
+                (640, 4),
+                (1280, 4),
+                (1280, 4),
+                (1280, 8),
+                (1280, 8),
+                (1280, 8),
             ]
             self.mid_block_channels = 1280
             self.mid_downsample_factor = 8
-        
+
         self._shape_cache = {}
-    
-    def _resolve_output_shapes(self, batch_size: int, latent_height: int, latent_width: int) -> Dict[str, Tuple[int, ...]]:
+
+    def _resolve_output_shapes(
+        self, batch_size: int, latent_height: int, latent_width: int
+    ) -> Dict[str, Tuple[int, ...]]:
         """Optimized shape resolution using pre-computed configurations"""
         cache_key = (batch_size, latent_height, latent_width)
         if cache_key in self._shape_cache:
             return self._shape_cache[cache_key]
-        
+
         output_shapes = {}
-        
+
         # Generate down block shapes using pre-computed configs
         for i, (channels, factor) in enumerate(self.down_block_configs):
             output_name = f"down_block_{i:02d}"
             h = max(1, latent_height // factor)
             w = max(1, latent_width // factor)
             output_shapes[output_name] = (batch_size, channels, h, w)
-        
+
         # Generate mid block shape
         mid_h = max(1, latent_height // self.mid_downsample_factor)
         mid_w = max(1, latent_width // self.mid_downsample_factor)
         output_shapes["mid_block"] = (batch_size, self.mid_block_channels, mid_h, mid_w)
-        
+
         self._shape_cache[cache_key] = output_shapes
         return output_shapes
 
-    def __call__(self, 
-                 sample: torch.Tensor,
-                 timestep: torch.Tensor, 
-                 encoder_hidden_states: torch.Tensor,
-                 controlnet_cond: torch.Tensor,
-                 conditioning_scale: float = 1.0,
-                 text_embeds: Optional[torch.Tensor] = None,
-                 time_ids: Optional[torch.Tensor] = None,
-                 **kwargs) -> Tuple[List[torch.Tensor], torch.Tensor]:
+    def __call__(
+        self,
+        sample: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        controlnet_cond: torch.Tensor,
+        conditioning_scale: float = 1.0,
+        text_embeds: Optional[torch.Tensor] = None,
+        time_ids: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Tuple[List[torch.Tensor], torch.Tensor]:
         """Forward pass through TensorRT ControlNet engine"""
         if timestep.dtype != torch.float32:
             timestep = timestep.float()
-        
+
         input_dict = {
             "sample": sample,
             "timestep": timestep,
             "encoder_hidden_states": encoder_hidden_states,
             "controlnet_cond": controlnet_cond,
-            "conditioning_scale": torch.tensor(conditioning_scale, dtype=torch.float32, device=sample.device)
+            "conditioning_scale": torch.tensor(conditioning_scale, dtype=torch.float32, device=sample.device),
         }
-        
+
         if text_embeds is not None:
             input_dict["text_embeds"] = text_embeds
         if time_ids is not None:
             input_dict["time_ids"] = time_ids
-        
 
-        
         shape_dict = {name: tensor.shape for name, tensor in input_dict.items()}
-        
+
         batch_size = sample.shape[0]
         latent_height = sample.shape[2]
         latent_width = sample.shape[3]
-        
+
         output_shapes = self._resolve_output_shapes(batch_size, latent_height, latent_width)
         shape_dict.update(output_shapes)
-        
+
         self.engine.allocate_buffers(shape_dict=shape_dict, device=sample.device)
-        
+
         outputs = self.engine.infer(
             input_dict,
             self.stream,
@@ -120,24 +142,18 @@ class ControlNetModelEngine:
         # _extract_controlnet_outputs only slices the tensor dict (no GPU work), so no sync required.
 
         down_blocks, mid_block = self._extract_controlnet_outputs(outputs)
-        
+
         return down_blocks, mid_block
-    
+
     def _extract_controlnet_outputs(self, outputs: Dict[str, torch.Tensor]) -> Tuple[List[torch.Tensor], torch.Tensor]:
         """Extract and organize ControlNet outputs from engine results"""
         down_blocks = []
-        
+
         for i in range(self.max_blocks):
             output_name = f"down_block_{i:02d}"
             if output_name in outputs:
                 tensor = outputs[output_name]
                 down_blocks.append(tensor)
-        
+
         mid_block = outputs.get("mid_block")
         return down_blocks, mid_block
-    
-
-
-
-
- 

--- a/src/streamdiffusion/acceleration/tensorrt/runtime_engines/unet_engine.py
+++ b/src/streamdiffusion/acceleration/tensorrt/runtime_engines/unet_engine.py
@@ -1,49 +1,58 @@
-import os
-import torch
 import logging
+import os
 from typing import *
 
-from polygraphy import cuda
+import torch
 import torch.nn.functional as F
 import torchvision.transforms as T
-from torchvision.transforms import InterpolationMode
 from diffusers.models.autoencoders.autoencoder_kl import DecoderOutput
-from diffusers.models.unets.unet_2d_condition import UNet2DConditionOutput
 from diffusers.models.autoencoders.autoencoder_tiny import AutoencoderTinyOutput
+from polygraphy import cuda
+from torchvision.transforms import InterpolationMode
 
 from ..utilities import Engine
+
 
 # Set up logger for this module
 logger = logging.getLogger(__name__)
 
 
 class UNet2DConditionModelEngine:
-    def __init__(self, filepath: str, stream: 'cuda.Stream', use_cuda_graph: bool = False):
+    def __init__(self, filepath: str, stream: "cuda.Stream", use_cuda_graph: bool = False):
         self.engine = Engine(filepath)
         self.stream = stream
         self.use_cuda_graph = use_cuda_graph
         self.use_control = False  # Will be set to True by wrapper if engine has ControlNet support
         self._cached_dummy_controlnet_inputs = None
-        
+
         # Enable VRAM monitoring only if explicitly requested (defaults to False for performance)
-        self.debug_vram = os.getenv('STREAMDIFFUSION_DEBUG_VRAM', '').lower() in ('1', 'true')
+        self.debug_vram = os.getenv("STREAMDIFFUSION_DEBUG_VRAM", "").lower() in ("1", "true")
 
         self.engine.load()
         self.engine.activate()
-        
+
         # Cache expensive attribute lookups to avoid repeated getattr calls
         self._use_ipadapter_cached = None
-        
+
         # Pre-compute ControlNet input names to avoid string formatting in hot paths
         # Support up to 20 ControlNet inputs (more than enough for typical use cases)
         self._input_control_names = [f"input_control_{i:02d}" for i in range(20)]
         self._output_control_names = [f"output_control_{i:02d}" for i in range(20)]
         self._input_control_middle = "input_control_middle"
 
+        # Pre-allocated template dicts for __call__ hot path — updated in-place each call
+        # to avoid per-call dict creation and f-string formatting overhead.
+        # KVO key names are populated lazily on first call (model-dependent length).
+        self._kvo_in_names: List[str] = []
+        self._kvo_out_names: List[str] = []
+        self._kvo_cache_len: int = -1  # -1 = not yet initialized
+        self._shape_dict: Dict[str, Any] = {}
+        self._input_dict: Dict[str, Any] = {}
+
     def _check_use_ipadapter(self) -> bool:
         """Cache IP-Adapter detection to avoid repeated getattr calls"""
         if self._use_ipadapter_cached is None:
-            self._use_ipadapter_cached = getattr(self, 'use_ipadapter', False)
+            self._use_ipadapter_cached = getattr(self, "use_ipadapter", False)
         return self._use_ipadapter_cached
 
     def __call__(
@@ -57,46 +66,48 @@ class UNet2DConditionModelEngine:
         controlnet_conditioning: Optional[Dict[str, List[torch.Tensor]]] = None,
         **kwargs,
     ) -> Any:
-        
-
         if timestep.dtype != torch.float32:
             timestep = timestep.float()
 
-        kvo_cache_in_shape_dict = {f"kvo_cache_in_{i}": _kvo_cache.shape for i, _kvo_cache in enumerate(kvo_cache)}
-        kvo_cache_out_shape_dict = {f"kvo_cache_out_{i}": (*_kvo_cache.shape[:1], 1, *_kvo_cache.shape[2:]) for i, _kvo_cache in enumerate(kvo_cache)}
-        kvo_cache_in_dict = {f"kvo_cache_in_{i}": _kvo_cache for i, _kvo_cache in enumerate(kvo_cache)}
+        # Lazy-init KVO key name lists when cache length becomes known (model-dependent).
+        # After first call the length is stable, so this branch runs exactly once.
+        n_kvo = len(kvo_cache)
+        if n_kvo != self._kvo_cache_len:
+            self._kvo_in_names = [f"kvo_cache_in_{i}" for i in range(n_kvo)]
+            self._kvo_out_names = [f"kvo_cache_out_{i}" for i in range(n_kvo)]
+            self._kvo_cache_len = n_kvo
 
-        # Prepare base shape and input dictionaries
-        shape_dict = {
-            "sample": latent_model_input.shape,
-            "timestep": timestep.shape,
-            "encoder_hidden_states": encoder_hidden_states.shape,
-            "latent": latent_model_input.shape,
-            **kvo_cache_in_shape_dict,
-            **kvo_cache_out_shape_dict,
-        }
-        
-        input_dict = {
-            "sample": latent_model_input,
-            "timestep": timestep,
-            "encoder_hidden_states": encoder_hidden_states,
-            **kvo_cache_in_dict,
-        }
+        # Update pre-allocated dicts in-place — no new dict objects created per call.
+        shape_dict = self._shape_dict
+        input_dict = self._input_dict
 
-        
+        shape_dict["sample"] = latent_model_input.shape
+        shape_dict["timestep"] = timestep.shape
+        shape_dict["encoder_hidden_states"] = encoder_hidden_states.shape
+        shape_dict["latent"] = latent_model_input.shape
+
+        input_dict["sample"] = latent_model_input
+        input_dict["timestep"] = timestep
+        input_dict["encoder_hidden_states"] = encoder_hidden_states
+
+        for i, _kvo in enumerate(kvo_cache):
+            in_name = self._kvo_in_names[i]
+            out_name = self._kvo_out_names[i]
+            shape_dict[in_name] = _kvo.shape
+            shape_dict[out_name] = (*_kvo.shape[:1], 1, *_kvo.shape[2:])
+            input_dict[in_name] = _kvo
+
         # Handle IP-Adapter runtime scale vector if engine was built with it
         if self._check_use_ipadapter():
-            if 'ipadapter_scale' not in kwargs:
+            if "ipadapter_scale" not in kwargs:
                 logger.error("UNet2DConditionModelEngine: ipadapter_scale missing but required (use_ipadapter=True)")
                 raise RuntimeError("UNet2DConditionModelEngine: ipadapter_scale is required for IP-Adapter engines")
-            ip_scale = kwargs['ipadapter_scale']
+            ip_scale = kwargs["ipadapter_scale"]
             if not isinstance(ip_scale, torch.Tensor):
                 logger.error(f"UNet2DConditionModelEngine: ipadapter_scale has wrong type: {type(ip_scale)}")
                 raise TypeError("ipadapter_scale must be a torch.Tensor")
             shape_dict["ipadapter_scale"] = ip_scale.shape
             input_dict["ipadapter_scale"] = ip_scale
-            
-
 
         # Handle ControlNet inputs if provided
         if controlnet_conditioning is not None:
@@ -105,40 +116,42 @@ class UNet2DConditionModelEngine:
         elif down_block_additional_residuals is not None or mid_block_additional_residual is not None:
             # Option 2: Diffusers-style ControlNet residuals
             self._add_controlnet_residuals(
-                down_block_additional_residuals, 
-                mid_block_additional_residual, 
-                shape_dict, 
-                input_dict
+                down_block_additional_residuals, mid_block_additional_residual, shape_dict, input_dict
             )
         else:
             # Check if this engine was compiled with ControlNet support but no conditioning is provided
             if self.use_control:
-                unet_arch = getattr(self, 'unet_arch', {})
+                unet_arch = getattr(self, "unet_arch", {})
                 if unet_arch:
                     current_latent_height = latent_model_input.shape[2]
                     current_latent_width = latent_model_input.shape[3]
-                    
+
                     # Check if cached dummy inputs exist and have correct dimensions
-                    if (self._cached_dummy_controlnet_inputs is None or 
-                        not hasattr(self, '_cached_latent_dims') or
-                        self._cached_latent_dims != (current_latent_height, current_latent_width)):
-                        
+                    if (
+                        self._cached_dummy_controlnet_inputs is None
+                        or not hasattr(self, "_cached_latent_dims")
+                        or self._cached_latent_dims != (current_latent_height, current_latent_width)
+                    ):
                         try:
-                            self._cached_dummy_controlnet_inputs = self._generate_dummy_controlnet_specs(latent_model_input)
+                            self._cached_dummy_controlnet_inputs = self._generate_dummy_controlnet_specs(
+                                latent_model_input
+                            )
                             self._cached_latent_dims = (current_latent_height, current_latent_width)
                         except RuntimeError:
                             self._cached_dummy_controlnet_inputs = None
-                    
+
                     if self._cached_dummy_controlnet_inputs is not None:
-                        self._add_cached_dummy_inputs(self._cached_dummy_controlnet_inputs, latent_model_input, shape_dict, input_dict)
+                        self._add_cached_dummy_inputs(
+                            self._cached_dummy_controlnet_inputs, latent_model_input, shape_dict, input_dict
+                        )
 
         # Allocate buffers and run inference
         if self.debug_vram:
             allocated_before = torch.cuda.memory_allocated() / 1024**3
             logger.debug(f"VRAM before allocation: {allocated_before:.2f}GB")
-        
+
         self.engine.allocate_buffers(shape_dict=shape_dict, device=latent_model_input.device)
-        
+
         if self.debug_vram:
             allocated_after = torch.cuda.memory_allocated() / 1024**3
             logger.debug(f"VRAM after allocation: {allocated_after:.2f}GB")
@@ -152,69 +165,67 @@ class UNet2DConditionModelEngine:
         except Exception as e:
             logger.exception(f"UNet2DConditionModelEngine.__call__: Engine.infer failed: {e}")
             raise
-        
-        
+
         if self.debug_vram:
             allocated_final = torch.cuda.memory_allocated() / 1024**3
             logger.debug(f"VRAM after inference: {allocated_final:.2f}GB")
-        
-       
-        
+
         noise_pred = outputs["latent"]
-        if len(kvo_cache) > 0:
-            kvo_cache_out = [outputs[f"kvo_cache_out_{i}"] for i in range(len(kvo_cache))]
+        if n_kvo > 0:
+            kvo_cache_out = [outputs[name] for name in self._kvo_out_names]
         else:
             kvo_cache_out = []
         return noise_pred, kvo_cache_out
 
-    def _add_controlnet_conditioning_dict(self, 
-                                        controlnet_conditioning: Dict[str, List[torch.Tensor]], 
-                                        shape_dict: Dict, 
-                                        input_dict: Dict):
+    def _add_controlnet_conditioning_dict(
+        self, controlnet_conditioning: Dict[str, List[torch.Tensor]], shape_dict: Dict, input_dict: Dict
+    ):
         """
         Add ControlNet conditioning from organized dictionary
-        
+
         Args:
             controlnet_conditioning: Dict with 'input', 'output', 'middle' keys
             shape_dict: Shape dictionary to update
             input_dict: Input dictionary to update
         """
         # Add input controls (down blocks)
-        if 'input' in controlnet_conditioning:
-            for i, tensor in enumerate(controlnet_conditioning['input']):
+        if "input" in controlnet_conditioning:
+            for i, tensor in enumerate(controlnet_conditioning["input"]):
                 input_name = self._input_control_names[i]  # Use pre-computed names
                 shape_dict[input_name] = tensor.shape
                 input_dict[input_name] = tensor
-        
-        # Add output controls (up blocks) 
-        if 'output' in controlnet_conditioning:
-            for i, tensor in enumerate(controlnet_conditioning['output']):
+
+        # Add output controls (up blocks)
+        if "output" in controlnet_conditioning:
+            for i, tensor in enumerate(controlnet_conditioning["output"]):
                 input_name = self._output_control_names[i]  # Use pre-computed names
                 shape_dict[input_name] = tensor.shape
                 input_dict[input_name] = tensor
-        
+
         # Add middle controls
-        if 'middle' in controlnet_conditioning:
-            for i, tensor in enumerate(controlnet_conditioning['middle']):
+        if "middle" in controlnet_conditioning:
+            for i, tensor in enumerate(controlnet_conditioning["middle"]):
                 input_name = self._input_control_middle  # Use pre-computed name
                 shape_dict[input_name] = tensor.shape
                 input_dict[input_name] = tensor
 
-    def _add_controlnet_residuals(self, 
-                                down_block_additional_residuals: Optional[List[torch.Tensor]], 
-                                mid_block_additional_residual: Optional[torch.Tensor],
-                                shape_dict: Dict, 
-                                input_dict: Dict):
+    def _add_controlnet_residuals(
+        self,
+        down_block_additional_residuals: Optional[List[torch.Tensor]],
+        mid_block_additional_residual: Optional[torch.Tensor],
+        shape_dict: Dict,
+        input_dict: Dict,
+    ):
         """
         Add ControlNet residuals in diffusers format
-        
+
         Args:
             down_block_additional_residuals: List of down block residuals
             mid_block_additional_residual: Middle block residual
             shape_dict: Shape dictionary to update
             input_dict: Input dictionary to update
         """
-        
+
         # Add down block residuals as input controls
         if down_block_additional_residuals is not None:
             # Map directly to engine input names (no reversal needed for our approach)
@@ -222,21 +233,19 @@ class UNet2DConditionModelEngine:
                 input_name = self._input_control_names[i]  # Use pre-computed names
                 shape_dict[input_name] = tensor.shape
                 input_dict[input_name] = tensor
-        
+
         # Add middle block residual
         if mid_block_additional_residual is not None:
             input_name = self._input_control_middle  # Use pre-computed name
             shape_dict[input_name] = mid_block_additional_residual.shape
             input_dict[input_name] = mid_block_additional_residual
 
-    def _add_cached_dummy_inputs(self, 
-                               dummy_inputs: Dict, 
-                               latent_model_input: torch.Tensor,
-                               shape_dict: Dict, 
-                               input_dict: Dict):
+    def _add_cached_dummy_inputs(
+        self, dummy_inputs: Dict, latent_model_input: torch.Tensor, shape_dict: Dict, input_dict: Dict
+    ):
         """
         Add cached dummy inputs to the shape dictionary and input dictionary
-        
+
         Args:
             dummy_inputs: Dictionary containing dummy input specifications
             latent_model_input: The main latent input tensor (used for device/dtype reference)
@@ -245,54 +254,58 @@ class UNet2DConditionModelEngine:
         """
         for input_name, shape_spec in dummy_inputs.items():
             channels = shape_spec["channels"]
-            height = shape_spec["height"] 
+            height = shape_spec["height"]
             width = shape_spec["width"]
-            
+
             # Create zero tensor with appropriate shape
             zero_tensor = torch.zeros(
-                latent_model_input.shape[0], channels, height, width,
-                dtype=latent_model_input.dtype, device=latent_model_input.device
+                latent_model_input.shape[0],
+                channels,
+                height,
+                width,
+                dtype=latent_model_input.dtype,
+                device=latent_model_input.device,
             )
-            
+
             shape_dict[input_name] = zero_tensor.shape
             input_dict[input_name] = zero_tensor
 
     def _generate_dummy_controlnet_specs(self, latent_model_input: torch.Tensor) -> Dict:
         """
         Generate dummy ControlNet input specifications once and cache them.
-        
+
         Args:
             latent_model_input: The main latent input tensor (used for dimensions)
-            
+
         Returns:
             Dictionary containing dummy input specifications
         """
         # Get latent dimensions
         latent_height = latent_model_input.shape[2]
         latent_width = latent_model_input.shape[3]
-        
+
         # Calculate image dimensions (assuming 8x upsampling from latent)
         image_height = latent_height * 8
         image_width = latent_width * 8
-        
+
         # Get stored architecture info from engine (set during building)
-        unet_arch = getattr(self, 'unet_arch', {})
-        
+        unet_arch = getattr(self, "unet_arch", {})
+
         if not unet_arch:
             raise RuntimeError("No ControlNet architecture info available on engine. Cannot generate dummy inputs.")
-        
+
         # Use the same logic as UNet.get_control() to generate control input specs
         from ..models.models import UNet
-        
+
         # Create a temporary UNet model instance just to use its get_control method
         temp_unet = UNet(
             use_control=True,
             unet_arch=unet_arch,
             image_height=image_height,
             image_width=image_width,
-            min_batch_size=1  # Minimal params needed for get_control
+            min_batch_size=1,  # Minimal params needed for get_control
         )
-        
+
         return temp_unet.get_control(image_height, image_width)
 
     def to(self, *args, **kwargs):
@@ -307,7 +320,7 @@ class AutoencoderKLEngine:
         self,
         encoder_path: str,
         decoder_path: str,
-        stream: 'cuda.Stream',
+        stream: "cuda.Stream",
         scaling_factor: int,
         use_cuda_graph: bool = False,
     ):
@@ -370,7 +383,7 @@ class AutoencoderKLEngine:
 
 
 class SafetyCheckerEngine:
-    def __init__(self, filepath: str, stream: 'cuda.Stream', use_cuda_graph: bool = False):
+    def __init__(self, filepath: str, stream: "cuda.Stream", use_cuda_graph: bool = False):
         self.engine = Engine(filepath)
         self.stream = stream
         self.use_cuda_graph = use_cuda_graph
@@ -398,23 +411,26 @@ class SafetyCheckerEngine:
     def forward(self, *args, **kwargs):
         pass
 
+
 class NSFWDetectorEngine:
-    def __init__(self, filepath: str, stream: 'cuda.Stream', use_cuda_graph: bool = False):
+    def __init__(self, filepath: str, stream: "cuda.Stream", use_cuda_graph: bool = False):
         self.engine = Engine(filepath)
         self.stream = stream
         self.use_cuda_graph = use_cuda_graph
 
         # The resize shape, mean and std are fetched from the model/processor config
-        self.image_transforms = T.Compose([
-            T.Resize(size=(448, 448), interpolation=InterpolationMode.BICUBIC, max_size=None, antialias=True),
-            T.CenterCrop(size=(448, 448)),
-            T.Lambda(lambda x: x.clamp(0, 1)),
-            T.Normalize(mean=[0.4815, 0.4578, 0.4082], std=[0.2686, 0.2613, 0.2758])
-        ])
+        self.image_transforms = T.Compose(
+            [
+                T.Resize(size=(448, 448), interpolation=InterpolationMode.BICUBIC, max_size=None, antialias=True),
+                T.CenterCrop(size=(448, 448)),
+                T.Lambda(lambda x: x.clamp(0, 1)),
+                T.Normalize(mean=[0.4815, 0.4578, 0.4082], std=[0.2686, 0.2613, 0.2758]),
+            ]
+        )
 
         self.engine.load()
         self.engine.activate()
-        
+
     def __call__(self, image_tensor: torch.Tensor, threshold: float):
         pixel_values = self.image_transforms(image_tensor)
         self.engine.allocate_buffers(
@@ -426,16 +442,15 @@ class NSFWDetectorEngine:
         )
         logits = self.engine.infer(
             {"pixel_values": pixel_values},
-            self.stream,    
+            self.stream,
             use_cuda_graph=self.use_cuda_graph,
         )["logits"]
 
         probs = F.softmax(logits, dim=-1)
         nsfw_prob = 1 - probs[0, 0].item()
         return nsfw_prob >= threshold
-        
 
-    def to(self, *args, **kwargs):  
+    def to(self, *args, **kwargs):
         pass
 
     def forward(self, *args, **kwargs):

--- a/src/streamdiffusion/acceleration/tensorrt/runtime_engines/unet_engine.py
+++ b/src/streamdiffusion/acceleration/tensorrt/runtime_engines/unet_engine.py
@@ -319,6 +319,13 @@ class UNet2DConditionModelEngine:
 
         return temp_unet.get_control(image_height, image_width)
 
+    def dump_profile(self, last_n: int = 10) -> None:
+        """Delegate per-layer profiling summary to the underlying TRT Engine.
+
+        No-op when STREAMDIFFUSION_PROFILE_TRT is not set.
+        """
+        self.engine.dump_profile(last_n)
+
     def to(self, *args, **kwargs):
         pass
 
@@ -385,6 +392,14 @@ class AutoencoderKLEngine:
             use_cuda_graph=self.use_cuda_graph,
         )["images"]
         return DecoderOutput(sample=images)
+
+    def dump_profile(self, last_n: int = 10) -> None:
+        """Delegate per-layer profiling summary to encoder and decoder TRT Engines.
+
+        No-op when STREAMDIFFUSION_PROFILE_TRT is not set.
+        """
+        self.encoder.dump_profile(last_n)
+        self.decoder.dump_profile(last_n)
 
     def to(self, *args, **kwargs):
         pass

--- a/src/streamdiffusion/acceleration/tensorrt/runtime_engines/unet_engine.py
+++ b/src/streamdiffusion/acceleration/tensorrt/runtime_engines/unet_engine.py
@@ -24,6 +24,7 @@ class UNet2DConditionModelEngine:
         self.use_cuda_graph = use_cuda_graph
         self.use_control = False  # Will be set to True by wrapper if engine has ControlNet support
         self._cached_dummy_controlnet_inputs = None
+        self._cached_dummy_controlnet_tensors: Optional[Dict[str, torch.Tensor]] = None  # pre-alloc zero tensors
 
         # Enable VRAM monitoring only if explicitly requested (defaults to False for performance)
         self.debug_vram = os.getenv("STREAMDIFFUSION_DEBUG_VRAM", "").lower() in ("1", "true")
@@ -137,6 +138,7 @@ class UNet2DConditionModelEngine:
                                 latent_model_input
                             )
                             self._cached_latent_dims = (current_latent_height, current_latent_width)
+                            self._cached_dummy_controlnet_tensors = None  # invalidate tensor cache
                         except RuntimeError:
                             self._cached_dummy_controlnet_inputs = None
 
@@ -244,29 +246,38 @@ class UNet2DConditionModelEngine:
         self, dummy_inputs: Dict, latent_model_input: torch.Tensor, shape_dict: Dict, input_dict: Dict
     ):
         """
-        Add cached dummy inputs to the shape dictionary and input dictionary
+        Add dummy ControlNet zero tensors to shape/input dicts.
+        Tensors are pre-allocated once and reused — no per-call torch.zeros() malloc.
 
         Args:
             dummy_inputs: Dictionary containing dummy input specifications
-            latent_model_input: The main latent input tensor (used for device/dtype reference)
+            latent_model_input: The main latent input tensor (used for device/dtype/batch reference)
             shape_dict: Shape dictionary to update
             input_dict: Input dictionary to update
         """
-        for input_name, shape_spec in dummy_inputs.items():
-            channels = shape_spec["channels"]
-            height = shape_spec["height"]
-            width = shape_spec["width"]
+        batch_size = latent_model_input.shape[0]
 
-            # Create zero tensor with appropriate shape
-            zero_tensor = torch.zeros(
-                latent_model_input.shape[0],
-                channels,
-                height,
-                width,
-                dtype=latent_model_input.dtype,
-                device=latent_model_input.device,
-            )
+        # Invalidate cache if batch size or dtype changed (rare; only on pipeline reconfigure)
+        if self._cached_dummy_controlnet_tensors is not None:
+            first = next(iter(self._cached_dummy_controlnet_tensors.values()))
+            if first.shape[0] != batch_size or first.dtype != latent_model_input.dtype:
+                self._cached_dummy_controlnet_tensors = None
 
+        # Build cache on first call (or after invalidation)
+        if self._cached_dummy_controlnet_tensors is None:
+            self._cached_dummy_controlnet_tensors = {
+                input_name: torch.zeros(
+                    batch_size,
+                    shape_spec["channels"],
+                    shape_spec["height"],
+                    shape_spec["width"],
+                    dtype=latent_model_input.dtype,
+                    device=latent_model_input.device,
+                )
+                for input_name, shape_spec in dummy_inputs.items()
+            }
+
+        for input_name, zero_tensor in self._cached_dummy_controlnet_tensors.items():
             shape_dict[input_name] = zero_tensor.shape
             input_dict[input_name] = zero_tensor
 

--- a/src/streamdiffusion/acceleration/tensorrt/utilities.py
+++ b/src/streamdiffusion/acceleration/tensorrt/utilities.py
@@ -539,6 +539,24 @@ def build_engine(
 
 
 
+def _find_external_data_files(directory: str) -> list:
+    """Find external data files in a directory by checking common extensions.
+
+    torch.onnx.export may create .data files, while our pipeline uses .pb.
+    This detects both to ensure proper handling of >2GB ONNX models.
+    """
+    import os
+    external_exts = ('.pb', '.data', '.onnx.data', '.onnx_data')
+    result = []
+    try:
+        for f in os.listdir(directory):
+            if any(f.endswith(ext) for ext in external_exts):
+                result.append(f)
+    except OSError:
+        pass
+    return result
+
+
 def export_onnx(
     model,
     onnx_path: str,
@@ -628,14 +646,31 @@ def export_onnx(
         if is_large_model:
             import os
 
-            # Check file size on disk (avoids protobuf 2GB serialization limit in ByteSize())
-            if os.path.getsize(onnx_path) > 2147483648:  # 2GB
-                # Load the exported model for re-saving
-                onnx_model = onnx.load(onnx_path)
-                # Create directory for external data
-                onnx_dir = os.path.dirname(onnx_path)
-                
-                # Re-save with external data format
+            onnx_dir = os.path.dirname(onnx_path)
+            onnx_file_size = os.path.getsize(onnx_path)
+
+            # Check if torch.onnx.export already created external data files
+            # PyTorch may auto-save with .data extension for >2GB models
+            existing_external = _find_external_data_files(onnx_dir)
+
+            if onnx_file_size > 2147483648:  # >2GB single file
+                logger.info(f"ONNX file is {onnx_file_size / (1024**3):.2f} GB, converting to external data format...")
+                # Load the >2GB single-file model. The protobuf upb backend (used in protobuf 4.25.x)
+                # can handle >2GB messages. If this fails, it means protobuf can't parse it.
+                try:
+                    onnx_model = onnx.load(onnx_path)
+                except Exception as load_err:
+                    raise RuntimeError(
+                        f"Failed to load >2GB ONNX model ({onnx_file_size / (1024**3):.2f} GB): {load_err}\n"
+                        f"This may be a protobuf version issue. Ensure protobuf==4.25.3 is installed.\n"
+                        f"Run: pip install protobuf==4.25.3"
+                    ) from load_err
+                # Clean up any existing external data files before saving
+                for ef in existing_external:
+                    try:
+                        os.remove(os.path.join(onnx_dir, ef))
+                    except OSError:
+                        pass
                 onnx.save_model(
                     onnx_model,
                     onnx_path,
@@ -646,6 +681,29 @@ def export_onnx(
                 )
                 logger.info(f"Converted to external data format with weights in weights.pb")
                 del onnx_model
+            elif existing_external:
+                # torch.onnx.export already saved with external data (e.g., .data files)
+                # Normalize to weights.pb for consistent downstream detection
+                logger.info(f"Found existing external data files from torch export: {existing_external}")
+                onnx_model = onnx.load(onnx_path, load_external_data=True)
+                # Clean up old external data files
+                for ef in existing_external:
+                    try:
+                        os.remove(os.path.join(onnx_dir, ef))
+                    except OSError:
+                        pass
+                onnx.save_model(
+                    onnx_model,
+                    onnx_path,
+                    save_as_external_data=True,
+                    all_tensors_to_one_file=True,
+                    location="weights.pb",
+                    convert_attribute=False,
+                )
+                logger.info(f"Normalized external data to weights.pb")
+                del onnx_model
+            else:
+                logger.info(f"ONNX file is {onnx_file_size / (1024**3):.2f} GB (under 2GB), no external data conversion needed")
     del wrapped_model
     gc.collect()
     torch.cuda.empty_cache()
@@ -658,27 +716,35 @@ def optimize_onnx(
 ):
     import os
     import shutil
-    
-    # Check if external data files exist (indicating external data format was used)
+
     onnx_dir = os.path.dirname(onnx_path)
-    external_data_files = [f for f in os.listdir(onnx_dir) if f.endswith('.pb')]
+
+    # Detect external data files using comprehensive extension check
+    external_data_files = _find_external_data_files(onnx_dir)
     uses_external_data = len(external_data_files) > 0
-    
+
+    # Also check ONNX file size — if the main file is small but no external data detected,
+    # something may be wrong (torch may have saved external data with an unexpected name)
+    onnx_file_size = os.path.getsize(onnx_path)
+
     if uses_external_data:
+        logger.info(f"Optimizing ONNX with external data (found: {external_data_files})")
         # Load model with external data
         onnx_model = onnx.load(onnx_path, load_external_data=True)
         onnx_opt_graph = model_data.optimize(onnx_model)
-        
+        del onnx_model
+
         # Create output directory
         opt_dir = os.path.dirname(onnx_opt_path)
         os.makedirs(opt_dir, exist_ok=True)
-        
-        # Clean up existing files in output directory
+
+        # Clean up existing ONNX/external data files in output directory
         if os.path.exists(opt_dir):
+            cleanup_exts = ('.pb', '.onnx', '.data', '.onnx.data', '.onnx_data')
             for f in os.listdir(opt_dir):
-                if f.endswith('.pb') or f.endswith('.onnx'):
+                if any(f.endswith(ext) for ext in cleanup_exts):
                     os.remove(os.path.join(opt_dir, f))
-        
+
         # Save optimized model with external data format
         onnx.save_model(
             onnx_opt_graph,
@@ -689,12 +755,40 @@ def optimize_onnx(
             convert_attribute=False,
         )
         logger.info(f"ONNX optimization complete with external data")
-        
+
     else:
         # Standard optimization for smaller models
+        logger.info(f"Optimizing ONNX (single file, {onnx_file_size / (1024**2):.1f} MB)")
         onnx_opt_graph = model_data.optimize(onnx.load(onnx_path))
-        onnx.save(onnx_opt_graph, onnx_opt_path)
-    
+
+        # Check if the optimized graph is too large for single-file serialization
+        try:
+            opt_size = onnx_opt_graph.ByteSize()
+        except Exception:
+            opt_size = 0
+
+        if opt_size > 2000000000:  # ~2GB with margin
+            logger.info(f"Optimized model is {opt_size / (1024**3):.2f} GB, saving with external data")
+            onnx.save_model(
+                onnx_opt_graph,
+                onnx_opt_path,
+                save_as_external_data=True,
+                all_tensors_to_one_file=True,
+                location="weights.pb",
+                convert_attribute=False,
+            )
+        else:
+            onnx.save(onnx_opt_graph, onnx_opt_path)
+
+    # Verify the output file was created
+    if not os.path.exists(onnx_opt_path):
+        raise RuntimeError(f"ONNX optimization failed: output file was not created at {onnx_opt_path}")
+    opt_file_size = os.path.getsize(onnx_opt_path)
+    if opt_file_size == 0:
+        os.remove(onnx_opt_path)
+        raise RuntimeError(f"ONNX optimization failed: output file is empty (0 bytes) at {onnx_opt_path}")
+    logger.info(f"Optimized ONNX saved: {onnx_opt_path} ({opt_file_size / (1024**2):.1f} MB)")
+
     del onnx_opt_graph
     gc.collect()
     torch.cuda.empty_cache()

--- a/src/streamdiffusion/acceleration/tensorrt/utilities.py
+++ b/src/streamdiffusion/acceleration/tensorrt/utilities.py
@@ -130,24 +130,24 @@ def detect_gpu_profile(device: int = 0) -> GPUBuildProfile:
     sms = props.multi_processor_count
 
     # --- Tier selection ---
-    # opt_level=3 for all tiers: level-4's "always compile dynamic kernels" is
-    # unnecessary with fully static shapes (build_static_batch + build_dynamic_shape=False)
-    # and triggers tactic 0x3e9 "Assertion g.nodes.size() == 0" failures in TRT 10.12.
-    # Level-3 heuristic selection produces equivalent results for static profiles.
-    # Level-5 still avoided — causes OOM during tactic profiling (160 GiB requests).
+    # opt_level=4 for all tiers: always compiles dynamic kernels (better kernel
+    # selection than level-3 heuristics, even for static shapes). Level 5 avoided —
+    # causes OOM during tactic profiling (160 GiB requests observed).
+    # NOTE: tactic 0x3e9 "Assertion g.nodes.size() == 0" errors in TRT 10.12 are
+    # a known TRT bug — benign, the tactic is skipped and build succeeds.
     if cc >= (12, 0):
         tier = "blackwell"
-        opt_level = 3
+        opt_level = 4
         tiling = "FULL"
         max_ws_cap = 16 * (2 ** 30)   # 16 GiB cap
     elif cc >= (8, 9):                 # Ada Lovelace (8.9 exactly)
         tier = "ada"
-        opt_level = 3
+        opt_level = 4
         tiling = "MODERATE"
         max_ws_cap = 12 * (2 ** 30)   # 12 GiB cap
     elif cc >= (8, 0):                 # Ampere (8.0 – 8.8)
         tier = "ampere"
-        opt_level = 3
+        opt_level = 4
         tiling = "FAST"
         max_ws_cap = 8 * (2 ** 30)    # 8 GiB cap
     else:
@@ -224,12 +224,11 @@ def _apply_gpu_profile_to_config(
         return
 
     # builder_optimization_level (0–5):
-    #   3 = heuristic-based tactic selection — optimal for fully static shapes
-    #   4 = always compiles dynamic kernels — unnecessary with static shapes,
-    #       triggers tactic 0x3e9 assertion failures in TRT 10.12
-    #   5 = compares dynamic vs static kernels — OOMs during tactic profiling
-    # Level 3 used for all tiers: static builds (build_dynamic_shape=False) don't
-    # benefit from dynamic-kernel compilation, and level 4 causes spurious errors.
+    #   4 = always compiles dynamic kernels (better than level-3 heuristics)
+    #   5 = additionally compares dynamic vs static kernels — causes OOM during
+    #       tactic profiling on dynamic-shape engines (160 GiB requests observed).
+    # We use level 4 for all tiers to get the dynamic-kernel benefit without the
+    # level-5 exhaustive comparison that OOMs.
     try:
         config.builder_optimization_level = gpu_profile.builder_optimization_level
         logger.info(f"[TRT Config] builder_optimization_level={gpu_profile.builder_optimization_level}")

--- a/src/streamdiffusion/acceleration/tensorrt/utilities.py
+++ b/src/streamdiffusion/acceleration/tensorrt/utilities.py
@@ -31,6 +31,7 @@ import onnx_graphsurgeon as gs
 import tensorrt as trt
 import torch
 
+
 # cuda-python 13.x renamed 'cudart' to 'cuda.bindings.runtime'
 try:
     from cuda.bindings import runtime as cudart
@@ -242,8 +243,14 @@ class Engine:
         enable_all_tactics=False,
         timing_cache=None,
         workspace_size=0,
+        fp8=False,
     ):
         logger.info(f"Building TensorRT engine for {onnx_path}: {self.engine_path}")
+
+        if fp8:
+            self._build_fp8(onnx_path, input_profile, workspace_size, enable_all_tactics)
+            return
+
         p = Profile()
         if input_profile:
             for name, dims in input_profile.items():
@@ -273,6 +280,67 @@ class Engine:
             save_timing_cache=timing_cache,
         )
         save_engine(engine, path=self.engine_path)
+
+    def _build_fp8(self, onnx_path, input_profile, workspace_size, enable_all_tactics):
+        """
+        Build a TRT engine from a Q/DQ-annotated FP8 ONNX using the raw TRT builder API.
+
+        Polygraphy 0.49.26's CreateConfig does not support fp8=, so we use the raw
+        TensorRT Python API directly. The STRONGLY_TYPED network flag is required to
+        preserve the Q/DQ precision annotations inserted by nvidia-modelopt.
+
+        Args:
+            onnx_path: Path to *.fp8.onnx (Q/DQ-annotated by fp8_quantize.py).
+            input_profile: Dict of {name: (min, opt, max)} shapes.
+            workspace_size: TRT workspace limit in bytes.
+            enable_all_tactics: If True, allow all TRT tactic sources.
+        """
+        TRT_LOGGER = trt.Logger(trt.Logger.WARNING)
+
+        builder = trt.Builder(TRT_LOGGER)
+
+        # STRONGLY_TYPED: required for FP8. Tells TRT to use the data-type annotations
+        # from Q/DQ nodes rather than running its own precision heuristics.
+        network_flags = 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
+        network = builder.create_network(network_flags)
+
+        parser = trt.OnnxParser(network, TRT_LOGGER)
+        success = parser.parse_from_file(onnx_path)
+        if not success:
+            errors = [parser.get_error(i) for i in range(parser.num_errors)]
+            raise RuntimeError(
+                f"TRT ONNX parser failed for FP8 engine: {onnx_path}\n"
+                + "\n".join(str(e) for e in errors)
+            )
+
+        config = builder.create_builder_config()
+        config.set_flag(trt.BuilderFlag.FP8)
+        config.set_flag(trt.BuilderFlag.FP16)   # FP16 fallback for non-quantized ops
+        config.set_flag(trt.BuilderFlag.TF32)
+        config.set_flag(trt.BuilderFlag.STRONGLY_TYPED)
+
+        if workspace_size > 0:
+            config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_size)
+
+        if input_profile:
+            profile = builder.create_optimization_profile()
+            for name, dims in input_profile.items():
+                assert len(dims) == 3, f"Expected (min, opt, max) for {name}"
+                profile.set_shape(name, min=dims[0], opt=dims[1], max=dims[2])
+            config.add_optimization_profile(profile)
+
+        logger.info(f"[FP8] Building TRT FP8 engine (STRONGLY_TYPED): {self.engine_path}")
+        serialized = builder.build_serialized_network(network, config)
+        if serialized is None:
+            raise RuntimeError(
+                f"TRT FP8 engine build failed for {onnx_path}. "
+                "Check TRT logs above for details."
+            )
+
+        with open(self.engine_path, "wb") as f:
+            f.write(serialized)
+
+        logger.info(f"[FP8] Engine saved: {self.engine_path} ({len(serialized) / 1024 / 1024:.0f} MB)")
 
     def load(self):
         logger.info(f"Loading TensorRT engine: {self.engine_path}")
@@ -516,6 +584,7 @@ def build_engine(
     build_dynamic_shape: bool = False,
     build_all_tactics: bool = False,
     build_enable_refit: bool = False,
+    fp8: bool = False,
 ):
     _, free_mem, _ = cudart.cudaMemGetInfo()
     GiB = 2**30
@@ -540,6 +609,7 @@ def build_engine(
         enable_refit=build_enable_refit,
         enable_all_tactics=build_all_tactics,
         workspace_size=max_workspace_size,
+        fp8=fp8,
     )
 
     return engine

--- a/src/streamdiffusion/acceleration/tensorrt/utilities.py
+++ b/src/streamdiffusion/acceleration/tensorrt/utilities.py
@@ -22,7 +22,9 @@ import gc
 
 # Set up logger for this module
 import logging
+import os
 from collections import OrderedDict
+from dataclasses import dataclass
 from typing import Optional, Union
 
 import numpy as np
@@ -40,14 +42,7 @@ except ImportError:
 from PIL import Image
 from polygraphy import cuda
 from polygraphy.backend.common import bytes_from_path
-from polygraphy.backend.trt import (
-    CreateConfig,
-    Profile,
-    engine_from_bytes,
-    engine_from_network,
-    network_from_onnx_path,
-    save_engine,
-)
+from polygraphy.backend.trt import engine_from_bytes
 
 from .models.models import CLIP, VAE, BaseModel, UNet, VAEEncoder
 
@@ -57,6 +52,244 @@ logger = logging.getLogger(__name__)
 TRT_LOGGER = trt.Logger(trt.Logger.ERROR)
 
 from ...model_detection import detect_model
+
+
+# ---------------------------------------------------------------------------
+# GPU Hardware Profile — hardware-aware TRT builder configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class GPUBuildProfile:
+    """
+    Hardware-aware TRT builder configuration derived from CUDA device properties.
+
+    All parameters are auto-selected based on GPU architecture tier:
+      - Ampere  (CC 8.0–8.8): Conservative — small L2, preserve VRAM
+      - Ada     (CC 8.9):      Balanced   — large L2, benefit from deeper tiling/opt
+      - Blackwell (CC 12.0+):  Aggressive — massive L2, max search depth
+    """
+    gpu_name: str
+    compute_capability: tuple
+    l2_cache_bytes: int
+    vram_bytes: int
+    sm_count: int
+    tier: str  # "ampere", "ada", "blackwell", "unknown"
+
+    # IBuilderConfig parameters
+    builder_optimization_level: int     # 0–5; higher = better kernels, longer build
+    tiling_optimization_level: str      # "NONE"/"FAST"/"MODERATE"/"FULL"
+    l2_limit_for_tiling: int            # bytes; target L2 budget for tiling
+    max_aux_streams: int                # reserved; NOT applied (TRT heuristic is better)
+    sparse_weights: bool                # examine weights for 2:4 sparsity (Ampere+)
+    enable_runtime_activation_resize: bool  # RUNTIME_ACTIVATION_RESIZE_10_10
+    max_workspace_cap_bytes: int        # hard cap on workspace (before free-mem calc)
+
+
+def detect_gpu_profile(device: int = 0) -> GPUBuildProfile:
+    """
+    Detect the current GPU and return hardware-optimal TRT builder parameters.
+
+    Called once at the start of every engine build so that all IBuilderConfig
+    settings are tuned to the exact GPU running the build.
+
+    Tiers and rationale
+    -------------------
+    Ampere (CC 8.0–8.8, e.g. RTX 3090 — 6 MiB L2, 82 SMs):
+      - Opt level 4: always compiles dynamic kernels (better than level-3 heuristics)
+      - Tiling FAST (static shapes only): small L2 gains little from deep search
+      - 8 GiB workspace cap: conserve VRAM on 24 GB cards
+
+    Ada Lovelace (CC 8.9, e.g. RTX 4090 — 72 MiB L2, 128 SMs):
+      - Opt level 4: dynamic kernels without level-5 profiling OOM risk
+      - Tiling MODERATE (static shapes only): 12× more L2 makes tiling worthwhile
+      - 12 GiB workspace cap
+
+    Blackwell (CC 12.0+, e.g. RTX 5090 — 128 MiB L2, ~170 SMs):
+      - Opt level 4: same rationale — level 5 causes OOM during tactic profiling
+      - Tiling FULL (static shapes only): massive L2 warrants widest search
+      - 16 GiB workspace cap
+
+    Note: tiling_optimization_level and l2_limit_for_tiling are only effective for
+    static-shape engines. TRT confirms: "Graph contains symbolic shape, l2tc doesn't
+    take effect." For dynamic-shape builds (our default), these are skipped entirely
+    to avoid warning spam and wasted build time.
+
+    max_aux_streams is NOT set — TRT's own heuristic is better than a fixed value.
+    Setting it explicitly causes "[MS] Multi stream is disabled" warnings on simple
+    models (VAE) without proven benefit on complex ones (UNet).
+    """
+    try:
+        props = torch.cuda.get_device_properties(device)
+    except Exception as e:
+        logger.warning(f"[TRT Build] Could not query GPU properties: {e} — using fallback profile")
+        return _fallback_profile()
+
+    cc = (props.major, props.minor)
+    l2 = props.L2_cache_size
+    vram = props.total_memory
+    sms = props.multi_processor_count
+
+    # --- Tier selection ---
+    # opt_level=4 for all tiers: always compiles dynamic kernels (better than
+    # level-3 heuristics) without level-5's "compare dynamic vs static" extra pass
+    # which OOMs during tactic profiling on dynamic-shape engines (160 GiB request).
+    if cc >= (12, 0):
+        tier = "blackwell"
+        opt_level = 4
+        tiling = "FULL"
+        max_ws_cap = 16 * (2 ** 30)   # 16 GiB cap
+    elif cc >= (8, 9):                 # Ada Lovelace (8.9 exactly)
+        tier = "ada"
+        opt_level = 4
+        tiling = "MODERATE"
+        max_ws_cap = 12 * (2 ** 30)   # 12 GiB cap
+    elif cc >= (8, 0):                 # Ampere (8.0 – 8.8)
+        tier = "ampere"
+        opt_level = 4
+        tiling = "FAST"
+        max_ws_cap = 8 * (2 ** 30)    # 8 GiB cap
+    else:
+        # Pre-Ampere or unknown — use conservative defaults
+        tier = "unknown"
+        opt_level = 3
+        tiling = "NONE"
+        max_ws_cap = 8 * (2 ** 30)
+
+    profile = GPUBuildProfile(
+        gpu_name=props.name,
+        compute_capability=cc,
+        l2_cache_bytes=l2,
+        vram_bytes=vram,
+        sm_count=sms,
+        tier=tier,
+        builder_optimization_level=opt_level,
+        tiling_optimization_level=tiling,
+        l2_limit_for_tiling=l2,        # use full L2 as tiling budget (static builds only)
+        max_aux_streams=0,              # 0 = let TRT decide (avoids "[MS] disabled" spam)
+        sparse_weights=True,            # always examine; no downside if not sparse
+        enable_runtime_activation_resize=True,
+        max_workspace_cap_bytes=max_ws_cap,
+    )
+
+    logger.info(
+        f"[TRT Build] GPU detected: {props.name} | "
+        f"CC {cc[0]}.{cc[1]} | Tier: {tier} | "
+        f"L2: {l2 // (1024 * 1024)} MiB | VRAM: {vram // (1024 ** 3)} GiB | "
+        f"opt_level={opt_level}"
+    )
+    return profile
+
+
+def _fallback_profile() -> GPUBuildProfile:
+    """Conservative fallback when GPU detection fails."""
+    return GPUBuildProfile(
+        gpu_name="unknown",
+        compute_capability=(8, 0),
+        l2_cache_bytes=6 * 1024 * 1024,
+        vram_bytes=24 * (2 ** 30),
+        sm_count=82,
+        tier="unknown",
+        builder_optimization_level=3,
+        tiling_optimization_level="NONE",
+        l2_limit_for_tiling=6 * 1024 * 1024,
+        max_aux_streams=0,              # reserved; NOT applied
+        sparse_weights=False,
+        enable_runtime_activation_resize=True,
+        max_workspace_cap_bytes=8 * (2 ** 30),
+    )
+
+
+def _apply_gpu_profile_to_config(
+    config: "trt.IBuilderConfig",
+    gpu_profile: Optional[GPUBuildProfile],
+    dynamic_shapes: bool = True,
+) -> None:
+    """
+    Apply hardware-aware IBuilderConfig parameters that Polygraphy does not expose.
+
+    Called for both FP16 and FP8 builds after the config object is created.
+    All settings gracefully degrade if the TRT version doesn't support a feature.
+
+    Args:
+        config: TRT IBuilderConfig to modify.
+        gpu_profile: Hardware-detected build parameters from detect_gpu_profile().
+        dynamic_shapes: Whether this engine uses dynamic input shapes.
+            - True  (default): tiling and l2_limit skipped — TRT confirms these have
+              no effect on symbolic-shape graphs and only produce warning spam.
+            - False (static): tiling and l2_limit applied for full L2 cache benefit.
+    """
+    if gpu_profile is None:
+        return
+
+    # builder_optimization_level (0–5):
+    #   4 = always compiles dynamic kernels (better than level-3 heuristics)
+    #   5 = additionally compares dynamic vs static kernels — causes OOM during
+    #       tactic profiling on dynamic-shape engines (160 GiB requests observed).
+    # We use level 4 for all tiers to get the dynamic-kernel benefit without the
+    # level-5 exhaustive comparison that OOMs.
+    try:
+        config.builder_optimization_level = gpu_profile.builder_optimization_level
+        logger.info(f"[TRT Config] builder_optimization_level={gpu_profile.builder_optimization_level}")
+    except AttributeError:
+        logger.debug("[TRT Config] builder_optimization_level not supported — skipping")
+
+    # tiling_optimization_level + l2_limit_for_tiling:
+    # TRT's L2 tiling cache optimization requires static/concrete shapes to work.
+    # For dynamic-shape engines, TRT emits: "Graph contains symbolic shape, l2tc
+    # doesn't take effect" for every applicable layer — pure warning spam with zero
+    # benefit. Skipped when dynamic_shapes=True.
+    if not dynamic_shapes and gpu_profile.tiling_optimization_level != "NONE":
+        try:
+            tiling_map = {
+                "NONE": trt.TilingOptimizationLevel.NONE,
+                "FAST": trt.TilingOptimizationLevel.FAST,
+                "MODERATE": trt.TilingOptimizationLevel.MODERATE,
+                "FULL": trt.TilingOptimizationLevel.FULL,
+            }
+            tiling_level = tiling_map.get(gpu_profile.tiling_optimization_level, trt.TilingOptimizationLevel.NONE)
+            config.tiling_optimization_level = tiling_level
+            logger.info(f"[TRT Config] tiling_optimization_level={gpu_profile.tiling_optimization_level}")
+        except AttributeError:
+            logger.debug("[TRT Config] tiling_optimization_level not supported — skipping")
+
+        try:
+            if gpu_profile.l2_limit_for_tiling > 0:
+                config.l2_limit_for_tiling = gpu_profile.l2_limit_for_tiling
+                logger.info(
+                    f"[TRT Config] l2_limit_for_tiling={gpu_profile.l2_limit_for_tiling // (1024 * 1024)} MiB"
+                )
+        except AttributeError:
+            logger.debug("[TRT Config] l2_limit_for_tiling not supported — skipping")
+    elif dynamic_shapes:
+        logger.debug(
+            "[TRT Config] tiling_optimization_level/l2_limit skipped — dynamic shapes "
+            "(would produce '[l2tc] VALIDATE FAIL' warnings with no effect)"
+        )
+
+    # max_aux_streams: NOT SET — let TRT use its own heuristic.
+    # Setting an explicit value causes "[MS] Multi stream is disabled" warnings on
+    # any model where TRT can't assign that many streams (e.g. VAE decoder which is
+    # too sequential). TRT's heuristic silently chooses the right value per model.
+
+    # SPARSE_WEIGHTS: let TRT examine weight tensors for structured 2:4 sparsity
+    # and use Sparse Tensor Core kernels if suitable. Zero downside for dense weights.
+    if gpu_profile.sparse_weights:
+        try:
+            config.set_flag(trt.BuilderFlag.SPARSE_WEIGHTS)
+            logger.info("[TRT Config] SPARSE_WEIGHTS enabled")
+        except Exception:
+            logger.debug("[TRT Config] SPARSE_WEIGHTS not supported — skipping")
+
+    # RUNTIME_ACTIVATION_RESIZE_10_10: allows update_device_memory_size_for_shapes()
+    # to shrink activation memory when actual input shapes are smaller than max profile
+    # dims. Our engines use dynamic shapes (min 256 → max 1024), so running at 512x512
+    # can save ~50–75% of peak activation VRAM compared to always allocating for 1024.
+    if gpu_profile.enable_runtime_activation_resize:
+        try:
+            config.set_preview_feature(trt.PreviewFeature.RUNTIME_ACTIVATION_RESIZE_10_10, True)
+            logger.info("[TRT Config] RUNTIME_ACTIVATION_RESIZE_10_10 enabled")
+        except Exception:
+            logger.debug("[TRT Config] RUNTIME_ACTIVATION_RESIZE_10_10 not supported — skipping")
 
 
 # Map of numpy dtype -> torch dtype
@@ -244,42 +477,116 @@ class Engine:
         timing_cache=None,
         workspace_size=0,
         fp8=False,
+        gpu_profile: Optional["GPUBuildProfile"] = None,
+        dynamic_shapes: bool = True,
     ):
         logger.info(f"Building TensorRT engine for {onnx_path}: {self.engine_path}")
 
         if fp8:
-            self._build_fp8(onnx_path, input_profile, workspace_size, enable_all_tactics)
+            self._build_fp8(
+                onnx_path, input_profile, workspace_size, enable_all_tactics,
+                timing_cache=timing_cache, gpu_profile=gpu_profile,
+                dynamic_shapes=dynamic_shapes,
+            )
             return
 
-        p = Profile()
-        if input_profile:
-            for name, dims in input_profile.items():
-                assert len(dims) == 3
-                p.add(name, min=dims[0], opt=dims[1], max=dims[2])
+        # --- Build using raw TRT API for full IBuilderConfig access ---
+        # Polygraphy's CreateConfig does not expose: tiling_optimization_level,
+        # l2_limit_for_tiling, max_aux_streams, builder_optimization_level,
+        # set_preview_feature, or SPARSE_WEIGHTS. We use the raw API (same as
+        # the FP8 path) so all parameters are available for both precision paths.
 
-        config_kwargs = {}
+        build_logger = trt.Logger(trt.Logger.WARNING)
+        builder = trt.Builder(build_logger)
 
+        network_flags = 0
+        network = builder.create_network(network_flags)
+
+        parser = trt.OnnxParser(network, build_logger)
+        parser.set_flag(trt.OnnxParserFlag.NATIVE_INSTANCENORM)
+        success = parser.parse_from_file(onnx_path)
+        if not success:
+            errors = [parser.get_error(i) for i in range(parser.num_errors)]
+            raise RuntimeError(
+                f"TRT ONNX parser failed for FP16 engine: {onnx_path}\n"
+                + "\n".join(str(e) for e in errors)
+            )
+
+        config = builder.create_builder_config()
+
+        # Precision flags
+        if fp16:
+            config.set_flag(trt.BuilderFlag.FP16)
+        config.set_flag(trt.BuilderFlag.TF32)
+
+        if enable_refit:
+            config.set_flag(trt.BuilderFlag.REFIT)
+
+        # Workspace
         if workspace_size > 0:
-            config_kwargs["memory_pool_limits"] = {trt.MemoryPoolType.WORKSPACE: workspace_size}
-        # tactic_sources restriction removed: TacticSource.CUBLAS (deprecated TRT 10.0)
-        # and CUBLAS_LT (deprecated TRT 9.0) are no longer meaningful on TRT 10.x.
-        # TRT uses its default tactic selection for all builds regardless of enable_all_tactics.
+            config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_size)
 
-        engine = engine_from_network(
-            network_from_onnx_path(onnx_path, flags=[trt.OnnxParserFlag.NATIVE_INSTANCENORM]),
-            config=CreateConfig(
-                fp16=fp16,
-                tf32=True,
-                refittable=enable_refit,
-                profiles=[p],
-                load_timing_cache=timing_cache,
-                **config_kwargs,
-            ),
-            save_timing_cache=timing_cache,
-        )
-        save_engine(engine, path=self.engine_path)
+        # Optimization profile
+        if input_profile:
+            profile = builder.create_optimization_profile()
+            for name, dims in input_profile.items():
+                assert len(dims) == 3, f"Expected (min, opt, max) for {name}"
+                profile.set_shape(name, min=dims[0], opt=dims[1], max=dims[2])
+            config.add_optimization_profile(profile)
 
-    def _build_fp8(self, onnx_path, input_profile, workspace_size, enable_all_tactics):
+        # Timing cache — load existing or create fresh
+        cache_data = b""
+        if timing_cache and os.path.exists(timing_cache):
+            try:
+                with open(timing_cache, "rb") as f:
+                    cache_data = f.read()
+                logger.info(f"[TRT Build] Loaded timing cache: {timing_cache} ({len(cache_data) // 1024} KB)")
+            except Exception as e:
+                logger.warning(f"[TRT Build] Could not load timing cache {timing_cache}: {e} — starting fresh")
+                cache_data = b""
+        trt_cache = config.create_timing_cache(cache_data)
+        config.set_timing_cache(trt_cache, ignore_mismatch=False)
+
+        # Apply hardware-aware profile parameters
+        _apply_gpu_profile_to_config(config, gpu_profile, dynamic_shapes=dynamic_shapes)
+
+        # Build and serialize
+        logger.info(f"[TRT Build] Building FP16 engine (raw API): {self.engine_path}")
+        serialized = builder.build_serialized_network(network, config)
+        if serialized is None:
+            raise RuntimeError(
+                f"TRT FP16 engine build failed for {onnx_path}. "
+                "Check TRT logs above for details."
+            )
+
+        with open(self.engine_path, "wb") as f:
+            f.write(serialized)
+
+        # Save timing cache for next build
+        if timing_cache:
+            try:
+                updated_cache = config.get_timing_cache()
+                if updated_cache is not None:
+                    os.makedirs(os.path.dirname(timing_cache), exist_ok=True)
+                    with open(timing_cache, "wb") as f:
+                        f.write(updated_cache.serialize())
+                    logger.info(f"[TRT Build] Saved timing cache: {timing_cache}")
+            except Exception as e:
+                logger.warning(f"[TRT Build] Could not save timing cache: {e}")
+
+        size_bytes = getattr(serialized, 'nbytes', None) or len(serialized)
+        logger.info(f"[TRT Build] FP16 engine saved: {self.engine_path} ({size_bytes / 1024 / 1024:.0f} MB)")
+
+    def _build_fp8(
+        self,
+        onnx_path,
+        input_profile,
+        workspace_size,
+        enable_all_tactics,
+        timing_cache=None,
+        gpu_profile: Optional["GPUBuildProfile"] = None,
+        dynamic_shapes: bool = True,
+    ):
         """
         Build a TRT engine from a Q/DQ-annotated FP8 ONNX using the raw TRT builder API.
 
@@ -292,17 +599,23 @@ class Engine:
             input_profile: Dict of {name: (min, opt, max)} shapes.
             workspace_size: TRT workspace limit in bytes.
             enable_all_tactics: If True, allow all TRT tactic sources.
+            timing_cache: Path to timing cache file for load/save.
+            gpu_profile: Hardware-aware build parameters from detect_gpu_profile().
+            dynamic_shapes: Whether the engine uses dynamic input shapes.
         """
-        TRT_LOGGER = trt.Logger(trt.Logger.WARNING)
+        build_logger = trt.Logger(trt.Logger.WARNING)
 
-        builder = trt.Builder(TRT_LOGGER)
+        builder = trt.Builder(build_logger)
 
         # STRONGLY_TYPED: required for FP8. Tells TRT to use the data-type annotations
         # from Q/DQ nodes rather than running its own precision heuristics.
         network_flags = 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
         network = builder.create_network(network_flags)
 
-        parser = trt.OnnxParser(network, TRT_LOGGER)
+        parser = trt.OnnxParser(network, build_logger)
+        # NATIVE_INSTANCENORM: use TRT's fused InstanceNorm/GroupNorm kernel instead
+        # of decomposing into primitive ops. Diffusion UNets use GroupNorm heavily.
+        parser.set_flag(trt.OnnxParserFlag.NATIVE_INSTANCENORM)
         success = parser.parse_from_file(onnx_path)
         if not success:
             errors = [parser.get_error(i) for i in range(parser.num_errors)]
@@ -313,9 +626,9 @@ class Engine:
 
         config = builder.create_builder_config()
         # BuilderFlag.STRONGLY_TYPED was removed in TRT 10.12; the network-level flag
-        # (NetworkDefinitionCreationFlag.STRONGLY_TYPED, line ~304) is now the only
-        # mechanism. On older TRT versions where BuilderFlag.STRONGLY_TYPED still exists,
-        # we also set precision flags on the config so the builder considers FP8/FP16 kernels.
+        # (NetworkDefinitionCreationFlag.STRONGLY_TYPED, set on network creation above)
+        # is now the only mechanism. On older TRT versions where BuilderFlag.STRONGLY_TYPED
+        # still exists, we also set precision flags on the config.
         if hasattr(trt.BuilderFlag, 'STRONGLY_TYPED'):
             # TRT < 10.12: BuilderFlag.STRONGLY_TYPED exists — set precision flags and
             # the builder-level STRONGLY_TYPED flag alongside the network-level flag.
@@ -336,6 +649,22 @@ class Engine:
                 profile.set_shape(name, min=dims[0], opt=dims[1], max=dims[2])
             config.add_optimization_profile(profile)
 
+        # Timing cache — load existing or create fresh
+        cache_data = b""
+        if timing_cache and os.path.exists(timing_cache):
+            try:
+                with open(timing_cache, "rb") as f:
+                    cache_data = f.read()
+                logger.info(f"[FP8] Loaded timing cache: {timing_cache} ({len(cache_data) // 1024} KB)")
+            except Exception as e:
+                logger.warning(f"[FP8] Could not load timing cache {timing_cache}: {e} — starting fresh")
+                cache_data = b""
+        trt_cache = config.create_timing_cache(cache_data)
+        config.set_timing_cache(trt_cache, ignore_mismatch=False)
+
+        # Apply hardware-aware profile parameters
+        _apply_gpu_profile_to_config(config, gpu_profile, dynamic_shapes=dynamic_shapes)
+
         logger.info(f"[FP8] Building TRT FP8 engine (STRONGLY_TYPED): {self.engine_path}")
         serialized = builder.build_serialized_network(network, config)
         if serialized is None:
@@ -346,6 +675,18 @@ class Engine:
 
         with open(self.engine_path, "wb") as f:
             f.write(serialized)
+
+        # Save timing cache for next build
+        if timing_cache:
+            try:
+                updated_cache = config.get_timing_cache()
+                if updated_cache is not None:
+                    os.makedirs(os.path.dirname(timing_cache), exist_ok=True)
+                    with open(timing_cache, "wb") as f:
+                        f.write(updated_cache.serialize())
+                    logger.info(f"[FP8] Saved timing cache: {timing_cache}")
+            except Exception as e:
+                logger.warning(f"[FP8] Could not save timing cache: {e}")
 
         size_bytes = getattr(serialized, 'nbytes', None) or len(serialized)
         logger.info(f"[FP8] Engine saved: {self.engine_path} ({size_bytes / 1024 / 1024:.0f} MB)")
@@ -386,7 +727,16 @@ class Engine:
             else:
                 shape = self.engine.get_tensor_shape(name)
 
-            dtype_np = trt.nptype(self.engine.get_tensor_dtype(name))
+            trt_dtype = self.engine.get_tensor_dtype(name)
+            try:
+                dtype_np = trt.nptype(trt_dtype)
+                torch_dtype = numpy_to_torch_dtype_dict[dtype_np]
+            except TypeError:
+                # FP8 (FLOAT8E4M3FN) has no numpy equivalent — map directly to torch
+                if trt_dtype == trt.DataType.FP8:
+                    torch_dtype = torch.float8_e4m3fn
+                else:
+                    raise
             mode = self.engine.get_tensor_mode(name)
 
             if mode == trt.TensorIOMode.INPUT:
@@ -395,7 +745,7 @@ class Engine:
                         f"TensorRT: set_input_shape failed for '{name}' with shape {shape}"
                     )
 
-            tensor = torch.empty(tuple(shape), dtype=numpy_to_torch_dtype_dict[dtype_np]).to(device=device)
+            tensor = torch.empty(tuple(shape), dtype=torch_dtype).to(device=device)
             self.tensors[name] = tensor
 
         # Cache allocation parameters for reuse check
@@ -600,14 +950,31 @@ def build_engine(
     build_enable_refit: bool = False,
     fp8: bool = False,
 ):
+    # --- Step 0: Detect GPU and select hardware-optimal build parameters ---
+    gpu_profile = detect_gpu_profile(device=torch.cuda.current_device())
+
+    # --- Workspace sizing: leave 2 GiB for activations, cap per GPU tier ---
     _, free_mem, _ = cudart.cudaMemGetInfo()
-    GiB = 2**30
+    GiB = 2 ** 30
     if free_mem > 6 * GiB:
         activation_carveout = 2 * GiB
-        max_workspace_size = min(free_mem - activation_carveout, 8 * GiB)
+        max_workspace_size = min(
+            free_mem - activation_carveout,
+            gpu_profile.max_workspace_cap_bytes,
+        )
     else:
         max_workspace_size = 0
-    logger.info(f"TRT workspace: free_mem={free_mem / GiB:.1f}GiB, max_workspace={max_workspace_size / GiB:.1f}GiB")
+    logger.info(
+        f"[TRT Build] Workspace: free={free_mem / GiB:.1f} GiB, "
+        f"cap={gpu_profile.max_workspace_cap_bytes / GiB:.1f} GiB, "
+        f"allocated={max_workspace_size / GiB:.1f} GiB"
+    )
+
+    # --- Timing cache: shared per engine directory ---
+    # Cache is stored alongside the engine files so it persists across rebuilds.
+    engine_dir = os.path.dirname(engine_path)
+    timing_cache_path = os.path.join(engine_dir, "timing.cache")
+
     engine = Engine(engine_path)
     input_profile = model_data.get_input_profile(
         opt_batch_size,
@@ -622,8 +989,11 @@ def build_engine(
         input_profile=input_profile,
         enable_refit=build_enable_refit,
         enable_all_tactics=build_all_tactics,
+        timing_cache=timing_cache_path,
         workspace_size=max_workspace_size,
         fp8=fp8,
+        gpu_profile=gpu_profile,
+        dynamic_shapes=build_dynamic_shape,
     )
 
     return engine

--- a/src/streamdiffusion/acceleration/tensorrt/utilities.py
+++ b/src/streamdiffusion/acceleration/tensorrt/utilities.py
@@ -130,22 +130,24 @@ def detect_gpu_profile(device: int = 0) -> GPUBuildProfile:
     sms = props.multi_processor_count
 
     # --- Tier selection ---
-    # opt_level=4 for all tiers: always compiles dynamic kernels (better than
-    # level-3 heuristics) without level-5's "compare dynamic vs static" extra pass
-    # which OOMs during tactic profiling on dynamic-shape engines (160 GiB request).
+    # opt_level=3 for all tiers: level-4's "always compile dynamic kernels" is
+    # unnecessary with fully static shapes (build_static_batch + build_dynamic_shape=False)
+    # and triggers tactic 0x3e9 "Assertion g.nodes.size() == 0" failures in TRT 10.12.
+    # Level-3 heuristic selection produces equivalent results for static profiles.
+    # Level-5 still avoided — causes OOM during tactic profiling (160 GiB requests).
     if cc >= (12, 0):
         tier = "blackwell"
-        opt_level = 4
+        opt_level = 3
         tiling = "FULL"
         max_ws_cap = 16 * (2 ** 30)   # 16 GiB cap
     elif cc >= (8, 9):                 # Ada Lovelace (8.9 exactly)
         tier = "ada"
-        opt_level = 4
+        opt_level = 3
         tiling = "MODERATE"
         max_ws_cap = 12 * (2 ** 30)   # 12 GiB cap
     elif cc >= (8, 0):                 # Ampere (8.0 – 8.8)
         tier = "ampere"
-        opt_level = 4
+        opt_level = 3
         tiling = "FAST"
         max_ws_cap = 8 * (2 ** 30)    # 8 GiB cap
     else:
@@ -222,11 +224,12 @@ def _apply_gpu_profile_to_config(
         return
 
     # builder_optimization_level (0–5):
-    #   4 = always compiles dynamic kernels (better than level-3 heuristics)
-    #   5 = additionally compares dynamic vs static kernels — causes OOM during
-    #       tactic profiling on dynamic-shape engines (160 GiB requests observed).
-    # We use level 4 for all tiers to get the dynamic-kernel benefit without the
-    # level-5 exhaustive comparison that OOMs.
+    #   3 = heuristic-based tactic selection — optimal for fully static shapes
+    #   4 = always compiles dynamic kernels — unnecessary with static shapes,
+    #       triggers tactic 0x3e9 assertion failures in TRT 10.12
+    #   5 = compares dynamic vs static kernels — OOMs during tactic profiling
+    # Level 3 used for all tiers: static builds (build_dynamic_shape=False) don't
+    # benefit from dynamic-kernel compilation, and level 4 causes spurious errors.
     try:
         config.builder_optimization_level = gpu_profile.builder_optimization_level
         logger.info(f"[TRT Config] builder_optimization_level={gpu_profile.builder_optimization_level}")

--- a/src/streamdiffusion/acceleration/tensorrt/utilities.py
+++ b/src/streamdiffusion/acceleration/tensorrt/utilities.py
@@ -291,6 +291,17 @@ def _apply_gpu_profile_to_config(
         except Exception:
             logger.debug("[TRT Config] RUNTIME_ACTIVATION_RESIZE_10_10 not supported — skipping")
 
+    # avg_timing_iterations: number of timing runs averaged per tactic candidate.
+    # Default 1 produces noisy measurements — occasional slow GPU clocks or cache
+    # miss can unfairly disqualify the best kernel. Value of 4 gives stable rankings
+    # with minimal extra build time (4× timing overhead, which is tiny vs. compilation).
+    # TRT 10.12 confirmed to support this property.
+    try:
+        config.avg_timing_iterations = 4
+        logger.info("[TRT Config] avg_timing_iterations=4")
+    except AttributeError:
+        logger.debug("[TRT Config] avg_timing_iterations not supported — skipping")
+
 
 # Map of numpy dtype -> torch dtype
 numpy_to_torch_dtype_dict = {
@@ -473,7 +484,6 @@ class Engine:
         fp16,
         input_profile=None,
         enable_refit=False,
-        enable_all_tactics=False,
         timing_cache=None,
         workspace_size=0,
         fp8=False,
@@ -484,7 +494,7 @@ class Engine:
 
         if fp8:
             self._build_fp8(
-                onnx_path, input_profile, workspace_size, enable_all_tactics,
+                onnx_path, input_profile, workspace_size,
                 timing_cache=timing_cache, gpu_profile=gpu_profile,
                 dynamic_shapes=dynamic_shapes,
             )
@@ -582,7 +592,6 @@ class Engine:
         onnx_path,
         input_profile,
         workspace_size,
-        enable_all_tactics,
         timing_cache=None,
         gpu_profile: Optional["GPUBuildProfile"] = None,
         dynamic_shapes: bool = True,
@@ -598,7 +607,6 @@ class Engine:
             onnx_path: Path to *.fp8.onnx (Q/DQ-annotated by fp8_quantize.py).
             input_profile: Dict of {name: (min, opt, max)} shapes.
             workspace_size: TRT workspace limit in bytes.
-            enable_all_tactics: If True, allow all TRT tactic sources.
             timing_cache: Path to timing cache file for load/save.
             gpu_profile: Hardware-aware build parameters from detect_gpu_profile().
             dynamic_shapes: Whether the engine uses dynamic input shapes.
@@ -946,7 +954,6 @@ def build_engine(
     opt_batch_size: int,
     build_static_batch: bool = False,
     build_dynamic_shape: bool = False,
-    build_all_tactics: bool = False,
     build_enable_refit: bool = False,
     fp8: bool = False,
 ):
@@ -988,7 +995,6 @@ def build_engine(
         fp16=True,
         input_profile=input_profile,
         enable_refit=build_enable_refit,
-        enable_all_tactics=build_all_tactics,
         timing_cache=timing_cache_path,
         workspace_size=max_workspace_size,
         fp8=fp8,

--- a/src/streamdiffusion/acceleration/tensorrt/utilities.py
+++ b/src/streamdiffusion/acceleration/tensorrt/utilities.py
@@ -30,7 +30,12 @@ import onnx
 import onnx_graphsurgeon as gs
 import tensorrt as trt
 import torch
-from cuda import cudart
+
+# cuda-python 13.x renamed 'cudart' to 'cuda.bindings.runtime'
+try:
+    from cuda.bindings import runtime as cudart
+except ImportError:
+    from cuda import cudart
 from PIL import Image
 from polygraphy import cuda
 from polygraphy.backend.common import bytes_from_path

--- a/src/streamdiffusion/acceleration/tensorrt/utilities.py
+++ b/src/streamdiffusion/acceleration/tensorrt/utilities.py
@@ -732,6 +732,15 @@ def export_onnx(
                 )
                 logger.info("Converted to external data format with weights in weights.pb")
 
+                # Delete individual tensor files left by torch.onnx.export (~4 GB for SDXL)
+                # They are now consolidated into weights.pb and no longer needed
+                for f in os.listdir(onnx_dir):
+                    if f.startswith("onnx__"):
+                        try:
+                            os.remove(os.path.join(onnx_dir, f))
+                        except OSError:
+                            pass  # Caught by builder.py final cleanup if still present
+
             del onnx_model
     del wrapped_model
     gc.collect()

--- a/src/streamdiffusion/acceleration/tensorrt/utilities.py
+++ b/src/streamdiffusion/acceleration/tensorrt/utilities.py
@@ -19,9 +19,11 @@
 #
 
 import gc
+
+# Set up logger for this module
+import logging
 from collections import OrderedDict
-from pathlib import Path
-from typing import Any, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 import onnx
@@ -40,17 +42,16 @@ from polygraphy.backend.trt import (
     network_from_onnx_path,
     save_engine,
 )
-from polygraphy.backend.trt import util as trt_util
 
 from .models.models import CLIP, VAE, BaseModel, UNet, VAEEncoder
 
-# Set up logger for this module
-import logging
+
 logger = logging.getLogger(__name__)
 
 TRT_LOGGER = trt.Logger(trt.Logger.ERROR)
 
 from ...model_detection import detect_model
+
 
 # Map of numpy dtype -> torch dtype
 numpy_to_torch_dtype_dict = {
@@ -96,7 +97,7 @@ class Engine:
         self.buffers = OrderedDict()
         self.tensors = OrderedDict()
         self.cuda_graph_instance = None  # cuda graph
-        
+
         # Buffer reuse optimization tracking
         self._last_shape_dict = None
         self._last_device = None
@@ -105,21 +106,21 @@ class Engine:
 
     def __del__(self):
         # Check if AttributeError: 'Engine' object has no attribute 'buffers'
-        if not hasattr(self, 'buffers'):
+        if not hasattr(self, "buffers"):
             return
         [buf.free() for buf in self.buffers.values() if isinstance(buf, cuda.DeviceArray)]
-        
-        if hasattr(self, 'cuda_graph_instance') and self.cuda_graph_instance is not None:
+
+        if hasattr(self, "cuda_graph_instance") and self.cuda_graph_instance is not None:
             try:
                 CUASSERT(cudart.cudaGraphExecDestroy(self.cuda_graph_instance))
             except:
                 pass
-        if hasattr(self, 'graph') and self.graph is not None:
+        if hasattr(self, "graph") and self.graph is not None:
             try:
                 CUASSERT(cudart.cudaGraphDestroy(self.graph))
             except:
                 pass
-        
+
         del self.engine
         del self.context
         del self.buffers
@@ -257,7 +258,12 @@ class Engine:
         engine = engine_from_network(
             network_from_onnx_path(onnx_path, flags=[trt.OnnxParserFlag.NATIVE_INSTANCENORM]),
             config=CreateConfig(
-                fp16=fp16, tf32=True, refittable=enable_refit, profiles=[p], load_timing_cache=timing_cache, **config_kwargs
+                fp16=fp16,
+                tf32=True,
+                refittable=enable_refit,
+                profiles=[p],
+                load_timing_cache=timing_cache,
+                **config_kwargs,
             ),
             save_timing_cache=timing_cache,
         )
@@ -278,19 +284,19 @@ class Engine:
         # Check if we can reuse existing buffers (OPTIMIZATION)
         if self._can_reuse_buffers(shape_dict, device):
             return
-        
+
         # Clear existing buffers before reallocating
         self.tensors.clear()
-        
+
         # Reset CUDA graph when buffers are reallocated
         # The captured graph becomes invalid with new memory addresses
         if self.cuda_graph_instance is not None:
             CUASSERT(cudart.cudaGraphExecDestroy(self.cuda_graph_instance))
             self.cuda_graph_instance = None
-            if hasattr(self, 'graph') and self.graph is not None:
+            if hasattr(self, "graph") and self.graph is not None:
                 CUASSERT(cudart.cudaGraphDestroy(self.graph))
                 self.graph = None
-        
+
         for idx in range(self.engine.num_io_tensors):
             name = self.engine.get_tensor_name(idx)
 
@@ -305,65 +311,60 @@ class Engine:
             if mode == trt.TensorIOMode.INPUT:
                 self.context.set_input_shape(name, shape)
 
-            if any(s < 0 for s in shape):
-                import logging as _logging
-                _logging.getLogger(__name__).error(f"allocate_buffers: tensor '{name}' has negative shape {shape} — not in shape_dict. shape_dict keys: {list(shape_dict.keys()) if shape_dict else []}")
-            tensor = torch.empty(tuple(shape),
-                                 dtype=numpy_to_torch_dtype_dict[dtype_np]) \
-                          .to(device=device)
+            tensor = torch.empty(tuple(shape), dtype=numpy_to_torch_dtype_dict[dtype_np]).to(device=device)
             self.tensors[name] = tensor
-        
+
         # Cache allocation parameters for reuse check
         self._last_shape_dict = shape_dict.copy() if shape_dict else None
         self._last_device = device
-    
+
     def _can_reuse_buffers(self, shape_dict=None, device="cuda"):
         """
         Check if existing buffers can be reused (avoiding expensive reallocation)
-        
+
         Returns:
             bool: True if buffers can be reused, False if reallocation needed
         """
         # No existing tensors - need to allocate
         if not self.tensors:
             return False
-        
+
         # Device changed - need to reallocate
-        if not hasattr(self, '_last_device') or self._last_device != device:
+        if not hasattr(self, "_last_device") or self._last_device != device:
             return False
-        
+
         # No cached shape_dict - need to allocate
-        if not hasattr(self, '_last_shape_dict'):
+        if not hasattr(self, "_last_shape_dict"):
             return False
-            
+
         # Compare current vs cached shape_dict
         if shape_dict is None and self._last_shape_dict is None:
             return True
         elif shape_dict is None or self._last_shape_dict is None:
             return False
-        
+
         # Quick check: if tensor counts differ, can't reuse
         if len(shape_dict) != len(self._last_shape_dict):
             return False
-        
+
         # Compare shapes for all tensors in the new shape_dict
         for name, new_shape in shape_dict.items():
             # Check if tensor exists in cached shapes
             cached_shape = self._last_shape_dict.get(name)
             if cached_shape is None:
                 return False
-            
+
             # Compare shapes (handle different types consistently)
             if tuple(cached_shape) != tuple(new_shape):
                 return False
-        
+
         return True
 
     def reset_cuda_graph(self):
         if self.cuda_graph_instance is not None:
             CUASSERT(cudart.cudaGraphExecDestroy(self.cuda_graph_instance))
             self.cuda_graph_instance = None
-        if hasattr(self, 'graph') and self.graph is not None:
+        if hasattr(self, "graph") and self.graph is not None:
             CUASSERT(cudart.cudaGraphDestroy(self.graph))
             self.graph = None
 
@@ -388,10 +389,11 @@ class Engine:
                 if missing:
                     logger.debug(
                         "TensorRT Engine: filtering unsupported inputs %s (allowed=%s)",
-                        missing, sorted(list(self._allowed_inputs))
+                        missing,
+                        sorted(list(self._allowed_inputs)),
                     )
             feed_dict = filtered_feed_dict
-        
+
         for name, buf in feed_dict.items():
             self.tensors[name].copy_(buf)
 
@@ -401,7 +403,9 @@ class Engine:
         if use_cuda_graph:
             if self.cuda_graph_instance is not None:
                 CUASSERT(cudart.cudaGraphLaunch(self.cuda_graph_instance, stream.ptr))
-                CUASSERT(cudart.cudaStreamSynchronize(stream.ptr))
+                # No cudaStreamSynchronize — graph replay is async; stream ordering ensures
+                # downstream GPU ops (copy_, attention) wait for graph completion.
+                # CPU sync happens only via end.synchronize() in pipeline.__call__.
             else:
                 # do inference before CUDA graph capture
                 noerror = self.context.execute_async_v3(stream.ptr)
@@ -515,7 +519,7 @@ def build_engine(
         max_workspace_size = min(free_mem - activation_carveout, 8 * GiB)
     else:
         max_workspace_size = 0
-    logger.info(f"TRT workspace: free_mem={free_mem/GiB:.1f}GiB, max_workspace={max_workspace_size/GiB:.1f}GiB")
+    logger.info(f"TRT workspace: free_mem={free_mem / GiB:.1f}GiB, max_workspace={max_workspace_size / GiB:.1f}GiB")
     engine = Engine(engine_path)
     input_profile = model_data.get_input_profile(
         opt_batch_size,
@@ -536,27 +540,6 @@ def build_engine(
     return engine
 
 
-
-
-
-def _find_external_data_files(directory: str) -> list:
-    """Find external data files in a directory by checking common extensions.
-
-    torch.onnx.export may create .data files, while our pipeline uses .pb.
-    This detects both to ensure proper handling of >2GB ONNX models.
-    """
-    import os
-    external_exts = ('.pb', '.data', '.onnx.data', '.onnx_data')
-    result = []
-    try:
-        for f in os.listdir(directory):
-            if any(f.endswith(ext) for ext in external_exts):
-                result.append(f)
-    except OSError:
-        pass
-    return result
-
-
 def export_onnx(
     model,
     onnx_path: str,
@@ -567,67 +550,66 @@ def export_onnx(
     onnx_opset: int,
 ):
     # TODO: Not 100% happy about this function - needs refactoring
-    
+
     is_sdxl = False
     is_sdxl_controlnet = False
 
     # Detect if this is a ControlNet model (vs UNet model)
-    is_controlnet = (
-        hasattr(model, '__class__') and 'ControlNet' in model.__class__.__name__
-    ) or (
-        hasattr(model, 'config') and hasattr(model.config, '_class_name') and
-        'ControlNet' in model.config._class_name
+    is_controlnet = (hasattr(model, "__class__") and "ControlNet" in model.__class__.__name__) or (
+        hasattr(model, "config") and hasattr(model.config, "_class_name") and "ControlNet" in model.config._class_name
     )
 
     # Detect if this is an SDXL model via detect_model
-    if hasattr(model, 'unet'):
+    if hasattr(model, "unet"):
         detection_result = detect_model(model.unet)
         if detection_result is not None:
-            is_sdxl = detection_result.get('is_sdxl', False)
-    elif hasattr(model, 'config'):
+            is_sdxl = detection_result.get("is_sdxl", False)
+    elif hasattr(model, "config"):
         detection_result = detect_model(model)
         if detection_result is not None:
-            is_sdxl = detection_result.get('is_sdxl', False)
-    
+            is_sdxl = detection_result.get("is_sdxl", False)
+
     # Detect if this is an SDXL ControlNet
-    is_sdxl_controlnet = is_controlnet and (is_sdxl or (
-        hasattr(model, 'config') and
-        getattr(model.config, 'addition_embed_type', None) == 'text_time'
-    ))
-    
+    is_sdxl_controlnet = is_controlnet and (
+        is_sdxl or (hasattr(model, "config") and getattr(model.config, "addition_embed_type", None) == "text_time")
+    )
+
     wrapped_model = model  # Default: use model as-is
-    
+
     # Apply SDXL wrapper for SDXL models (in practice, always UnifiedExportWrapper)
     # Skip SDXLExportWrapper if model is already a UnifiedExportWrapper — it handles
     # SDXL conditioning internally and has strict positional arg requirements (e.g.
     # ipadapter_scale) that SDXLExportWrapper's forward-test probe would violate.
     from .export_wrappers.unet_unified_export import UnifiedExportWrapper
+
     if is_sdxl and not is_controlnet and not isinstance(model, UnifiedExportWrapper):
-        embedding_dim = getattr(model_data, 'embedding_dim', 'unknown')
+        embedding_dim = getattr(model_data, "embedding_dim", "unknown")
         logger.info(f"Detected SDXL model (embedding_dim={embedding_dim}), using wrapper for ONNX export...")
         from .export_wrappers.unet_sdxl_export import SDXLExportWrapper
+
         wrapped_model = SDXLExportWrapper(model)
     elif not is_controlnet:
-        embedding_dim = getattr(model_data, 'embedding_dim', 'unknown')
+        embedding_dim = getattr(model_data, "embedding_dim", "unknown")
         logger.info(f"Detected non-SDXL model (embedding_dim={embedding_dim}), using model as-is for ONNX export...")
-    
+
     # SDXL ControlNet models need special wrapper for added_cond_kwargs
     elif is_sdxl_controlnet:
         logger.info("Detected SDXL ControlNet model, using specialized wrapper...")
         from .export_wrappers.controlnet_export import SDXLControlNetExportWrapper
+
         wrapped_model = SDXLControlNetExportWrapper(model)
-    
+
     # Regular ControlNet models are exported directly
     elif is_controlnet:
         logger.info("Detected ControlNet model, exporting directly...")
         wrapped_model = model
-    
+
     with torch.inference_mode(), torch.autocast("cuda"):
         inputs = model_data.get_sample_input(opt_batch_size, opt_image_height, opt_image_width)
-        
+
         # Determine if we need external data format for large models (like SDXL)
-        is_large_model = is_sdxl or (hasattr(model, 'config') and getattr(model.config, 'sample_size', 32) >= 64)
-        
+        is_large_model = is_sdxl or (hasattr(model, "config") and getattr(model.config, "sample_size", 32) >= 64)
+
         # Export ONNX normally first
         torch.onnx.export(
             wrapped_model,
@@ -641,36 +623,20 @@ def export_onnx(
             dynamic_axes=model_data.get_dynamic_axes(),
             dynamo=False,
         )
-        
+
         # Convert to external data format for large models (SDXL)
         if is_large_model:
             import os
 
-            onnx_dir = os.path.dirname(onnx_path)
-            onnx_file_size = os.path.getsize(onnx_path)
+            # Load the exported model
+            onnx_model = onnx.load(onnx_path)
 
-            # Check if torch.onnx.export already created external data files
-            # PyTorch may auto-save with .data extension for >2GB models
-            existing_external = _find_external_data_files(onnx_dir)
+            # Check if model is large enough to need external data
+            if onnx_model.ByteSize() > 2147483648:  # 2GB
+                # Create directory for external data
+                onnx_dir = os.path.dirname(onnx_path)
 
-            if onnx_file_size > 2147483648:  # >2GB single file
-                logger.info(f"ONNX file is {onnx_file_size / (1024**3):.2f} GB, converting to external data format...")
-                # Load the >2GB single-file model. The protobuf upb backend (used in protobuf 4.25.x)
-                # can handle >2GB messages. If this fails, it means protobuf can't parse it.
-                try:
-                    onnx_model = onnx.load(onnx_path)
-                except Exception as load_err:
-                    raise RuntimeError(
-                        f"Failed to load >2GB ONNX model ({onnx_file_size / (1024**3):.2f} GB): {load_err}\n"
-                        f"This may be a protobuf version issue. Ensure protobuf==4.25.3 is installed.\n"
-                        f"Run: pip install protobuf==4.25.3"
-                    ) from load_err
-                # Clean up any existing external data files before saving
-                for ef in existing_external:
-                    try:
-                        os.remove(os.path.join(onnx_dir, ef))
-                    except OSError:
-                        pass
+                # Re-save with external data format
                 onnx.save_model(
                     onnx_model,
                     onnx_path,
@@ -679,31 +645,9 @@ def export_onnx(
                     location="weights.pb",
                     convert_attribute=False,
                 )
-                logger.info(f"Converted to external data format with weights in weights.pb")
-                del onnx_model
-            elif existing_external:
-                # torch.onnx.export already saved with external data (e.g., .data files)
-                # Normalize to weights.pb for consistent downstream detection
-                logger.info(f"Found existing external data files from torch export: {existing_external}")
-                onnx_model = onnx.load(onnx_path, load_external_data=True)
-                # Clean up old external data files
-                for ef in existing_external:
-                    try:
-                        os.remove(os.path.join(onnx_dir, ef))
-                    except OSError:
-                        pass
-                onnx.save_model(
-                    onnx_model,
-                    onnx_path,
-                    save_as_external_data=True,
-                    all_tensors_to_one_file=True,
-                    location="weights.pb",
-                    convert_attribute=False,
-                )
-                logger.info(f"Normalized external data to weights.pb")
-                del onnx_model
-            else:
-                logger.info(f"ONNX file is {onnx_file_size / (1024**3):.2f} GB (under 2GB), no external data conversion needed")
+                logger.info("Converted to external data format with weights in weights.pb")
+
+            del onnx_model
     del wrapped_model
     gc.collect()
     torch.cuda.empty_cache()
@@ -715,34 +659,26 @@ def optimize_onnx(
     model_data: BaseModel,
 ):
     import os
-    import shutil
 
+    # Check if external data files exist (indicating external data format was used)
     onnx_dir = os.path.dirname(onnx_path)
-
-    # Detect external data files using comprehensive extension check
-    external_data_files = _find_external_data_files(onnx_dir)
+    external_data_files = [f for f in os.listdir(onnx_dir) if f.endswith(".pb")]
     uses_external_data = len(external_data_files) > 0
-
-    # Also check ONNX file size — if the main file is small but no external data detected,
-    # something may be wrong (torch may have saved external data with an unexpected name)
-    onnx_file_size = os.path.getsize(onnx_path)
 
     if uses_external_data:
         logger.info(f"Optimizing ONNX with external data (found: {external_data_files})")
         # Load model with external data
         onnx_model = onnx.load(onnx_path, load_external_data=True)
         onnx_opt_graph = model_data.optimize(onnx_model)
-        del onnx_model
 
         # Create output directory
         opt_dir = os.path.dirname(onnx_opt_path)
         os.makedirs(opt_dir, exist_ok=True)
 
-        # Clean up existing ONNX/external data files in output directory
+        # Clean up existing files in output directory
         if os.path.exists(opt_dir):
-            cleanup_exts = ('.pb', '.onnx', '.data', '.onnx.data', '.onnx_data')
             for f in os.listdir(opt_dir):
-                if any(f.endswith(ext) for ext in cleanup_exts):
+                if f.endswith(".pb") or f.endswith(".onnx"):
                     os.remove(os.path.join(opt_dir, f))
 
         # Save optimized model with external data format
@@ -754,40 +690,12 @@ def optimize_onnx(
             location="weights.pb",
             convert_attribute=False,
         )
-        logger.info(f"ONNX optimization complete with external data")
+        logger.info("ONNX optimization complete with external data")
 
     else:
         # Standard optimization for smaller models
-        logger.info(f"Optimizing ONNX (single file, {onnx_file_size / (1024**2):.1f} MB)")
         onnx_opt_graph = model_data.optimize(onnx.load(onnx_path))
-
-        # Check if the optimized graph is too large for single-file serialization
-        try:
-            opt_size = onnx_opt_graph.ByteSize()
-        except Exception:
-            opt_size = 0
-
-        if opt_size > 2000000000:  # ~2GB with margin
-            logger.info(f"Optimized model is {opt_size / (1024**3):.2f} GB, saving with external data")
-            onnx.save_model(
-                onnx_opt_graph,
-                onnx_opt_path,
-                save_as_external_data=True,
-                all_tensors_to_one_file=True,
-                location="weights.pb",
-                convert_attribute=False,
-            )
-        else:
-            onnx.save(onnx_opt_graph, onnx_opt_path)
-
-    # Verify the output file was created
-    if not os.path.exists(onnx_opt_path):
-        raise RuntimeError(f"ONNX optimization failed: output file was not created at {onnx_opt_path}")
-    opt_file_size = os.path.getsize(onnx_opt_path)
-    if opt_file_size == 0:
-        os.remove(onnx_opt_path)
-        raise RuntimeError(f"ONNX optimization failed: output file is empty (0 bytes) at {onnx_opt_path}")
-    logger.info(f"Optimized ONNX saved: {onnx_opt_path} ({opt_file_size / (1024**2):.1f} MB)")
+        onnx.save(onnx_opt_graph, onnx_opt_path)
 
     del onnx_opt_graph
     gc.collect()

--- a/src/streamdiffusion/acceleration/tensorrt/utilities.py
+++ b/src/streamdiffusion/acceleration/tensorrt/utilities.py
@@ -336,6 +336,84 @@ def CUASSERT(cuda_ret):
     return None
 
 
+class TRTProfiler(trt.IProfiler):
+    """
+    Per-layer TRT timing profiler.
+
+    Activated by setting the STREAMDIFFUSION_PROFILE_TRT environment variable.
+    Attach to Engine.context after create_execution_context(); TRT will call
+    report_layer_time() once per layer per inference pass.
+
+    NOTE: Attaching a profiler disables CUDA graph replay for that engine
+    (IProfiler cannot report per-layer times through a captured graph).
+    Production inference always runs without profiler — zero overhead.
+
+    Usage:
+        set STREAMDIFFUSION_PROFILE_TRT=1
+        python td_main.py
+        # After N iterations, call engine.dump_profile()
+
+    Nsight Systems workflow (standalone .engine files):
+        # Build with profilingVerbosity=DETAILED (done automatically at build time)
+        # Profile with trtexec:
+        trtexec --loadEngine=unet.engine --noDataTransfers --useSpinWait \\
+                --warmUp=0 --duration=0 --iterations=50 \\
+                --profilingVerbosity=detailed --dumpProfile --separateProfileRun
+        # For CUDA graph per-kernel view, add --useCudaGraph --cuda-graph-trace=node
+        # and wrap with: nsys profile --capture-range cudaProfilerApi trtexec ...
+    """
+
+    def __init__(self, name: str = ""):
+        super().__init__()
+        self.name = name
+        self._runs: list = []        # list of lists: [[( layer_name, ms ), ...], ...]
+        self._current: list = []     # accumulator for the in-progress inference
+
+    def report_layer_time(self, layer_name: str, ms: float) -> None:  # noqa: N802
+        self._current.append((layer_name, ms))
+
+    def start_run(self) -> None:
+        self._current = []
+
+    def end_run(self) -> None:
+        if self._current:
+            self._runs.append(self._current)
+        self._current = []
+
+    def get_summary(self, last_n: int = 10) -> str:
+        if not self._runs:
+            return f"[{self.name}] No profiling data collected yet."
+
+        runs = self._runs[-last_n:]
+        from collections import defaultdict
+        totals: dict = defaultdict(list)
+        for run in runs:
+            for layer_name, ms in run:
+                totals[layer_name].append(ms)
+
+        # Sort by median descending
+        def _median(v):
+            s = sorted(v)
+            return s[len(s) // 2]
+
+        sorted_layers = sorted(totals.items(), key=lambda x: _median(x[1]), reverse=True)
+        total_ms = sum(_median(v) for _, v in sorted_layers)
+
+        lines = [
+            f"[{self.name}] Layer Profile — {len(runs)} runs, "
+            f"{total_ms:.2f} ms total (median per layer):"
+        ]
+        for layer_name, times in sorted_layers[:25]:
+            med = _median(times)
+            pct = (med / total_ms * 100) if total_ms > 0 else 0
+            lines.append(f"  {med:8.3f} ms  {pct:5.1f}%  {layer_name}")
+        remaining = len(sorted_layers) - 25
+        if remaining > 0:
+            rest_ms = sum(_median(v) for _, v in sorted_layers[25:])
+            lines.append(f"  ... {remaining} more layers  ({rest_ms:.2f} ms)")
+        return "\n".join(lines)
+
+
 class Engine:
     def __init__(
         self,
@@ -524,6 +602,13 @@ class Engine:
 
         config = builder.create_builder_config()
 
+        # Embed layer names + tactic IDs in the engine for runtime IProfiler support.
+        # Zero runtime cost — only affects engine metadata size (a few KB).
+        try:
+            config.profiling_verbosity = trt.ProfilingVerbosity.DETAILED
+        except AttributeError:
+            pass
+
         # Precision flags
         if fp16:
             config.set_flag(trt.BuilderFlag.FP16)
@@ -633,6 +718,13 @@ class Engine:
             )
 
         config = builder.create_builder_config()
+
+        # Embed layer names + tactic IDs in the engine for runtime IProfiler support.
+        try:
+            config.profiling_verbosity = trt.ProfilingVerbosity.DETAILED
+        except AttributeError:
+            pass
+
         # BuilderFlag.STRONGLY_TYPED was removed in TRT 10.12; the network-level flag
         # (NetworkDefinitionCreationFlag.STRONGLY_TYPED, set on network creation above)
         # is now the only mechanism. On older TRT versions where BuilderFlag.STRONGLY_TYPED
@@ -709,6 +801,16 @@ class Engine:
             self.context.device_memory = reuse_device_memory
         else:
             self.context = self.engine.create_execution_context()
+
+        # Attach per-layer profiler when STREAMDIFFUSION_PROFILE_TRT is set.
+        # Requires engines built with profiling_verbosity=DETAILED for meaningful names.
+        # NOTE: profiler presence disables CUDA graph replay in infer() — IProfiler
+        # cannot report per-layer times through a captured graph.
+        self.profiler: Optional[TRTProfiler] = None
+        if os.environ.get("STREAMDIFFUSION_PROFILE_TRT"):
+            self.profiler = TRTProfiler(name=os.path.basename(self.engine_path))
+            self.context.profiler = self.profiler
+            logger.info(f"[TRTProfiler] Attached to {os.path.basename(self.engine_path)} (CUDA graphs disabled)")
 
     def allocate_buffers(self, shape_dict=None, device="cuda"):
         # Check if we can reuse existing buffers (OPTIMIZATION)
@@ -811,6 +913,12 @@ class Engine:
             self.graph = None
 
     def infer(self, feed_dict, stream, use_cuda_graph=False):
+        # IProfiler cannot report per-layer times through CUDA graph replay — disable graphs
+        # when profiler is attached. This is automatically set when STREAMDIFFUSION_PROFILE_TRT
+        # is set in activate(), so callers do not need to change anything.
+        if self.profiler is not None:
+            use_cuda_graph = False
+
         # Filter inputs to only those the engine actually exposes to avoid binding errors
         # _allowed_inputs is cached on first call — IO tensor names are immutable after engine build
         if self._allowed_inputs is None:
@@ -835,6 +943,9 @@ class Engine:
                         sorted(list(self._allowed_inputs)),
                     )
             feed_dict = filtered_feed_dict
+
+        if self.profiler is not None:
+            self.profiler.start_run()
 
         for name, buf in feed_dict.items():
             self.tensors[name].copy_(buf)
@@ -868,7 +979,21 @@ class Engine:
             if not noerror:
                 raise ValueError("ERROR: inference failed.")
 
+        if self.profiler is not None:
+            # Synchronize to ensure all IProfiler.report_layer_time() callbacks have fired
+            # before end_run() stores the accumulated per-layer data.
+            stream.synchronize()
+            self.profiler.end_run()
+
         return self.tensors
+
+    def dump_profile(self, last_n: int = 10) -> None:
+        """Log a per-layer timing summary for the last N profiled inference runs.
+
+        No-op when STREAMDIFFUSION_PROFILE_TRT is not set (profiler is None).
+        """
+        if self.profiler is not None:
+            logger.info(self.profiler.get_summary(last_n))
 
 
 def decode_images(images: torch.Tensor):

--- a/src/streamdiffusion/acceleration/tensorrt/utilities.py
+++ b/src/streamdiffusion/acceleration/tensorrt/utilities.py
@@ -261,11 +261,9 @@ class Engine:
 
         if workspace_size > 0:
             config_kwargs["memory_pool_limits"] = {trt.MemoryPoolType.WORKSPACE: workspace_size}
-        if not enable_all_tactics:
-            config_kwargs["tactic_sources"] = [
-                1 << int(trt.TacticSource.CUBLAS),
-                1 << int(trt.TacticSource.CUBLAS_LT),
-            ]
+        # tactic_sources restriction removed: TacticSource.CUBLAS (deprecated TRT 10.0)
+        # and CUBLAS_LT (deprecated TRT 9.0) are no longer meaningful on TRT 10.x.
+        # TRT uses its default tactic selection for all builds regardless of enable_all_tactics.
 
         engine = engine_from_network(
             network_from_onnx_path(onnx_path, flags=[trt.OnnxParserFlag.NATIVE_INSTANCENORM]),
@@ -314,19 +312,19 @@ class Engine:
             )
 
         config = builder.create_builder_config()
-        # TRT 10.12+ with STRONGLY_TYPED network: precision flags (FP8, FP16, TF32)
-        # must NOT be set — the Q/DQ node annotations dictate precision directly.
-        # Older TRT versions need both the BuilderFlag and the network flag.
+        # BuilderFlag.STRONGLY_TYPED was removed in TRT 10.12; the network-level flag
+        # (NetworkDefinitionCreationFlag.STRONGLY_TYPED, line ~304) is now the only
+        # mechanism. On older TRT versions where BuilderFlag.STRONGLY_TYPED still exists,
+        # we also set precision flags on the config so the builder considers FP8/FP16 kernels.
         if hasattr(trt.BuilderFlag, 'STRONGLY_TYPED'):
-            # TRT < 10.12: set all precision flags + STRONGLY_TYPED on config
+            # TRT < 10.12: BuilderFlag.STRONGLY_TYPED exists — set precision flags and
+            # the builder-level STRONGLY_TYPED flag alongside the network-level flag.
             config.set_flag(trt.BuilderFlag.FP8)
             config.set_flag(trt.BuilderFlag.FP16)
             config.set_flag(trt.BuilderFlag.TF32)
             config.set_flag(trt.BuilderFlag.STRONGLY_TYPED)
-        else:
-            # TRT 10.12+: NetworkDefinitionCreationFlag.STRONGLY_TYPED (line 304)
-            # handles precision; setting FP8 flag causes API Usage Error.
-            pass
+        # else: TRT 10.12+ — NetworkDefinitionCreationFlag.STRONGLY_TYPED (set on network
+        # creation above) is sufficient; Q/DQ node annotations dictate precision directly.
 
         if workspace_size > 0:
             config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_size)
@@ -392,7 +390,10 @@ class Engine:
             mode = self.engine.get_tensor_mode(name)
 
             if mode == trt.TensorIOMode.INPUT:
-                self.context.set_input_shape(name, shape)
+                if not self.context.set_input_shape(name, shape):
+                    raise RuntimeError(
+                        f"TensorRT: set_input_shape failed for '{name}' with shape {shape}"
+                    )
 
             tensor = torch.empty(tuple(shape), dtype=numpy_to_torch_dtype_dict[dtype_np]).to(device=device)
             self.tensors[name] = tensor
@@ -481,7 +482,10 @@ class Engine:
             self.tensors[name].copy_(buf)
 
         for name, tensor in self.tensors.items():
-            self.context.set_tensor_address(name, tensor.data_ptr())
+            if not self.context.set_tensor_address(name, tensor.data_ptr()):
+                raise RuntimeError(
+                    f"TensorRT: set_tensor_address failed for '{name}'"
+                )
 
         if use_cuda_graph:
             if self.cuda_graph_instance is not None:

--- a/src/streamdiffusion/acceleration/tensorrt/utilities.py
+++ b/src/streamdiffusion/acceleration/tensorrt/utilities.py
@@ -314,10 +314,19 @@ class Engine:
             )
 
         config = builder.create_builder_config()
-        config.set_flag(trt.BuilderFlag.FP8)
-        config.set_flag(trt.BuilderFlag.FP16)   # FP16 fallback for non-quantized ops
-        config.set_flag(trt.BuilderFlag.TF32)
-        config.set_flag(trt.BuilderFlag.STRONGLY_TYPED)
+        # TRT 10.12+ with STRONGLY_TYPED network: precision flags (FP8, FP16, TF32)
+        # must NOT be set — the Q/DQ node annotations dictate precision directly.
+        # Older TRT versions need both the BuilderFlag and the network flag.
+        if hasattr(trt.BuilderFlag, 'STRONGLY_TYPED'):
+            # TRT < 10.12: set all precision flags + STRONGLY_TYPED on config
+            config.set_flag(trt.BuilderFlag.FP8)
+            config.set_flag(trt.BuilderFlag.FP16)
+            config.set_flag(trt.BuilderFlag.TF32)
+            config.set_flag(trt.BuilderFlag.STRONGLY_TYPED)
+        else:
+            # TRT 10.12+: NetworkDefinitionCreationFlag.STRONGLY_TYPED (line 304)
+            # handles precision; setting FP8 flag causes API Usage Error.
+            pass
 
         if workspace_size > 0:
             config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_size)
@@ -340,7 +349,8 @@ class Engine:
         with open(self.engine_path, "wb") as f:
             f.write(serialized)
 
-        logger.info(f"[FP8] Engine saved: {self.engine_path} ({len(serialized) / 1024 / 1024:.0f} MB)")
+        size_bytes = getattr(serialized, 'nbytes', None) or len(serialized)
+        logger.info(f"[FP8] Engine saved: {self.engine_path} ({size_bytes / 1024 / 1024:.0f} MB)")
 
     def load(self):
         logger.info(f"Loading TensorRT engine: {self.engine_path}")

--- a/src/streamdiffusion/config.py
+++ b/src/streamdiffusion/config.py
@@ -411,6 +411,9 @@ def _validate_config(config: Dict[str, Any]) -> None:
         raise ValueError("_validate_config: Missing required field: model_id")
 
     if "controlnets" in config:
+        # YAML `controlnets:` with no value parses as None — normalize to empty list
+        if config["controlnets"] is None:
+            config["controlnets"] = []
         if not isinstance(config["controlnets"], list):
             raise ValueError("_validate_config: 'controlnets' must be a list")
 
@@ -431,6 +434,9 @@ def _validate_config(config: Dict[str, Any]) -> None:
 
     # Validate ipadapters if present
     if "ipadapters" in config:
+        # YAML `ipadapters:` with no value parses as None — normalize to empty list
+        if config["ipadapters"] is None:
+            config["ipadapters"] = []
         if not isinstance(config["ipadapters"], list):
             raise ValueError("_validate_config: 'ipadapters' must be a list")
 

--- a/src/streamdiffusion/config.py
+++ b/src/streamdiffusion/config.py
@@ -1,91 +1,96 @@
-import os
-import sys
-import yaml
 import json
-from typing import Dict, List, Optional, Union, Any, Tuple
 from pathlib import Path
+from typing import Any, Dict, List, Tuple, Union
+
+import yaml
+
 
 def load_config(config_path: Union[str, Path]) -> Dict[str, Any]:
     """Load StreamDiffusion configuration from YAML or JSON file"""
     config_path = Path(config_path)
-    
+
     if not config_path.exists():
         raise FileNotFoundError(f"load_config: Configuration file not found: {config_path}")
-    with open(config_path, 'r', encoding='utf-8') as f:
-        if config_path.suffix.lower() in ['.yaml', '.yml']:
+    with open(config_path, "r", encoding="utf-8") as f:
+        if config_path.suffix.lower() in [".yaml", ".yml"]:
             config_data = yaml.safe_load(f)
-        elif config_path.suffix.lower() == '.json':
+        elif config_path.suffix.lower() == ".json":
             config_data = json.load(f)
         else:
             raise ValueError(f"load_config: Unsupported configuration file format: {config_path.suffix}")
-    
+
     _validate_config(config_data)
-    
+
     return config_data
 
 
 def save_config(config: Dict[str, Any], config_path: Union[str, Path]) -> None:
     """Save StreamDiffusion configuration to YAML or JSON file"""
     config_path = Path(config_path)
-    
+
     _validate_config(config)
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(config_path, 'w', encoding='utf-8') as f:
-        if config_path.suffix.lower() in ['.yaml', '.yml']:
+    with open(config_path, "w", encoding="utf-8") as f:
+        if config_path.suffix.lower() in [".yaml", ".yml"]:
             yaml.dump(config, f, default_flow_style=False, indent=2)
-        elif config_path.suffix.lower() == '.json':
+        elif config_path.suffix.lower() == ".json":
             json.dump(config, f, indent=2)
         else:
             raise ValueError(f"save_config: Unsupported configuration file format: {config_path.suffix}")
 
+
 def create_wrapper_from_config(config: Dict[str, Any], **overrides) -> Any:
     """Create StreamDiffusionWrapper from configuration dictionary
-    
+
     Prompt Interface:
     - Legacy: Use 'prompt' field for single prompt
     - New: Use 'prompt_blending' with 'prompt_list' for multiple weighted prompts
     - If both are provided, 'prompt_blending' takes precedence and 'prompt' is ignored
     - negative_prompt: Currently a single string (not list) for all prompt types
     """
+
     from streamdiffusion import StreamDiffusionWrapper
-    import torch
 
     final_config = {**config, **overrides}
     wrapper_params = _extract_wrapper_params(final_config)
     wrapper = StreamDiffusionWrapper(**wrapper_params)
-    
+
     prepare_params = _extract_prepare_params(final_config)
 
     # Handle prompt configuration with clear precedence
-    if 'prompt_blending' in final_config:
+    if "prompt_blending" in final_config:
         # Use prompt blending (new interface) - ignore legacy 'prompt' field
-        blend_config = final_config['prompt_blending']
-        
+        blend_config = final_config["prompt_blending"]
+
         # Prepare with prompt blending directly using unified interface
-        prepare_params_with_blending = {k: v for k, v in prepare_params.items() 
-                                       if k not in ['prompt_blending', 'seed_blending']}
-        prepare_params_with_blending['prompt'] = blend_config.get('prompt_list', [])
-        prepare_params_with_blending['prompt_interpolation_method'] = blend_config.get('interpolation_method', 'slerp')
-        
+        prepare_params_with_blending = {
+            k: v for k, v in prepare_params.items() if k not in ["prompt_blending", "seed_blending"]
+        }
+        prepare_params_with_blending["prompt"] = blend_config.get("prompt_list", [])
+        prepare_params_with_blending["prompt_interpolation_method"] = blend_config.get("interpolation_method", "slerp")
+
         # Add seed blending if configured
-        if 'seed_blending' in final_config:
-            seed_blend_config = final_config['seed_blending']
-            prepare_params_with_blending['seed_list'] = seed_blend_config.get('seed_list', [])
-            prepare_params_with_blending['seed_interpolation_method'] = seed_blend_config.get('interpolation_method', 'linear')
-        
+        if "seed_blending" in final_config:
+            seed_blend_config = final_config["seed_blending"]
+            prepare_params_with_blending["seed_list"] = seed_blend_config.get("seed_list", [])
+            prepare_params_with_blending["seed_interpolation_method"] = seed_blend_config.get(
+                "interpolation_method", "linear"
+            )
+
         wrapper.prepare(**prepare_params_with_blending)
-    elif prepare_params.get('prompt'):
+    elif prepare_params.get("prompt"):
         # Use legacy single prompt interface
-        clean_prepare_params = {k: v for k, v in prepare_params.items() 
-                               if k not in ['prompt_blending', 'seed_blending']}
+        clean_prepare_params = {
+            k: v for k, v in prepare_params.items() if k not in ["prompt_blending", "seed_blending"]
+        }
         wrapper.prepare(**clean_prepare_params)
 
     # Apply seed blending if configured and not already handled in prepare
-    if 'seed_blending' in final_config and 'prompt_blending' not in final_config:
-        seed_blend_config = final_config['seed_blending']
+    if "seed_blending" in final_config and "prompt_blending" not in final_config:
+        seed_blend_config = final_config["seed_blending"]
         wrapper.update_stream_params(
-            seed_list=seed_blend_config.get('seed_list', []),
-            interpolation_method=seed_blend_config.get('interpolation_method', 'linear')
+            seed_list=seed_blend_config.get("seed_list", []),
+            interpolation_method=seed_blend_config.get("interpolation_method", "linear"),
         )
 
     return wrapper
@@ -93,251 +98,261 @@ def create_wrapper_from_config(config: Dict[str, Any], **overrides) -> Any:
 
 def _extract_wrapper_params(config: Dict[str, Any]) -> Dict[str, Any]:
     """Extract parameters for StreamDiffusionWrapper.__init__() from config"""
-    import torch
     param_map = {
-        'model_id_or_path': config.get('model_id', 'stabilityai/sd-turbo'),
-        't_index_list': config.get('t_index_list', [0, 16, 32, 45]),
-        'lora_dict': config.get('lora_dict'),
-        'mode': config.get('mode', 'img2img'),
-        'output_type': config.get('output_type', 'pil'),
-        'vae_id': config.get('vae_id'),
-        'device': config.get('device', 'cuda'),
-        'dtype': _parse_dtype(config.get('dtype', 'float16')),
-        'frame_buffer_size': config.get('frame_buffer_size', 1),
-        'width': config.get('width', 512),
-        'height': config.get('height', 512),
-        'warmup': config.get('warmup', 10),
-        'acceleration': config.get('acceleration', 'tensorrt'),
-        'do_add_noise': config.get('do_add_noise', True),
-        'device_ids': config.get('device_ids'),
-        'use_lcm_lora': config.get('use_lcm_lora'),  # Backwards compatibility
-        'use_tiny_vae': config.get('use_tiny_vae', True),
-        'enable_similar_image_filter': config.get('enable_similar_image_filter', False),
-        'similar_image_filter_threshold': config.get('similar_image_filter_threshold', 0.98),
-        'similar_image_filter_max_skip_frame': config.get('similar_image_filter_max_skip_frame', 10),
-        'similar_filter_sleep_fraction': config.get('similar_filter_sleep_fraction', 0.025),
-        'use_denoising_batch': config.get('use_denoising_batch', True),
-        'cfg_type': config.get('cfg_type', 'self'),
-        'seed': config.get('seed', 2),
-        'use_safety_checker': config.get('use_safety_checker', False),
-        'skip_diffusion': config.get('skip_diffusion', False),
-        'engine_dir': config.get('engine_dir', 'engines'),
-        'normalize_prompt_weights': config.get('normalize_prompt_weights', True),
-        'normalize_seed_weights': config.get('normalize_seed_weights', True),
-        'scheduler': config.get('scheduler', 'lcm'),
-        'sampler': config.get('sampler', 'normal'),
-        'compile_engines_only': config.get('compile_engines_only', False),
+        "model_id_or_path": config.get("model_id", "stabilityai/sd-turbo"),
+        "t_index_list": config.get("t_index_list", [0, 16, 32, 45]),
+        "lora_dict": config.get("lora_dict"),
+        "mode": config.get("mode", "img2img"),
+        "output_type": config.get("output_type", "pil"),
+        "vae_id": config.get("vae_id"),
+        "device": config.get("device", "cuda"),
+        "dtype": _parse_dtype(config.get("dtype", "float16")),
+        "frame_buffer_size": config.get("frame_buffer_size", 1),
+        "width": config.get("width", 512),
+        "height": config.get("height", 512),
+        "warmup": config.get("warmup", 10),
+        "acceleration": config.get("acceleration", "tensorrt"),
+        "do_add_noise": config.get("do_add_noise", True),
+        "device_ids": config.get("device_ids"),
+        "use_lcm_lora": config.get("use_lcm_lora"),  # Backwards compatibility
+        "use_tiny_vae": config.get("use_tiny_vae", True),
+        "enable_similar_image_filter": config.get("enable_similar_image_filter", False),
+        "similar_image_filter_threshold": config.get("similar_image_filter_threshold", 0.98),
+        "similar_image_filter_max_skip_frame": config.get("similar_image_filter_max_skip_frame", 10),
+        "similar_filter_sleep_fraction": config.get("similar_filter_sleep_fraction", 0.025),
+        "use_denoising_batch": config.get("use_denoising_batch", True),
+        "cfg_type": config.get("cfg_type", "self"),
+        "seed": config.get("seed", 2),
+        "use_safety_checker": config.get("use_safety_checker", False),
+        "skip_diffusion": config.get("skip_diffusion", False),
+        "engine_dir": config.get("engine_dir", "engines"),
+        "normalize_prompt_weights": config.get("normalize_prompt_weights", True),
+        "normalize_seed_weights": config.get("normalize_seed_weights", True),
+        "scheduler": config.get("scheduler", "lcm"),
+        "sampler": config.get("sampler", "normal"),
+        "compile_engines_only": config.get("compile_engines_only", False),
     }
-    if 'controlnets' in config and config['controlnets']:
-        param_map['use_controlnet'] = True
-        param_map['controlnet_config'] = _prepare_controlnet_configs(config)
+    if "controlnets" in config and config["controlnets"]:
+        param_map["use_controlnet"] = True
+        param_map["controlnet_config"] = _prepare_controlnet_configs(config)
     else:
-        param_map['use_controlnet'] = config.get('use_controlnet', False)
-        param_map['controlnet_config'] = config.get('controlnet_config')
-    
+        param_map["use_controlnet"] = config.get("use_controlnet", False)
+        param_map["controlnet_config"] = config.get("controlnet_config")
+
     # Set IPAdapter usage if IPAdapters are configured
-    if 'ipadapters' in config and config['ipadapters']:
-        param_map['use_ipadapter'] = True
-        param_map['ipadapter_config'] = _prepare_ipadapter_configs(config)
+    if "ipadapters" in config and config["ipadapters"]:
+        param_map["use_ipadapter"] = True
+        param_map["ipadapter_config"] = _prepare_ipadapter_configs(config)
     else:
-        param_map['use_ipadapter'] = config.get('use_ipadapter', False)
-        param_map['ipadapter_config'] = config.get('ipadapter_config')
-    
-    param_map['use_cached_attn'] = config.get('use_cached_attn', False)
-    
-    param_map['cache_maxframes'] = config.get('cache_maxframes', 1)
-    param_map['cache_interval'] = config.get('cache_interval', 1)
-    
+        param_map["use_ipadapter"] = config.get("use_ipadapter", False)
+        param_map["ipadapter_config"] = config.get("ipadapter_config")
+
+    param_map["use_cached_attn"] = config.get("use_cached_attn", False)
+
+    param_map["cache_maxframes"] = config.get("cache_maxframes", 1)
+    param_map["cache_interval"] = config.get("cache_interval", 1)
+
+    param_map["fp8"] = config.get("fp8", False)
+
     # Pipeline hook configurations (Phase 4: Configuration Integration)
     hook_configs = _prepare_pipeline_hook_configs(config)
     param_map.update(hook_configs)
-    
+
     return {k: v for k, v in param_map.items() if v is not None}
 
 
 def _extract_prepare_params(config: Dict[str, Any]) -> Dict[str, Any]:
     """Extract parameters for wrapper.prepare() from config"""
     prepare_params = {
-        'prompt': config.get('prompt', ''),
-        'negative_prompt': config.get('negative_prompt', ''),
-        'num_inference_steps': config.get('num_inference_steps', 50),
-        'guidance_scale': config.get('guidance_scale', 1.2),
-        'delta': config.get('delta', 1.0),
+        "prompt": config.get("prompt", ""),
+        "negative_prompt": config.get("negative_prompt", ""),
+        "num_inference_steps": config.get("num_inference_steps", 50),
+        "guidance_scale": config.get("guidance_scale", 1.2),
+        "delta": config.get("delta", 1.0),
     }
-    
+
     # Handle prompt blending configuration
-    if 'prompt_blending' in config:
-        blend_config = config['prompt_blending']
-        prepare_params['prompt_blending'] = {
-            'prompt_list': blend_config.get('prompt_list', []),
-            'interpolation_method': blend_config.get('interpolation_method', 'slerp'),
-            'enable_caching': blend_config.get('enable_caching', True)
+    if "prompt_blending" in config:
+        blend_config = config["prompt_blending"]
+        prepare_params["prompt_blending"] = {
+            "prompt_list": blend_config.get("prompt_list", []),
+            "interpolation_method": blend_config.get("interpolation_method", "slerp"),
+            "enable_caching": blend_config.get("enable_caching", True),
         }
-    
+
     # Handle seed blending configuration
-    if 'seed_blending' in config:
-        seed_blend_config = config['seed_blending']
-        prepare_params['seed_blending'] = {
-            'seed_list': seed_blend_config.get('seed_list', []),
-            'interpolation_method': seed_blend_config.get('interpolation_method', 'linear'),
-            'enable_caching': seed_blend_config.get('enable_caching', True)
+    if "seed_blending" in config:
+        seed_blend_config = config["seed_blending"]
+        prepare_params["seed_blending"] = {
+            "seed_list": seed_blend_config.get("seed_list", []),
+            "interpolation_method": seed_blend_config.get("interpolation_method", "linear"),
+            "enable_caching": seed_blend_config.get("enable_caching", True),
         }
-    
+
     return prepare_params
+
 
 def _prepare_controlnet_configs(config: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Prepare ControlNet configurations for wrapper"""
     controlnet_configs = []
-    pipeline_type = config.get('pipeline_type', 'sd1.5')
-    for cn_config in config['controlnets']:
+    pipeline_type = config.get("pipeline_type", "sd1.5")
+    for cn_config in config["controlnets"]:
         controlnet_config = {
-            'model_id': cn_config['model_id'],
-            'preprocessor': cn_config.get('preprocessor', 'passthrough'),
-            'conditioning_scale': cn_config.get('conditioning_scale', 1.0),
-            'enabled': cn_config.get('enabled', True),
-            'preprocessor_params': cn_config.get('preprocessor_params'),
-            'conditioning_channels': cn_config.get('conditioning_channels'),
-            'pipeline_type': pipeline_type,
-            'control_guidance_start': cn_config.get('control_guidance_start', 0.0),
-            'control_guidance_end': cn_config.get('control_guidance_end', 1.0),
+            "model_id": cn_config["model_id"],
+            "preprocessor": cn_config.get("preprocessor", "passthrough"),
+            "conditioning_scale": cn_config.get("conditioning_scale", 1.0),
+            "enabled": cn_config.get("enabled", True),
+            "preprocessor_params": cn_config.get("preprocessor_params"),
+            "conditioning_channels": cn_config.get("conditioning_channels"),
+            "pipeline_type": pipeline_type,
+            "control_guidance_start": cn_config.get("control_guidance_start", 0.0),
+            "control_guidance_end": cn_config.get("control_guidance_end", 1.0),
         }
         controlnet_configs.append(controlnet_config)
-    
+
     return controlnet_configs
 
 
 def _prepare_ipadapter_configs(config: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Prepare IPAdapter configurations for wrapper"""
     ipadapter_configs = []
-    
-    for ip_config in config['ipadapters']:
+
+    for ip_config in config["ipadapters"]:
         ipadapter_config = {
-            'ipadapter_model_path': ip_config['ipadapter_model_path'],
-            'image_encoder_path': ip_config['image_encoder_path'],
-            'style_image': ip_config.get('style_image'),
-            'scale': ip_config.get('scale', 1.0),
-            'enabled': ip_config.get('enabled', True),
+            "ipadapter_model_path": ip_config["ipadapter_model_path"],
+            "image_encoder_path": ip_config["image_encoder_path"],
+            "style_image": ip_config.get("style_image"),
+            "scale": ip_config.get("scale", 1.0),
+            "enabled": ip_config.get("enabled", True),
             # Preserve FaceID options from config for downstream wrapper/module handling
-            'type': ip_config.get('type', 'regular'),
-            'insightface_model_name': ip_config.get('insightface_model_name'),
+            "type": ip_config.get("type", "regular"),
+            "insightface_model_name": ip_config.get("insightface_model_name"),
         }
         ipadapter_configs.append(ipadapter_config)
-    
+
     return ipadapter_configs
 
 
 def _prepare_pipeline_hook_configs(config: Dict[str, Any]) -> Dict[str, Any]:
     """Prepare pipeline hook configurations for wrapper following ControlNet/IPAdapter pattern"""
     hook_configs = {}
-    
+
     # Image preprocessing hooks
-    if 'image_preprocessing' in config and config['image_preprocessing']:
-        if config['image_preprocessing'].get('enabled', True):
-            hook_configs['image_preprocessing_config'] = _prepare_single_hook_config(
-                config['image_preprocessing'], 'image_preprocessing'
+    if "image_preprocessing" in config and config["image_preprocessing"]:
+        if config["image_preprocessing"].get("enabled", True):
+            hook_configs["image_preprocessing_config"] = _prepare_single_hook_config(
+                config["image_preprocessing"], "image_preprocessing"
             )
-    
-    # Image postprocessing hooks  
-    if 'image_postprocessing' in config and config['image_postprocessing']:
-        if config['image_postprocessing'].get('enabled', True):
-            hook_configs['image_postprocessing_config'] = _prepare_single_hook_config(
-                config['image_postprocessing'], 'image_postprocessing'
+
+    # Image postprocessing hooks
+    if "image_postprocessing" in config and config["image_postprocessing"]:
+        if config["image_postprocessing"].get("enabled", True):
+            hook_configs["image_postprocessing_config"] = _prepare_single_hook_config(
+                config["image_postprocessing"], "image_postprocessing"
             )
-    
+
     # Latent preprocessing hooks
-    if 'latent_preprocessing' in config and config['latent_preprocessing']:
-        if config['latent_preprocessing'].get('enabled', True):
-            hook_configs['latent_preprocessing_config'] = _prepare_single_hook_config(
-                config['latent_preprocessing'], 'latent_preprocessing'
+    if "latent_preprocessing" in config and config["latent_preprocessing"]:
+        if config["latent_preprocessing"].get("enabled", True):
+            hook_configs["latent_preprocessing_config"] = _prepare_single_hook_config(
+                config["latent_preprocessing"], "latent_preprocessing"
             )
-    
+
     # Latent postprocessing hooks
-    if 'latent_postprocessing' in config and config['latent_postprocessing']:
-        if config['latent_postprocessing'].get('enabled', True):
-            hook_configs['latent_postprocessing_config'] = _prepare_single_hook_config(
-                config['latent_postprocessing'], 'latent_postprocessing'
+    if "latent_postprocessing" in config and config["latent_postprocessing"]:
+        if config["latent_postprocessing"].get("enabled", True):
+            hook_configs["latent_postprocessing_config"] = _prepare_single_hook_config(
+                config["latent_postprocessing"], "latent_postprocessing"
             )
-    
+
     return hook_configs
 
 
 def _prepare_single_hook_config(hook_config: Dict[str, Any], hook_type: str) -> Dict[str, Any]:
     """Prepare configuration for a single hook type"""
     return {
-        'enabled': hook_config.get('enabled', True),
-        'processors': hook_config.get('processors', []),
-        'hook_type': hook_type,
+        "enabled": hook_config.get("enabled", True),
+        "processors": hook_config.get("processors", []),
+        "hook_type": hook_type,
     }
 
 
 def _validate_pipeline_hook_configs(config: Dict[str, Any]) -> None:
     """Validate pipeline hook configurations following ControlNet/IPAdapter validation pattern"""
-    hook_types = ['image_preprocessing', 'image_postprocessing', 'latent_preprocessing', 'latent_postprocessing']
-    
+    hook_types = ["image_preprocessing", "image_postprocessing", "latent_preprocessing", "latent_postprocessing"]
+
     for hook_type in hook_types:
         if hook_type in config:
             hook_config = config[hook_type]
             if not isinstance(hook_config, dict):
                 raise ValueError(f"_validate_config: '{hook_type}' must be a dictionary")
-            
+
             # Validate enabled field
-            if 'enabled' in hook_config:
-                enabled = hook_config['enabled']
+            if "enabled" in hook_config:
+                enabled = hook_config["enabled"]
                 if not isinstance(enabled, bool):
                     raise ValueError(f"_validate_config: '{hook_type}.enabled' must be a boolean")
-            
+
             # Validate processors field
-            if 'processors' in hook_config:
-                processors = hook_config['processors']
+            if "processors" in hook_config:
+                processors = hook_config["processors"]
                 if not isinstance(processors, list):
                     raise ValueError(f"_validate_config: '{hook_type}.processors' must be a list")
-                
+
                 for i, processor in enumerate(processors):
                     if not isinstance(processor, dict):
                         raise ValueError(f"_validate_config: '{hook_type}.processors[{i}]' must be a dictionary")
-                    
+
                     # Validate processor type (required)
-                    if 'type' not in processor:
-                        raise ValueError(f"_validate_config: '{hook_type}.processors[{i}]' missing required 'type' field")
-                    
-                    if not isinstance(processor['type'], str):
+                    if "type" not in processor:
+                        raise ValueError(
+                            f"_validate_config: '{hook_type}.processors[{i}]' missing required 'type' field"
+                        )
+
+                    if not isinstance(processor["type"], str):
                         raise ValueError(f"_validate_config: '{hook_type}.processors[{i}].type' must be a string")
-                    
+
                     # Validate enabled field (optional, defaults to True)
-                    if 'enabled' in processor:
-                        enabled = processor['enabled']
+                    if "enabled" in processor:
+                        enabled = processor["enabled"]
                         if not isinstance(enabled, bool):
-                            raise ValueError(f"_validate_config: '{hook_type}.processors[{i}].enabled' must be a boolean")
-                    
+                            raise ValueError(
+                                f"_validate_config: '{hook_type}.processors[{i}].enabled' must be a boolean"
+                            )
+
                     # Validate order field (optional)
-                    if 'order' in processor:
-                        order = processor['order']
+                    if "order" in processor:
+                        order = processor["order"]
                         if not isinstance(order, int):
-                            raise ValueError(f"_validate_config: '{hook_type}.processors[{i}].order' must be an integer")
-                    
+                            raise ValueError(
+                                f"_validate_config: '{hook_type}.processors[{i}].order' must be an integer"
+                            )
+
                     # Validate params field (optional, coerce None to empty dict)
-                    if 'params' in processor:
-                        if processor['params'] is None:
-                            processor['params'] = {}
-                        elif not isinstance(processor['params'], dict):
-                            raise ValueError(f"_validate_config: '{hook_type}.processors[{i}].params' must be a dictionary")
+                    if "params" in processor:
+                        if processor["params"] is None:
+                            processor["params"] = {}
+                        elif not isinstance(processor["params"], dict):
+                            raise ValueError(
+                                f"_validate_config: '{hook_type}.processors[{i}].params' must be a dictionary"
+                            )
 
 
 def create_prompt_blending_config(
     base_config: Dict[str, Any],
     prompt_list: List[Tuple[str, float]],
     prompt_interpolation_method: str = "slerp",
-    enable_caching: bool = True
+    enable_caching: bool = True,
 ) -> Dict[str, Any]:
     """Create a configuration with prompt blending settings"""
     config = base_config.copy()
-    
-    config['prompt_blending'] = {
-        'prompt_list': prompt_list,
-        'interpolation_method': prompt_interpolation_method,
-        'enable_caching': enable_caching
+
+    config["prompt_blending"] = {
+        "prompt_list": prompt_list,
+        "interpolation_method": prompt_interpolation_method,
+        "enable_caching": enable_caching,
     }
-    
+
     return config
 
 
@@ -345,150 +360,152 @@ def create_seed_blending_config(
     base_config: Dict[str, Any],
     seed_list: List[Tuple[int, float]],
     interpolation_method: str = "linear",
-    enable_caching: bool = True
+    enable_caching: bool = True,
 ) -> Dict[str, Any]:
     """Create a configuration with seed blending settings"""
     config = base_config.copy()
-    
-    config['seed_blending'] = {
-        'seed_list': seed_list,
-        'interpolation_method': interpolation_method,
-        'enable_caching': enable_caching
+
+    config["seed_blending"] = {
+        "seed_list": seed_list,
+        "interpolation_method": interpolation_method,
+        "enable_caching": enable_caching,
     }
-    
+
     return config
 
 
 def set_normalize_weights_config(
-    base_config: Dict[str, Any],
-    normalize_prompt_weights: bool = True,
-    normalize_seed_weights: bool = True
+    base_config: Dict[str, Any], normalize_prompt_weights: bool = True, normalize_seed_weights: bool = True
 ) -> Dict[str, Any]:
     """Create a configuration with separate normalize weight settings"""
     config = base_config.copy()
-    
-    config['normalize_prompt_weights'] = normalize_prompt_weights
-    config['normalize_seed_weights'] = normalize_seed_weights
-    
+
+    config["normalize_prompt_weights"] = normalize_prompt_weights
+    config["normalize_seed_weights"] = normalize_seed_weights
+
     return config
+
 
 def _parse_dtype(dtype_str: str) -> Any:
     """Parse dtype string to torch dtype"""
     import torch
-    
+
     dtype_map = {
-        'float16': torch.float16,
-        'float32': torch.float32,
-        'half': torch.float16,
-        'float': torch.float32,
+        "float16": torch.float16,
+        "float32": torch.float32,
+        "half": torch.float16,
+        "float": torch.float32,
     }
-    
+
     if isinstance(dtype_str, str):
         return dtype_map.get(dtype_str.lower(), torch.float16)
     return dtype_str  # Assume it's already a torch dtype
+
+
 def _validate_config(config: Dict[str, Any]) -> None:
     """Basic validation of configuration dictionary"""
     if not isinstance(config, dict):
         raise ValueError("_validate_config: Configuration must be a dictionary")
-    
-    if 'model_id' not in config:
+
+    if "model_id" not in config:
         raise ValueError("_validate_config: Missing required field: model_id")
-    
-    if 'controlnets' in config:
-        if not isinstance(config['controlnets'], list):
+
+    if "controlnets" in config:
+        if not isinstance(config["controlnets"], list):
             raise ValueError("_validate_config: 'controlnets' must be a list")
-        
-        for i, controlnet in enumerate(config['controlnets']):
+
+        for i, controlnet in enumerate(config["controlnets"]):
             if not isinstance(controlnet, dict):
                 raise ValueError(f"_validate_config: ControlNet {i} must be a dictionary")
-            
-            if 'model_id' not in controlnet:
+
+            if "model_id" not in controlnet:
                 raise ValueError(f"_validate_config: ControlNet {i} missing required 'model_id'")
-            
+
             # Validate conditioning_channels if present
-            if 'conditioning_channels' in controlnet:
-                channels = controlnet['conditioning_channels']
+            if "conditioning_channels" in controlnet:
+                channels = controlnet["conditioning_channels"]
                 if not isinstance(channels, int) or channels <= 0:
-                    raise ValueError(f"_validate_config: ControlNet {i} 'conditioning_channels' must be a positive integer, got {channels}")
-    
+                    raise ValueError(
+                        f"_validate_config: ControlNet {i} 'conditioning_channels' must be a positive integer, got {channels}"
+                    )
+
     # Validate ipadapters if present
-    if 'ipadapters' in config:
-        if not isinstance(config['ipadapters'], list):
+    if "ipadapters" in config:
+        if not isinstance(config["ipadapters"], list):
             raise ValueError("_validate_config: 'ipadapters' must be a list")
-        
-        for i, ipadapter in enumerate(config['ipadapters']):
+
+        for i, ipadapter in enumerate(config["ipadapters"]):
             if not isinstance(ipadapter, dict):
                 raise ValueError(f"_validate_config: IPAdapter {i} must be a dictionary")
-            
-            if 'ipadapter_model_path' not in ipadapter:
+
+            if "ipadapter_model_path" not in ipadapter:
                 raise ValueError(f"_validate_config: IPAdapter {i} missing required 'ipadapter_model_path'")
-            
-            if 'image_encoder_path' not in ipadapter:
+
+            if "image_encoder_path" not in ipadapter:
                 raise ValueError(f"_validate_config: IPAdapter {i} missing required 'image_encoder_path'")
 
     # Validate prompt blending configuration if present
-    if 'prompt_blending' in config:
-        blend_config = config['prompt_blending']
+    if "prompt_blending" in config:
+        blend_config = config["prompt_blending"]
         if not isinstance(blend_config, dict):
             raise ValueError("_validate_config: 'prompt_blending' must be a dictionary")
-        
-        if 'prompt_list' in blend_config:
-            prompt_list = blend_config['prompt_list']
+
+        if "prompt_list" in blend_config:
+            prompt_list = blend_config["prompt_list"]
             if not isinstance(prompt_list, list):
                 raise ValueError("_validate_config: 'prompt_list' must be a list")
-            
+
             for i, prompt_item in enumerate(prompt_list):
                 if not isinstance(prompt_item, (list, tuple)) or len(prompt_item) != 2:
                     raise ValueError(f"_validate_config: Prompt item {i} must be [text, weight] pair")
-                
+
                 text, weight = prompt_item
                 if not isinstance(text, str):
                     raise ValueError(f"_validate_config: Prompt text {i} must be a string")
-                
+
                 if not isinstance(weight, (int, float)) or weight < 0:
                     raise ValueError(f"_validate_config: Prompt weight {i} must be a non-negative number")
-        
-        interpolation_method = blend_config.get('interpolation_method', 'slerp')
-        if interpolation_method not in ['linear', 'slerp']:
+
+        interpolation_method = blend_config.get("interpolation_method", "slerp")
+        if interpolation_method not in ["linear", "slerp"]:
             raise ValueError("_validate_config: interpolation_method must be 'linear' or 'slerp'")
 
     # Validate seed blending configuration if present
-    if 'seed_blending' in config:
-        seed_blend_config = config['seed_blending']
+    if "seed_blending" in config:
+        seed_blend_config = config["seed_blending"]
         if not isinstance(seed_blend_config, dict):
             raise ValueError("_validate_config: 'seed_blending' must be a dictionary")
-        
-        if 'seed_list' in seed_blend_config:
-            seed_list = seed_blend_config['seed_list']
+
+        if "seed_list" in seed_blend_config:
+            seed_list = seed_blend_config["seed_list"]
             if not isinstance(seed_list, list):
                 raise ValueError("_validate_config: 'seed_list' must be a list")
-            
+
             for i, seed_item in enumerate(seed_list):
                 if not isinstance(seed_item, (list, tuple)) or len(seed_item) != 2:
                     raise ValueError(f"_validate_config: Seed item {i} must be [seed, weight] pair")
-                
+
                 seed_value, weight = seed_item
                 if not isinstance(seed_value, int) or seed_value < 0:
                     raise ValueError(f"_validate_config: Seed value {i} must be a non-negative integer")
-                
+
             if not isinstance(weight, (int, float)) or weight < 0:
                 raise ValueError(f"_validate_config: Seed weight {i} must be a non-negative number")
-        
-        interpolation_method = seed_blend_config.get('interpolation_method', 'linear')
-        if interpolation_method not in ['linear', 'slerp']:
+
+        interpolation_method = seed_blend_config.get("interpolation_method", "linear")
+        if interpolation_method not in ["linear", "slerp"]:
             raise ValueError("_validate_config: seed blending interpolation_method must be 'linear' or 'slerp'")
 
     # Validate pipeline hook configurations if present (Phase 4: Configuration Integration)
     _validate_pipeline_hook_configs(config)
 
     # Validate separate normalize settings if present
-    if 'normalize_prompt_weights' in config:
-        normalize_prompt_weights = config['normalize_prompt_weights']
+    if "normalize_prompt_weights" in config:
+        normalize_prompt_weights = config["normalize_prompt_weights"]
         if not isinstance(normalize_prompt_weights, bool):
             raise ValueError("_validate_config: 'normalize_prompt_weights' must be a boolean value")
-    
-    if 'normalize_seed_weights' in config:
-        normalize_seed_weights = config['normalize_seed_weights']
+
+    if "normalize_seed_weights" in config:
+        normalize_seed_weights = config["normalize_seed_weights"]
         if not isinstance(normalize_seed_weights, bool):
             raise ValueError("_validate_config: 'normalize_seed_weights' must be a boolean value")
-

--- a/src/streamdiffusion/hooks.py
+++ b/src/streamdiffusion/hooks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
+
 import torch
 
 
@@ -13,6 +14,7 @@ class EmbedsCtx:
     - prompt_embeds: [batch, seq_len, dim]
     - negative_prompt_embeds: optional [batch, seq_len, dim]
     """
+
     prompt_embeds: torch.Tensor
     negative_prompt_embeds: Optional[torch.Tensor] = None
 
@@ -28,6 +30,7 @@ class StepCtx:
     - guidance_mode: one of {"none","full","self","initialize"}
     - sdxl_cond: optional dict with SDXL micro-cond tensors
     """
+
     x_t_latent: torch.Tensor
     t_list: torch.Tensor
     step_index: Optional[int]
@@ -38,6 +41,7 @@ class StepCtx:
 @dataclass
 class UnetKwargsDelta:
     """Delta produced by UNet hooks to augment UNet call kwargs."""
+
     down_block_additional_residuals: Optional[List[torch.Tensor]] = None
     mid_block_additional_residual: Optional[torch.Tensor] = None
     added_cond_kwargs: Optional[Dict[str, torch.Tensor]] = None
@@ -48,32 +52,33 @@ class UnetKwargsDelta:
 @dataclass
 class ImageCtx:
     """Context passed to image processing hooks.
-    
+
     Fields:
     - image: [B, C, H, W] tensor in image space
     - width: image width
-    - height: image height  
+    - height: image height
     - step_index: optional step index for multi-step processing
     """
+
     image: torch.Tensor
     width: int
     height: int
     step_index: Optional[int] = None
 
 
-@dataclass  
+@dataclass
 class LatentCtx:
     """Context passed to latent processing hooks.
-    
+
     Fields:
     - latent: [B, C, H/8, W/8] tensor in latent space
     - timestep: optional timestep tensor for diffusion context
     - step_index: optional step index for multi-step processing
     """
+
     latent: torch.Tensor
     timestep: Optional[torch.Tensor] = None
     step_index: Optional[int] = None
-
 
 
 # Type aliases for clarity
@@ -81,4 +86,3 @@ EmbeddingHook = Callable[[EmbedsCtx], EmbedsCtx]
 UnetHook = Callable[[StepCtx], UnetKwargsDelta]
 ImageHook = Callable[[ImageCtx], ImageCtx]
 LatentHook = Callable[[LatentCtx], LatentCtx]
-

--- a/src/streamdiffusion/image_filter.py
+++ b/src/streamdiffusion/image_filter.py
@@ -1,5 +1,5 @@
-from typing import Optional
 import random
+from typing import Optional
 
 import torch
 import torch.nn.functional as F

--- a/src/streamdiffusion/image_utils.py
+++ b/src/streamdiffusion/image_utils.py
@@ -30,9 +30,7 @@ def numpy_to_pil(images: np.ndarray) -> PIL.Image.Image:
     images = (images * 255).round().astype("uint8")
     if images.shape[-1] == 1:
         # special case for grayscale (single channel) images
-        pil_images = [
-            PIL.Image.fromarray(image.squeeze(), mode="L") for image in images
-        ]
+        pil_images = [PIL.Image.fromarray(image.squeeze(), mode="L") for image in images]
     else:
         pil_images = [PIL.Image.fromarray(image) for image in images]
 
@@ -56,12 +54,7 @@ def postprocess_image(
     if do_denormalize is None:
         do_denormalize = [do_normalize_flg] * image.shape[0]
 
-    image = torch.stack(
-        [
-            denormalize(image[i]) if do_denormalize[i] else image[i]
-            for i in range(image.shape[0])
-        ]
-    )
+    image = torch.stack([denormalize(image[i]) if do_denormalize[i] else image[i] for i in range(image.shape[0])])
 
     if output_type == "pt":
         return image
@@ -91,8 +84,6 @@ def pil2tensor(image_pil: PIL.Image.Image) -> torch.Tensor:
     img, _ = process_image(image_pil)
     imgs.append(img)
     imgs = torch.vstack(imgs)
-    images = torch.nn.functional.interpolate(
-        imgs, size=(height, width), mode="bilinear"
-    )
+    images = torch.nn.functional.interpolate(imgs, size=(height, width), mode="bilinear")
     image_tensors = images.to(torch.float16)
     return image_tensors

--- a/src/streamdiffusion/model_detection.py
+++ b/src/streamdiffusion/model_detection.py
@@ -1,13 +1,15 @@
 """Comprehensive model detection for TensorRT and pipeline support"""
 
-from typing import Dict, Tuple, Optional, Any, List
+from typing import Any, Dict, Optional
 
 import torch
 from diffusers.models.unets.unet_2d_condition import UNet2DConditionModel
 
+
 # Gracefully import the SD3 model class; it might not exist in older diffusers versions.
 try:
     from diffusers.models.transformers.mm_dit import MMDiTTransformer2DModel
+
     HAS_MMDIT = True
 except ImportError:
     # Create a dummy class if the import fails to prevent runtime errors.
@@ -15,6 +17,8 @@ except ImportError:
     HAS_MMDIT = False
 
 import logging
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,7 +27,7 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
     Comprehensive and robust model detection using definitive architectural features.
 
     This function replaces heuristic-based analysis with a deterministic,
-    rule-based approach by first inspecting the model's class and then its key 
+    rule-based approach by first inspecting the model's class and then its key
     configuration parameters that define the architecture.
 
     Args:
@@ -50,9 +54,9 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
             confidence = 1.0
             # Differentiating SD3 vs. SD3-Turbo from the MMDiT config alone is currently
             # speculative. A check on the pipeline's scheduler is a reasonable proxy.
-            if pipe and hasattr(pipe, 'scheduler'):
-                scheduler_name = getattr(pipe.scheduler.config, '_class_name', '').lower()
-                if 'lcm' in scheduler_name or 'turbo' in scheduler_name:
+            if pipe and hasattr(pipe, "scheduler"):
+                scheduler_name = getattr(pipe.scheduler.config, "_class_name", "").lower()
+                if "lcm" in scheduler_name or "turbo" in scheduler_name:
                     is_turbo = True
                     model_type = "SD3-Turbo"
         else:
@@ -62,7 +66,7 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
     # 2. UNet-based Model Detection (SDXL, SD2.1, SD1.5)
     elif isinstance(model, UNet2DConditionModel):
         config = model.config
-        
+
         # 2a. SDXL vs. non-SDXL
         # The `addition_embed_type` is the clearest indicator for the SDXL architecture.
         if config.get("addition_embed_type") is not None:
@@ -73,7 +77,7 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
             # Base SDXL has `time_cond_proj_dim` (e.g., 256), while Turbo has it set to `None`.
             if config.get("time_cond_proj_dim") is None:
                 is_turbo = True
-        
+
         # 2b. SD2.1 vs. SD1.5 (if not SDXL)
         # Differentiate based on the text encoder's projection dimension.
         else:
@@ -90,10 +94,10 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
                 confidence = 0.7
 
     # 3. ControlNet Model Detection (detect underlying architecture)
-    elif hasattr(model, 'config') and hasattr(model.config, 'cross_attention_dim'):
+    elif hasattr(model, "config") and hasattr(model.config, "cross_attention_dim"):
         # ControlNet models have UNet-like configs, detect their base architecture
         config = model.config
-        
+
         # Apply same detection logic as UNet models
         if config.get("addition_embed_type") is not None:
             model_type = "SDXL"
@@ -107,12 +111,12 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
                 model_type = "SD2.1"
                 confidence = 0.95
             elif cross_attention_dim == 768:
-                model_type = "SD1.5" 
+                model_type = "SD1.5"
                 confidence = 0.95
             else:
                 model_type = "SD-finetune"
                 confidence = 0.7
-    
+
     else:
         # The model is not a known UNet or MMDiT class.
         confidence = 0.0
@@ -120,44 +124,46 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
 
     # Populate architecture and compatibility details (can be expanded as needed)
     architecture_details = {
-        'model_class': model.__class__.__name__,
-        'in_channels': getattr(model.config, 'in_channels', 'N/A'),
-        'cross_attention_dim': getattr(model.config, 'cross_attention_dim', 'N/A'),
-        'block_out_channels': getattr(model.config, 'block_out_channels', 'N/A'),
+        "model_class": model.__class__.__name__,
+        "in_channels": getattr(model.config, "in_channels", "N/A"),
+        "cross_attention_dim": getattr(model.config, "cross_attention_dim", "N/A"),
+        "block_out_channels": getattr(model.config, "block_out_channels", "N/A"),
     }
-    
+
     # For UNet models, add detailed characteristics that SDXL code expects
     if isinstance(model, UNet2DConditionModel):
         unet_chars = detect_unet_characteristics(model)
-        architecture_details.update({
-            'has_time_conditioning': unet_chars['has_time_cond'],
-            'has_addition_embeds': unet_chars['has_addition_embed'],
-        })
-    
+        architecture_details.update(
+            {
+                "has_time_conditioning": unet_chars["has_time_cond"],
+                "has_addition_embeds": unet_chars["has_addition_embed"],
+            }
+        )
+
     # For ControlNet models, add similar characteristics
-    elif hasattr(model, 'config') and hasattr(model.config, 'cross_attention_dim'):
+    elif hasattr(model, "config") and hasattr(model.config, "cross_attention_dim"):
         # ControlNet models have similar config structure to UNet
         config = model.config
         has_addition_embed = config.get("addition_embed_type") is not None
-        has_time_cond = hasattr(config, 'time_cond_proj_dim') and config.time_cond_proj_dim is not None
-        
-        architecture_details.update({
-            'has_time_conditioning': has_time_cond,
-            'has_addition_embeds': has_addition_embed,
-        })
+        has_time_cond = hasattr(config, "time_cond_proj_dim") and config.time_cond_proj_dim is not None
 
-    compatibility_info = {
-        'notes': f"Detected as {model_type} with {confidence:.2f} confidence based on architecture."
-    }
+        architecture_details.update(
+            {
+                "has_time_conditioning": has_time_cond,
+                "has_addition_embeds": has_addition_embed,
+            }
+        )
+
+    compatibility_info = {"notes": f"Detected as {model_type} with {confidence:.2f} confidence based on architecture."}
 
     result = {
-        'model_type': model_type,
-        'is_turbo': is_turbo,
-        'is_sdxl': is_sdxl,
-        'is_sd3': is_sd3,
-        'confidence': confidence,
-        'architecture_details': architecture_details,
-        'compatibility_info': compatibility_info,
+        "model_type": model_type,
+        "is_turbo": is_turbo,
+        "is_sdxl": is_sdxl,
+        "is_sd3": is_sd3,
+        "confidence": confidence,
+        "architecture_details": architecture_details,
+        "compatibility_info": compatibility_info,
     }
 
     return result
@@ -166,13 +172,13 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
 def detect_unet_characteristics(unet: UNet2DConditionModel) -> Dict[str, any]:
     """Detect detailed UNet characteristics including SDXL-specific features"""
     config = unet.config
-    
+
     # Get cross attention dimensions to detect model type
-    cross_attention_dim = getattr(config, 'cross_attention_dim', None)
-    
+    cross_attention_dim = getattr(config, "cross_attention_dim", None)
+
     # Detect SDXL by multiple indicators
     is_sdxl = False
-    
+
     # Check cross attention dimension
     if isinstance(cross_attention_dim, (list, tuple)):
         # SDXL typically has [1280, 1280, 1280, 1280, 1280, 1280, 1280, 1280, 1280, 1280]
@@ -180,73 +186,74 @@ def detect_unet_characteristics(unet: UNet2DConditionModel) -> Dict[str, any]:
     elif isinstance(cross_attention_dim, int):
         # Single value - SDXL uses 2048 for concatenated embeddings, or 1280+ for individual encoders
         is_sdxl = cross_attention_dim >= 1280
-    
+
     # Check addition_embed_type for SDXL detection (strong indicator)
-    addition_embed_type = getattr(config, 'addition_embed_type', None)
+    addition_embed_type = getattr(config, "addition_embed_type", None)
     has_addition_embed = addition_embed_type is not None
-    
-    if addition_embed_type in ['text_time', 'text_time_guidance']:
+
+    if addition_embed_type in ["text_time", "text_time_guidance"]:
         is_sdxl = True  # This is a definitive SDXL indicator
-    
+
     # Check if model has time conditioning projection (SDXL feature)
-    has_time_cond = hasattr(config, 'time_cond_proj_dim') and config.time_cond_proj_dim is not None
-    
+    has_time_cond = hasattr(config, "time_cond_proj_dim") and config.time_cond_proj_dim is not None
+
     # Additional SDXL detection checks
-    if hasattr(config, 'num_class_embeds') and config.num_class_embeds is not None:
+    if hasattr(config, "num_class_embeds") and config.num_class_embeds is not None:
         is_sdxl = True  # SDXL often has class embeddings
-        
+
     # Check sample size (SDXL typically uses 128 vs 64 for SD1.5)
-    sample_size = getattr(config, 'sample_size', 64)
+    sample_size = getattr(config, "sample_size", 64)
     if sample_size >= 128:
         is_sdxl = True
-    
+
     return {
-        'is_sdxl': is_sdxl,
-        'has_time_cond': has_time_cond, 
-        'has_addition_embed': has_addition_embed,
-        'cross_attention_dim': cross_attention_dim,
-        'addition_embed_type': addition_embed_type,
-        'in_channels': getattr(config, 'in_channels', 4),
-        'sample_size': getattr(config, 'sample_size', 64 if not is_sdxl else 128),
-        'block_out_channels': tuple(getattr(config, 'block_out_channels', [])),
-        'attention_head_dim': getattr(config, 'attention_head_dim', None)
+        "is_sdxl": is_sdxl,
+        "has_time_cond": has_time_cond,
+        "has_addition_embed": has_addition_embed,
+        "cross_attention_dim": cross_attention_dim,
+        "addition_embed_type": addition_embed_type,
+        "in_channels": getattr(config, "in_channels", 4),
+        "sample_size": getattr(config, "sample_size", 64 if not is_sdxl else 128),
+        "block_out_channels": tuple(getattr(config, "block_out_channels", [])),
+        "attention_head_dim": getattr(config, "attention_head_dim", None),
     }
+
 
 # This is used for controlnet/ipadapter model detection - can be deprecated (along with detect_unet_characteristics)
 def detect_model_from_diffusers_unet(unet: UNet2DConditionModel) -> str:
     """Detect model type from diffusers UNet configuration"""
     characteristics = detect_unet_characteristics(unet)
-    
-    in_channels = characteristics['in_channels']
-    block_out_channels = characteristics['block_out_channels']
-    cross_attention_dim = characteristics['cross_attention_dim']
-    is_sdxl = characteristics['is_sdxl']
-    
+
+    in_channels = characteristics["in_channels"]
+    block_out_channels = characteristics["block_out_channels"]
+    cross_attention_dim = characteristics["cross_attention_dim"]
+    is_sdxl = characteristics["is_sdxl"]
+
     # Use enhanced SDXL detection
     if is_sdxl:
         return "SDXL"
-    
+
     # Original detection logic for other models
-    if (cross_attention_dim == 768 and 
-        block_out_channels == (320, 640, 1280, 1280) and
-        in_channels == 4):
+    if cross_attention_dim == 768 and block_out_channels == (320, 640, 1280, 1280) and in_channels == 4:
         return "SD15"
-    
-    elif (cross_attention_dim == 1024 and 
-          block_out_channels == (320, 640, 1280, 1280) and
-          in_channels == 4):
+
+    elif cross_attention_dim == 1024 and block_out_channels == (320, 640, 1280, 1280) and in_channels == 4:
         return "SD21"
-    
+
     elif cross_attention_dim == 768 and in_channels == 4:
         return "SD15"
     elif cross_attention_dim == 1024 and in_channels == 4:
         return "SD21"
-    
+
     if cross_attention_dim == 768:
-        print(f"detect_model_from_diffusers_unet: Unknown SD1.5-like model with channels {block_out_channels}, defaulting to SD15")
+        print(
+            f"detect_model_from_diffusers_unet: Unknown SD1.5-like model with channels {block_out_channels}, defaulting to SD15"
+        )
         return "SD15"
     elif cross_attention_dim == 1024:
-        print(f"detect_model_from_diffusers_unet: Unknown SD2.1-like model with channels {block_out_channels}, defaulting to SD21")
+        print(
+            f"detect_model_from_diffusers_unet: Unknown SD2.1-like model with channels {block_out_channels}, defaulting to SD21"
+        )
         return "SD21"
     else:
         raise ValueError(
@@ -260,58 +267,58 @@ def detect_model_from_diffusers_unet(unet: UNet2DConditionModel) -> str:
 def extract_unet_architecture(unet: UNet2DConditionModel) -> Dict[str, Any]:
     """
     Extract UNet architecture details needed for TensorRT engine building.
-    
+
     This function provides the essential architecture information needed
     for TensorRT engine compilation in a clean, structured format.
-    
+
     Args:
         unet: The UNet model to analyze
-        
+
     Returns:
         Dict with architecture parameters for TensorRT engine building
     """
     config = unet.config
-    
+
     # Basic model parameters
     model_channels = config.block_out_channels[0] if config.block_out_channels else 320
     block_out_channels = tuple(config.block_out_channels)
     channel_mult = tuple(ch // model_channels for ch in block_out_channels)
-    
+
     # Resolution blocks
-    if hasattr(config, 'layers_per_block'):
+    if hasattr(config, "layers_per_block"):
         if isinstance(config.layers_per_block, (list, tuple)):
             num_res_blocks = tuple(config.layers_per_block)
         else:
             num_res_blocks = tuple([config.layers_per_block] * len(block_out_channels))
     else:
         num_res_blocks = tuple([2] * len(block_out_channels))
-    
+
     # Attention and context dimensions
     context_dim = config.cross_attention_dim
     in_channels = config.in_channels
-    
+
     # Attention head configuration
-    attention_head_dim = getattr(config, 'attention_head_dim', 8)
+    attention_head_dim = getattr(config, "attention_head_dim", 8)
     if isinstance(attention_head_dim, (list, tuple)):
         attention_head_dim = attention_head_dim[0]
-    
+
     # Transformer depth
-    transformer_depth = getattr(config, 'transformer_layers_per_block', 1)
+    transformer_depth = getattr(config, "transformer_layers_per_block", 1)
     if isinstance(transformer_depth, (list, tuple)):
         transformer_depth = tuple(transformer_depth)
     else:
         transformer_depth = tuple([transformer_depth] * len(block_out_channels))
-    
+
     # Time embedding
-    time_embed_dim = getattr(config, 'time_embedding_dim', None)
+    time_embed_dim = getattr(config, "time_embedding_dim", None)
     if time_embed_dim is None:
         time_embed_dim = model_channels * 4
-    
+
     # Build architecture dictionary
     architecture_dict = {
         "model_channels": model_channels,
         "in_channels": in_channels,
-        "out_channels": getattr(config, 'out_channels', in_channels),
+        "out_channels": getattr(config, "out_channels", in_channels),
         "num_res_blocks": num_res_blocks,
         "channel_mult": channel_mult,
         "context_dim": context_dim,
@@ -319,48 +326,50 @@ def extract_unet_architecture(unet: UNet2DConditionModel) -> Dict[str, Any]:
         "transformer_depth": transformer_depth,
         "time_embed_dim": time_embed_dim,
         "block_out_channels": block_out_channels,
-        
         # Additional configuration
-        "use_linear_in_transformer": getattr(config, 'use_linear_in_transformer', False),
-        "conv_in_kernel": getattr(config, 'conv_in_kernel', 3),
-        "conv_out_kernel": getattr(config, 'conv_out_kernel', 3),
-        "resnet_time_scale_shift": getattr(config, 'resnet_time_scale_shift', 'default'),
-        "class_embed_type": getattr(config, 'class_embed_type', None),
-        "num_class_embeds": getattr(config, 'num_class_embeds', None),
-        
+        "use_linear_in_transformer": getattr(config, "use_linear_in_transformer", False),
+        "conv_in_kernel": getattr(config, "conv_in_kernel", 3),
+        "conv_out_kernel": getattr(config, "conv_out_kernel", 3),
+        "resnet_time_scale_shift": getattr(config, "resnet_time_scale_shift", "default"),
+        "class_embed_type": getattr(config, "class_embed_type", None),
+        "num_class_embeds": getattr(config, "num_class_embeds", None),
         # Block types
-        "down_block_types": getattr(config, 'down_block_types', []),
-        "up_block_types": getattr(config, 'up_block_types', []),
+        "down_block_types": getattr(config, "down_block_types", []),
+        "up_block_types": getattr(config, "up_block_types", []),
     }
-    
+
     return architecture_dict
 
 
 def validate_architecture(arch_dict: Dict[str, Any], model_type: str) -> Dict[str, Any]:
     """
     Validate and fix architecture dictionary using model type presets.
-    
+
     Ensures that all required architecture parameters are present and
     have reasonable values for the specified model type.
-    
+
     Args:
         arch_dict: Architecture dictionary to validate
         model_type: Expected model type for validation
-        
+
     Returns:
         Validated and corrected architecture dictionary
     """
-    
+
     # Check for required keys
     required_keys = [
-        "model_channels", "channel_mult", "num_res_blocks", 
-        "context_dim", "in_channels", "block_out_channels"
+        "model_channels",
+        "channel_mult",
+        "num_res_blocks",
+        "context_dim",
+        "in_channels",
+        "block_out_channels",
     ]
-    
+
     for key in required_keys:
         if key not in arch_dict:
             raise ValueError(f"Missing required architecture parameter: {key}")
-    
+
     # Ensure tuple format for sequence parameters
     for key in ["channel_mult", "num_res_blocks", "transformer_depth", "block_out_channels"]:
         if key in arch_dict and not isinstance(arch_dict[key], tuple):
@@ -371,12 +380,11 @@ def validate_architecture(arch_dict: Dict[str, Any], model_type: str) -> Dict[st
                     arch_dict[key] = tuple(arch_dict[key])
             else:
                 arch_dict[key] = preset[key]
-    
+
     # Validate sequence lengths match
     expected_levels = len(arch_dict["channel_mult"])
     for key in ["num_res_blocks", "transformer_depth"]:
         if key in arch_dict and len(arch_dict[key]) != expected_levels:
             arch_dict[key] = preset[key]
-    
-    return arch_dict
 
+    return arch_dict

--- a/src/streamdiffusion/modules/__init__.py
+++ b/src/streamdiffusion/modules/__init__.py
@@ -1,22 +1,21 @@
 # StreamDiffusion Modules Package
 
 from .controlnet_module import ControlNetModule
+from .image_processing_module import ImagePostprocessingModule, ImagePreprocessingModule, ImageProcessingModule
 from .ipadapter_module import IPAdapterModule
-from .image_processing_module import ImageProcessingModule, ImagePreprocessingModule, ImagePostprocessingModule
-from .latent_processing_module import LatentProcessingModule, LatentPreprocessingModule, LatentPostprocessingModule
+from .latent_processing_module import LatentPostprocessingModule, LatentPreprocessingModule, LatentProcessingModule
+
 
 __all__ = [
     # Existing modules
-    'ControlNetModule',
-    'IPAdapterModule',
-    
+    "ControlNetModule",
+    "IPAdapterModule",
     # Pipeline processing base classes
-    'ImageProcessingModule',
-    'LatentProcessingModule',
-    
+    "ImageProcessingModule",
+    "LatentProcessingModule",
     # Pipeline processing timing-specific modules
-    'ImagePreprocessingModule',
-    'ImagePostprocessingModule', 
-    'LatentPreprocessingModule',
-    'LatentPostprocessingModule',
+    "ImagePreprocessingModule",
+    "ImagePostprocessingModule",
+    "LatentPreprocessingModule",
+    "LatentPostprocessingModule",
 ]

--- a/src/streamdiffusion/modules/controlnet_module.py
+++ b/src/streamdiffusion/modules/controlnet_module.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
+import logging
 import threading
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 
 import torch
 from diffusers.models import ControlNetModel
-import logging
 
-from streamdiffusion.hooks import StepCtx, UnetKwargsDelta, UnetHook
+from streamdiffusion.hooks import StepCtx, UnetHook, UnetKwargsDelta
+from streamdiffusion.preprocessing.orchestrator_user import OrchestratorUser
 from streamdiffusion.preprocessing.preprocessing_orchestrator import (
     PreprocessingOrchestrator,
 )
-from streamdiffusion.preprocessing.orchestrator_user import OrchestratorUser
 
 
 @dataclass
@@ -55,17 +55,17 @@ class ControlNetModule(OrchestratorUser):
         self._prepared_dtype: Optional[torch.dtype] = None
         self._prepared_batch: Optional[int] = None
         self._images_version: int = 0
-        
+
         # Cache expensive lookups to avoid repeated hasattr/getattr calls
         self._engines_by_id: Dict[str, Any] = {}
         self._engines_cache_valid: bool = False
         self._is_sdxl: Optional[bool] = None
         self._expected_text_len: int = 77
-        
+
         # SDXL-specific caching for performance optimization
         self._sdxl_conditioning_cache: Optional[Dict[str, torch.Tensor]] = None
         self._sdxl_conditioning_valid: bool = False
-        
+
         # Cache engine type detection to avoid repeated hasattr calls
         self._engine_type_cache: Dict[str, bool] = {}
 
@@ -78,9 +78,9 @@ class ControlNetModule(OrchestratorUser):
         # Register UNet hook
         stream.unet_hooks.append(self.build_unet_hook())
         # Expose controlnet collections so existing updater can find them
-        setattr(stream, 'controlnets', self.controlnets)
-        setattr(stream, 'controlnet_scales', self.controlnet_scales)
-        setattr(stream, 'preprocessors', self.preprocessors)
+        setattr(stream, "controlnets", self.controlnets)
+        setattr(stream, "controlnet_scales", self.controlnet_scales)
+        setattr(stream, "preprocessors", self.preprocessors)
         # Reset prepared tensors on install
         self._prepared_tensors = []
         self._prepared_device = None
@@ -92,18 +92,26 @@ class ControlNetModule(OrchestratorUser):
         self._sdxl_conditioning_valid = False
         self._engine_type_cache.clear()
 
-    def add_controlnet(self, cfg: ControlNetConfig, control_image: Optional[Union[str, Any, torch.Tensor]] = None) -> None:
+    def add_controlnet(
+        self, cfg: ControlNetConfig, control_image: Optional[Union[str, Any, torch.Tensor]] = None
+    ) -> None:
         model = self._load_pytorch_controlnet_model(cfg.model_id, cfg.conditioning_channels)
 
         preproc = None
         if cfg.preprocessor:
             from streamdiffusion.preprocessing.processors import get_preprocessor
-            preproc = get_preprocessor(cfg.preprocessor, pipeline_ref=self._stream, normalization_context='controlnet', params=cfg.preprocessor_params)
+
+            preproc = get_preprocessor(
+                cfg.preprocessor,
+                pipeline_ref=self._stream,
+                normalization_context="controlnet",
+                params=cfg.preprocessor_params,
+            )
             # Apply provided parameters to the preprocessor instance
             if cfg.preprocessor_params:
                 params = cfg.preprocessor_params or {}
                 # If the preprocessor exposes a 'params' dict, update it
-                if hasattr(preproc, 'params') and isinstance(getattr(preproc, 'params'), dict):
+                if hasattr(preproc, "params") and isinstance(getattr(preproc, "params"), dict):
                     preproc.params.update(params)
                 # Also set attributes directly when they exist
                 for name, value in params.items():
@@ -113,16 +121,15 @@ class ControlNetModule(OrchestratorUser):
                     except Exception:
                         pass
 
-
             # Align preprocessor target size with stream resolution once (avoid double-resize later)
             try:
-                if hasattr(preproc, 'params') and isinstance(getattr(preproc, 'params'), dict):
-                    preproc.params['image_width'] = int(self._stream.width)
-                    preproc.params['image_height'] = int(self._stream.height)
-                if hasattr(preproc, 'image_width'):
-                    setattr(preproc, 'image_width', int(self._stream.width))
-                if hasattr(preproc, 'image_height'):
-                    setattr(preproc, 'image_height', int(self._stream.height))
+                if hasattr(preproc, "params") and isinstance(getattr(preproc, "params"), dict):
+                    preproc.params["image_width"] = int(self._stream.width)
+                    preproc.params["image_height"] = int(self._stream.height)
+                if hasattr(preproc, "image_width"):
+                    setattr(preproc, "image_width", int(self._stream.width))
+                if hasattr(preproc, "image_height"):
+                    setattr(preproc, "image_height", int(self._stream.height))
             except Exception:
                 pass
 
@@ -142,7 +149,9 @@ class ControlNetModule(OrchestratorUser):
             # Invalidate SDXL conditioning cache when ControlNet configuration changes
             self._sdxl_conditioning_valid = False
 
-    def update_control_image_efficient(self, control_image: Union[str, Any, torch.Tensor], index: Optional[int] = None) -> None:
+    def update_control_image_efficient(
+        self, control_image: Union[str, Any, torch.Tensor], index: Optional[int] = None
+    ) -> None:
         if self._preprocessing_orchestrator is None:
             return
         with self._collections_lock:
@@ -150,23 +159,15 @@ class ControlNetModule(OrchestratorUser):
                 return
             total = len(self.controlnets)
             # Build active scales, respecting enabled_list if present
-            scales = [
-                (self.controlnet_scales[i] if i < len(self.controlnet_scales) else 1.0)
-                for i in range(total)
-            ]
-            if hasattr(self, 'enabled_list') and self.enabled_list and len(self.enabled_list) == total:
+            scales = [(self.controlnet_scales[i] if i < len(self.controlnet_scales) else 1.0) for i in range(total)]
+            if hasattr(self, "enabled_list") and self.enabled_list and len(self.enabled_list) == total:
                 scales = [sc if bool(self.enabled_list[i]) else 0.0 for i, sc in enumerate(scales)]
             preprocessors = [self.preprocessors[i] if i < len(self.preprocessors) else None for i in range(total)]
 
         # Single-index fast path
         if index is not None:
             results = self._preprocessing_orchestrator.process_sync(
-                control_image,
-                preprocessors,
-                scales,
-                self._stream.width,
-                self._stream.height,
-                index
+                control_image, preprocessors, scales, self._stream.width, self._stream.height, index
             )
             processed = results[index] if results and len(results) > index else None
             with self._collections_lock:
@@ -182,11 +183,7 @@ class ControlNetModule(OrchestratorUser):
 
         # Use intelligent pipelining (automatically detects feedback preprocessors and switches to sync)
         processed_images = self._preprocessing_orchestrator.process_pipelined(
-            control_image,
-            preprocessors,
-            scales,
-            self._stream.width,
-            self._stream.height
+            control_image, preprocessors, scales, self._stream.width, self._stream.height
         )
 
         # If orchestrator returns empty list, it indicates no update needed for this frame
@@ -243,7 +240,7 @@ class ControlNetModule(OrchestratorUser):
             # Build current mapping from model_id to index
             current_ids: List[str] = []
             for i, cn in enumerate(self.controlnets):
-                model_id = getattr(cn, 'model_id', f'controlnet_{i}')
+                model_id = getattr(cn, "model_id", f"controlnet_{i}")
                 current_ids.append(model_id)
 
             # Compute new index order
@@ -275,23 +272,29 @@ class ControlNetModule(OrchestratorUser):
         cfg: List[Dict[str, Any]] = []
         with self._collections_lock:
             for i, cn in enumerate(self.controlnets):
-                model_id = getattr(cn, 'model_id', f'controlnet_{i}')
+                model_id = getattr(cn, "model_id", f"controlnet_{i}")
                 scale = self.controlnet_scales[i] if i < len(self.controlnet_scales) else 1.0
-                preproc_params = getattr(self.preprocessors[i], 'params', {}) if i < len(self.preprocessors) and self.preprocessors[i] else {}
-                cfg.append({
-                    'model_id': model_id,
-                    'conditioning_scale': scale,
-                    'preprocessor_params': preproc_params,
-                    'enabled': (self.enabled_list[i] if i < len(self.enabled_list) else True),
-                })
+                preproc_params = (
+                    getattr(self.preprocessors[i], "params", {})
+                    if i < len(self.preprocessors) and self.preprocessors[i]
+                    else {}
+                )
+                cfg.append(
+                    {
+                        "model_id": model_id,
+                        "conditioning_scale": scale,
+                        "preprocessor_params": preproc_params,
+                        "enabled": (self.enabled_list[i] if i < len(self.enabled_list) else True),
+                    }
+                )
         return cfg
 
     def prepare_frame_tensors(self, device: torch.device, dtype: torch.dtype, batch_size: int) -> None:
         """Prepare control image tensors for the current frame.
-        
+
         This method is called once per frame to prepare all control images with the correct
         device, dtype, and batch size. This avoids redundant operations during each denoising step.
-        
+
         Args:
             device: Target device for tensors
             dtype: Target dtype for tensors
@@ -300,22 +303,22 @@ class ControlNetModule(OrchestratorUser):
         with self._collections_lock:
             # Check if we need to re-prepare tensors
             cache_valid = (
-                self._prepared_device == device and
-                self._prepared_dtype == dtype and
-                self._prepared_batch == batch_size and
-                len(self._prepared_tensors) == len(self.controlnet_images)
+                self._prepared_device == device
+                and self._prepared_dtype == dtype
+                and self._prepared_batch == batch_size
+                and len(self._prepared_tensors) == len(self.controlnet_images)
             )
-            
+
             if cache_valid:
                 return
-            
+
             # Prepare tensors for current frame
             self._prepared_tensors = []
             for img in self.controlnet_images:
                 if img is None:
                     self._prepared_tensors.append(None)
                     continue
-                
+
                 # Prepare tensor with correct batch size
                 prepared = img
                 if prepared.dim() == 4 and prepared.shape[0] != batch_size:
@@ -324,63 +327,62 @@ class ControlNetModule(OrchestratorUser):
                     else:
                         repeat_factor = max(1, batch_size // prepared.shape[0])
                         prepared = prepared.repeat(repeat_factor, 1, 1, 1)[:batch_size]
-                
+
                 # Move to correct device and dtype
                 prepared = prepared.to(device=device, dtype=dtype)
                 self._prepared_tensors.append(prepared)
-            
+
             # Update cache state
             self._prepared_device = device
             self._prepared_dtype = dtype
             self._prepared_batch = batch_size
 
-    def _get_cached_sdxl_conditioning(self, ctx: 'StepCtx') -> Optional[Dict[str, torch.Tensor]]:
+    def _get_cached_sdxl_conditioning(self, ctx: "StepCtx") -> Optional[Dict[str, torch.Tensor]]:
         """Get cached SDXL conditioning to avoid repeated preparation"""
         if not self._is_sdxl or ctx.sdxl_cond is None:
             return None
-            
+
         # Check if cache is valid
         if self._sdxl_conditioning_valid and self._sdxl_conditioning_cache is not None:
             cached = self._sdxl_conditioning_cache
             # Verify batch size matches current context
-            if ('text_embeds' in cached and 
-                cached['text_embeds'].shape[0] == ctx.x_t_latent.shape[0]):
+            if "text_embeds" in cached and cached["text_embeds"].shape[0] == ctx.x_t_latent.shape[0]:
                 return cached
-        
+
         # Cache miss or invalid - prepare new conditioning
         try:
             conditioning = {}
-            if 'text_embeds' in ctx.sdxl_cond:
-                text_embeds = ctx.sdxl_cond['text_embeds']
+            if "text_embeds" in ctx.sdxl_cond:
+                text_embeds = ctx.sdxl_cond["text_embeds"]
                 batch_size = ctx.x_t_latent.shape[0]
-                
+
                 # Optimize batch expansion for SDXL text embeddings
                 if text_embeds.shape[0] != batch_size:
                     if text_embeds.shape[0] == 1:
-                        conditioning['text_embeds'] = text_embeds.repeat(batch_size, 1)
+                        conditioning["text_embeds"] = text_embeds.repeat(batch_size, 1)
                     else:
-                        conditioning['text_embeds'] = text_embeds[:batch_size]
+                        conditioning["text_embeds"] = text_embeds[:batch_size]
                 else:
-                    conditioning['text_embeds'] = text_embeds
-            
-            if 'time_ids' in ctx.sdxl_cond:
-                time_ids = ctx.sdxl_cond['time_ids']
+                    conditioning["text_embeds"] = text_embeds
+
+            if "time_ids" in ctx.sdxl_cond:
+                time_ids = ctx.sdxl_cond["time_ids"]
                 batch_size = ctx.x_t_latent.shape[0]
-                
+
                 # Optimize batch expansion for SDXL time IDs
                 if time_ids.shape[0] != batch_size:
                     if time_ids.shape[0] == 1:
-                        conditioning['time_ids'] = time_ids.repeat(batch_size, 1)
+                        conditioning["time_ids"] = time_ids.repeat(batch_size, 1)
                     else:
-                        conditioning['time_ids'] = time_ids[:batch_size]
+                        conditioning["time_ids"] = time_ids[:batch_size]
                 else:
-                    conditioning['time_ids'] = time_ids
-            
+                    conditioning["time_ids"] = time_ids
+
             # Cache the prepared conditioning
             self._sdxl_conditioning_cache = conditioning
             self._sdxl_conditioning_valid = True
             return conditioning
-            
+
         except Exception:
             # Fallback to original conditioning on any error
             return ctx.sdxl_cond
@@ -399,8 +401,10 @@ class ControlNetModule(OrchestratorUser):
                 # Single pass to collect active ControlNet data
                 active_data = []
                 enabled_flags = self.enabled_list if len(self.enabled_list) == len(self.controlnets) else None
-                
-                for i, (cn, img, scale) in enumerate(zip(self.controlnets, self.controlnet_images, self.controlnet_scales)):
+
+                for i, (cn, img, scale) in enumerate(
+                    zip(self.controlnets, self.controlnet_images, self.controlnet_scales)
+                ):
                     if cn is not None and img is not None and scale > 0:
                         enabled = enabled_flags[i] if enabled_flags else True
                         if enabled:
@@ -413,9 +417,11 @@ class ControlNetModule(OrchestratorUser):
             if not self._engines_cache_valid:
                 self._engines_by_id.clear()
                 try:
-                    if hasattr(self._stream, 'controlnet_engines') and isinstance(self._stream.controlnet_engines, list):
+                    if hasattr(self._stream, "controlnet_engines") and isinstance(
+                        self._stream.controlnet_engines, list
+                    ):
                         for eng in self._stream.controlnet_engines:
-                            mid = getattr(eng, 'model_id', None)
+                            mid = getattr(eng, "model_id", None)
                             if mid:
                                 self._engines_by_id[mid] = eng
                     self._engines_cache_valid = True
@@ -425,17 +431,17 @@ class ControlNetModule(OrchestratorUser):
             # Cache SDXL detection to avoid repeated hasattr calls
             if self._is_sdxl is None:
                 try:
-                    self._is_sdxl = getattr(self._stream, 'is_sdxl', False)
+                    self._is_sdxl = getattr(self._stream, "is_sdxl", False)
                 except Exception:
                     self._is_sdxl = False
 
-            encoder_hidden_states = self._stream.prompt_embeds[:, :self._expected_text_len, :]
+            encoder_hidden_states = self._stream.prompt_embeds[:, : self._expected_text_len, :]
 
             base_kwargs: Dict[str, Any] = {
-                'sample': x_t,
-                'timestep': t_list,
-                'encoder_hidden_states': encoder_hidden_states,
-                'return_dict': False,
+                "sample": x_t,
+                "timestep": t_list,
+                "encoder_hidden_states": encoder_hidden_states,
+                "return_dict": False,
             }
 
             down_samples_list: List[List[torch.Tensor]] = []
@@ -443,20 +449,22 @@ class ControlNetModule(OrchestratorUser):
 
             # Ensure tensors are prepared for this frame
             # This should have been called earlier, but we call it here as a safety net
-            if (self._prepared_device != x_t.device or 
-                self._prepared_dtype != x_t.dtype or 
-                self._prepared_batch != x_t.shape[0]):
+            if (
+                self._prepared_device != x_t.device
+                or self._prepared_dtype != x_t.dtype
+                or self._prepared_batch != x_t.shape[0]
+            ):
                 self.prepare_frame_tensors(x_t.device, x_t.dtype, x_t.shape[0])
-            
+
             # Use pre-prepared tensors
             prepared_images = self._prepared_tensors
 
             for cn, img, scale, idx_i in active_data:
                 # Swap to TRT engine if available for this model_id (use cached lookup)
-                model_id = getattr(cn, 'model_id', None)
+                model_id = getattr(cn, "model_id", None)
                 if model_id and model_id in self._engines_by_id:
                     cn = self._engines_by_id[model_id]
-                
+
                 # Use pre-prepared tensor
                 current_img = prepared_images[idx_i] if idx_i < len(prepared_images) else img
                 if current_img is None:
@@ -467,12 +475,12 @@ class ControlNetModule(OrchestratorUser):
                 if cache_key in self._engine_type_cache:
                     is_trt_engine = self._engine_type_cache[cache_key]
                 else:
-                    is_trt_engine = hasattr(cn, 'engine') and hasattr(cn, 'stream')
+                    is_trt_engine = hasattr(cn, "engine") and hasattr(cn, "stream")
                     self._engine_type_cache[cache_key] = is_trt_engine
-                
+
                 # Get optimized SDXL conditioning (uses caching to avoid repeated tensor operations)
                 added_cond_kwargs = self._get_cached_sdxl_conditioning(ctx)
-                
+
                 try:
                     if is_trt_engine:
                         # TensorRT engine path
@@ -483,7 +491,7 @@ class ControlNetModule(OrchestratorUser):
                                 encoder_hidden_states=encoder_hidden_states,
                                 controlnet_cond=current_img,
                                 conditioning_scale=float(scale),
-                                **added_cond_kwargs
+                                **added_cond_kwargs,
                             )
                         else:
                             down_samples, mid_sample = cn(
@@ -491,7 +499,7 @@ class ControlNetModule(OrchestratorUser):
                                 timestep=t_list,
                                 encoder_hidden_states=encoder_hidden_states,
                                 controlnet_cond=current_img,
-                                conditioning_scale=float(scale)
+                                conditioning_scale=float(scale),
                             )
                     else:
                         # PyTorch ControlNet path
@@ -503,7 +511,7 @@ class ControlNetModule(OrchestratorUser):
                                 controlnet_cond=current_img,
                                 conditioning_scale=float(scale),
                                 return_dict=False,
-                                added_cond_kwargs=added_cond_kwargs
+                                added_cond_kwargs=added_cond_kwargs,
                             )
                         else:
                             down_samples, mid_sample = cn(
@@ -512,21 +520,30 @@ class ControlNetModule(OrchestratorUser):
                                 encoder_hidden_states=encoder_hidden_states,
                                 controlnet_cond=current_img,
                                 conditioning_scale=float(scale),
-                                return_dict=False
+                                return_dict=False,
                             )
                 except Exception as e:
                     import traceback
-                    __import__('logging').getLogger(__name__).error("ControlNetModule: controlnet forward failed: %s", e)
+
+                    __import__("logging").getLogger(__name__).error(
+                        "ControlNetModule: controlnet forward failed: %s", e
+                    )
                     try:
-                        __import__('logging').getLogger(__name__).error("ControlNetModule: call_summary: cond_shape=%s, img_shape=%s, scale=%s, is_sdxl=%s, is_trt=%s",
-                                     (tuple(encoder_hidden_states.shape) if isinstance(encoder_hidden_states, torch.Tensor) else None),
-                                     (tuple(current_img.shape) if isinstance(current_img, torch.Tensor) else None),
-                                     scale,
-                                     self._is_sdxl,
-                                     is_trt_engine)
+                        __import__("logging").getLogger(__name__).error(
+                            "ControlNetModule: call_summary: cond_shape=%s, img_shape=%s, scale=%s, is_sdxl=%s, is_trt=%s",
+                            (
+                                tuple(encoder_hidden_states.shape)
+                                if isinstance(encoder_hidden_states, torch.Tensor)
+                                else None
+                            ),
+                            (tuple(current_img.shape) if isinstance(current_img, torch.Tensor) else None),
+                            scale,
+                            self._is_sdxl,
+                            is_trt_engine,
+                        )
                     except Exception:
                         pass
-                    __import__('logging').getLogger(__name__).error(traceback.format_exc())
+                    __import__("logging").getLogger(__name__).error(traceback.format_exc())
                     continue
                 down_samples_list.append(down_samples)
                 mid_samples_list.append(mid_sample)
@@ -555,48 +572,53 @@ class ControlNetModule(OrchestratorUser):
 
         return _unet_hook
 
-    def _prepare_control_image(self, control_image: Union[str, Any, torch.Tensor], preprocessor: Optional[Any]) -> torch.Tensor:
+    def _prepare_control_image(
+        self, control_image: Union[str, Any, torch.Tensor], preprocessor: Optional[Any]
+    ) -> torch.Tensor:
         if self._preprocessing_orchestrator is None:
             raise RuntimeError("ControlNetModule: preprocessing orchestrator is not initialized")
         # Reuse orchestrator API used by BaseControlNetPipeline
         images = self._preprocessing_orchestrator.process_sync(
-            control_image,
-            [preprocessor],
-            [1.0],
-            self._stream.width,
-            self._stream.height,
-            0
+            control_image, [preprocessor], [1.0], self._stream.width, self._stream.height, 0
         )
         # API returns a list; pick first if present
         return images[0] if images else None
 
-    #FIXME: more robust model management is needed in general.
-    def _load_pytorch_controlnet_model(self, model_id: str, conditioning_channels: Optional[int] = None) -> ControlNetModel:
-        from pathlib import Path
-        import logging
+    # FIXME: more robust model management is needed in general.
+    def _load_pytorch_controlnet_model(
+        self, model_id: str, conditioning_channels: Optional[int] = None
+    ) -> ControlNetModel:
         import os
+        from pathlib import Path
+
         logger = logging.getLogger(__name__)
-        
+
         try:
             # Prepare loading kwargs
             load_kwargs = {"torch_dtype": self.dtype}
             if conditioning_channels is not None:
                 load_kwargs["conditioning_channels"] = conditioning_channels
-            
+
             # Check if offline mode is enabled via environment variables
-            is_offline = os.environ.get("HF_HUB_OFFLINE", "0") == "1" or os.environ.get("TRANSFORMERS_OFFLINE", "0") == "1"
-            
+            is_offline = (
+                os.environ.get("HF_HUB_OFFLINE", "0") == "1" or os.environ.get("TRANSFORMERS_OFFLINE", "0") == "1"
+            )
+
             if Path(model_id).exists():
                 model_path = Path(model_id)
-                
+
                 # Check if it's a direct file path to a safetensors/ckpt file
-                if model_path.is_file() and model_path.suffix in ['.safetensors', '.ckpt', '.bin']:
-                    logger.info(f"ControlNetModule._load_pytorch_controlnet_model: Loading ControlNet from single file: {model_path} (channels={conditioning_channels})")
+                if model_path.is_file() and model_path.suffix in [".safetensors", ".ckpt", ".bin"]:
+                    logger.info(
+                        f"ControlNetModule._load_pytorch_controlnet_model: Loading ControlNet from single file: {model_path} (channels={conditioning_channels})"
+                    )
                     # Try loading from single file (works for most ControlNet models)
                     try:
                         controlnet = ControlNetModel.from_single_file(str(model_path), **load_kwargs)
                     except Exception as e:
-                        logger.warning(f"ControlNetModule._load_pytorch_controlnet_model: Single file loading failed: {e}")
+                        logger.warning(
+                            f"ControlNetModule._load_pytorch_controlnet_model: Single file loading failed: {e}"
+                        )
                         # Fallback: try pretrained loading in case it's in a proper directory structure
                         load_kwargs["local_files_only"] = True
                         controlnet = ControlNetModel.from_pretrained(str(model_path.parent), **load_kwargs)
@@ -608,29 +630,27 @@ class ControlNetModule(OrchestratorUser):
                 # Loading from HuggingFace Hub - respect offline mode
                 if is_offline:
                     load_kwargs["local_files_only"] = True
-                    logger.info(f"ControlNetModule._load_pytorch_controlnet_model: Offline mode enabled, loading '{model_id}' from cache only")
-                
+                    logger.info(
+                        f"ControlNetModule._load_pytorch_controlnet_model: Offline mode enabled, loading '{model_id}' from cache only"
+                    )
+
                 if "/" in model_id and model_id.count("/") > 1:
                     parts = model_id.split("/")
                     repo_id = "/".join(parts[:2])
                     subfolder = "/".join(parts[2:])
-                    controlnet = ControlNetModel.from_pretrained(
-                        repo_id, subfolder=subfolder, **load_kwargs
-                    )
+                    controlnet = ControlNetModel.from_pretrained(repo_id, subfolder=subfolder, **load_kwargs)
                 else:
                     controlnet = ControlNetModel.from_pretrained(model_id, **load_kwargs)
             controlnet = controlnet.to(device=self.device, dtype=self.dtype)
             # Track model_id for updater diffing
             try:
-                setattr(controlnet, 'model_id', model_id)
+                setattr(controlnet, "model_id", model_id)
             except Exception:
                 pass
             return controlnet
         except Exception as e:
             import traceback
+
             logger.error(f"ControlNetModule: failed to load model '{model_id}': {e}")
             logger.error(traceback.format_exc())
             raise
-
-
-

--- a/src/streamdiffusion/modules/image_processing_module.py
+++ b/src/streamdiffusion/modules/image_processing_module.py
@@ -1,55 +1,57 @@
-from typing import List, Optional, Any, Dict
+from typing import Any, Dict, List
+
 import torch
 
-from ..preprocessing.orchestrator_user import OrchestratorUser
-from ..preprocessing.pipeline_preprocessing_orchestrator import PipelinePreprocessingOrchestrator
 from ..hooks import ImageCtx, ImageHook
+from ..preprocessing.orchestrator_user import OrchestratorUser
 
 
 class ImageProcessingModule(OrchestratorUser):
     """
     Shared base class for image domain processing modules.
-    
+
     Handles sequential chain execution for both preprocessing and postprocessing
     timing variants. Processing domain is always image tensors.
     """
-    
+
     def __init__(self):
         """Initialize image processing module."""
         self.processors = []
-        
+
     def _process_image_chain(self, input_image: torch.Tensor) -> torch.Tensor:
         """Execute sequential chain of processors in image domain.
-        
+
         Uses the shared orchestrator's sequential chain processing.
         """
         if not self.processors:
             return input_image
-            
+
         ordered_processors = self._get_ordered_processors()
         return self._preprocessing_orchestrator.execute_pipeline_chain(
             input_image, ordered_processors, processing_domain="image"
         )
-    
+
     def add_processor(self, proc_config: Dict[str, Any]) -> None:
         """Add a processor using the existing registry, following ControlNet pattern."""
         from streamdiffusion.preprocessing.processors import get_preprocessor
-        
-        processor_type = proc_config.get('type')
+
+        processor_type = proc_config.get("type")
         if not processor_type:
             raise ValueError("Processor config missing 'type' field")
-        
+
         # Check if processor is enabled (default to True, same as ControlNet)
-        enabled = proc_config.get('enabled', True)
-        
+        enabled = proc_config.get("enabled", True)
+
         # Create processor using existing registry (same as ControlNet)
         # ImageProcessingModule uses 'pipeline' normalization context
-        processor = get_preprocessor(processor_type, pipeline_ref=getattr(self, '_stream', None), normalization_context='pipeline')
-        
+        processor = get_preprocessor(
+            processor_type, pipeline_ref=getattr(self, "_stream", None), normalization_context="pipeline"
+        )
+
         # Apply parameters (same pattern as ControlNet)
-        processor_params = proc_config.get('params', {})
+        processor_params = proc_config.get("params", {})
         if processor_params:
-            if hasattr(processor, 'params') and isinstance(getattr(processor, 'params'), dict):
+            if hasattr(processor, "params") and isinstance(getattr(processor, "params"), dict):
                 processor.params.update(processor_params)
             for name, value in processor_params.items():
                 try:
@@ -57,109 +59,109 @@ class ImageProcessingModule(OrchestratorUser):
                         setattr(processor, name, value)
                 except Exception:
                     pass
-        
+
         # Set order for sequential execution
-        order = proc_config.get('order', len(self.processors))
-        setattr(processor, 'order', order)
-        
+        order = proc_config.get("order", len(self.processors))
+        setattr(processor, "order", order)
+
         # Set enabled state
-        setattr(processor, 'enabled', enabled)
-        
+        setattr(processor, "enabled", enabled)
+
         # Align preprocessor target size with stream resolution (same as ControlNet)
-        if hasattr(self, '_stream'):
+        if hasattr(self, "_stream"):
             try:
-                if hasattr(processor, 'params') and isinstance(getattr(processor, 'params'), dict):
-                    processor.params['image_width'] = int(self._stream.width)
-                    processor.params['image_height'] = int(self._stream.height)
-                if hasattr(processor, 'image_width'):
-                    setattr(processor, 'image_width', int(self._stream.width))
-                if hasattr(processor, 'image_height'):
-                    setattr(processor, 'image_height', int(self._stream.height))
+                if hasattr(processor, "params") and isinstance(getattr(processor, "params"), dict):
+                    processor.params["image_width"] = int(self._stream.width)
+                    processor.params["image_height"] = int(self._stream.height)
+                if hasattr(processor, "image_width"):
+                    setattr(processor, "image_width", int(self._stream.width))
+                if hasattr(processor, "image_height"):
+                    setattr(processor, "image_height", int(self._stream.height))
             except Exception:
                 pass
-        
+
         self.processors.append(processor)
-    
+
     def _get_ordered_processors(self) -> List[Any]:
         """Return enabled processors in execution order based on their order attribute."""
         # Filter for enabled processors first, then sort by order
-        enabled_processors = [p for p in self.processors if getattr(p, 'enabled', True)]
-        return sorted(enabled_processors, key=lambda p: getattr(p, 'order', 0))
+        enabled_processors = [p for p in self.processors if getattr(p, "enabled", True)]
+        return sorted(enabled_processors, key=lambda p: getattr(p, "order", 0))
 
 
 class ImagePreprocessingModule(ImageProcessingModule):
     """
     Image domain preprocessing module - executes before VAE encoding.
-    
+
     Timing: After image_processor.preprocess(), before similar_image_filter
     Uses pipelined processing for performance optimization.
     """
-    
+
     def install(self, stream) -> None:
         """Install module by registering hook with stream and attaching orchestrators."""
         self._stream = stream  # Store stream reference for dimension access
         self.attach_orchestrator(stream)  # For sequential chain processing (fallback)
         self.attach_pipeline_preprocessing_orchestrator(stream)  # For pipelined processing
         stream.image_preprocessing_hooks.append(self.build_image_hook())
-    
+
     def build_image_hook(self) -> ImageHook:
         """Build hook function that processes image context with pipelined processing."""
+
         def hook(ctx: ImageCtx) -> ImageCtx:
             ctx.image = self._process_image_pipelined(ctx.image)
             return ctx
+
         return hook
-    
+
     def _process_image_pipelined(self, input_image: torch.Tensor) -> torch.Tensor:
         """Execute pipelined processing of preprocessors for performance.
-        
+
         Uses PipelinePreprocessingOrchestrator for Frame N-1 results while starting Frame N processing.
         Falls back to synchronous processing when needed.
         """
         if not self.processors:
             return input_image
-        
+
         ordered_processors = self._get_ordered_processors()
-        
+
         # Use pipelined pipeline preprocessing orchestrator for performance
-        return self._pipeline_preprocessing_orchestrator.process_pipelined(
-            input_image, ordered_processors
-        )
+        return self._pipeline_preprocessing_orchestrator.process_pipelined(input_image, ordered_processors)
 
 
 class ImagePostprocessingModule(ImageProcessingModule):
     """
     Image domain postprocessing module - executes after VAE decoding.
-    
+
     Timing: After decode_image(), before returning final output
     Uses pipelined processing for performance optimization.
     """
-    
+
     def install(self, stream) -> None:
         """Install module by registering hook with stream and attaching orchestrators."""
         self._stream = stream  # Store stream reference for dimension access
         self.attach_preprocessing_orchestrator(stream)  # For sequential chain processing (fallback)
         self.attach_postprocessing_orchestrator(stream)  # For pipelined processing
         stream.image_postprocessing_hooks.append(self.build_image_hook())
-    
+
     def build_image_hook(self) -> ImageHook:
         """Build hook function that processes image context with pipelined processing."""
+
         def hook(ctx: ImageCtx) -> ImageCtx:
             ctx.image = self._process_image_pipelined(ctx.image)
             return ctx
+
         return hook
-    
+
     def _process_image_pipelined(self, input_image: torch.Tensor) -> torch.Tensor:
         """Execute pipelined processing of postprocessors for performance.
-        
+
         Uses PostprocessingOrchestrator for Frame N-1 results while starting Frame N processing.
         Falls back to synchronous processing when needed.
         """
         if not self.processors:
             return input_image
-        
+
         ordered_processors = self._get_ordered_processors()
-        
+
         # Use pipelined postprocessing orchestrator for performance
-        return self._postprocessing_orchestrator.process_pipelined(
-            input_image, ordered_processors
-        )
+        return self._postprocessing_orchestrator.process_pipelined(input_image, ordered_processors)

--- a/src/streamdiffusion/modules/ipadapter_module.py
+++ b/src/streamdiffusion/modules/ipadapter_module.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+import logging
+import os
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple, Any
 from enum import Enum
+from typing import Any, Dict, Optional, Tuple
+
 import torch
 
-from streamdiffusion.hooks import EmbedsCtx, EmbeddingHook, StepCtx, UnetKwargsDelta, UnetHook
-import os
+from streamdiffusion.hooks import EmbeddingHook, EmbedsCtx, StepCtx, UnetHook, UnetKwargsDelta
 from streamdiffusion.preprocessing.orchestrator_user import OrchestratorUser
-import logging
 from streamdiffusion.utils.reporting import report_error
+
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +29,7 @@ class IPAdapterConfig:
     This module focuses only on embedding composition (step 2 of migration).
     Runtime installation and wrapper wiring will come in later steps.
     """
+
     style_image_key: Optional[str] = None
     num_image_tokens: int = 4  # e.g., 4 for standard, 16 for plus
     ipadapter_model_path: Optional[str] = None
@@ -59,7 +62,7 @@ IPADAPTER_MODEL_MAP: Dict[tuple, Optional[Dict[str, str]]] = {
         "image_encoder_path": "h94/IP-Adapter/models/image_encoder",
     },
     ("SD2.1", IPAdapterType.REGULAR): None,  # not available from h94 (ip-adapter_sd21.bin was never released)
-    ("SD2.1", IPAdapterType.PLUS): None,    # not available from h94
+    ("SD2.1", IPAdapterType.PLUS): None,  # not available from h94
     ("SD2.1", IPAdapterType.FACEID): None,  # not available from h94
     ("SDXL", IPAdapterType.REGULAR): {
         "model_path": "h94/IP-Adapter/sdxl_models/ip-adapter_sdxl.bin",
@@ -78,15 +81,15 @@ IPADAPTER_MODEL_MAP: Dict[tuple, Optional[Dict[str, str]]] = {
 # Set of all known HF model paths — used to distinguish known vs custom paths.
 # Custom/local paths are never overridden.
 _KNOWN_IPADAPTER_PATHS: frozenset = frozenset(
-    entry["model_path"]
-    for entry in IPADAPTER_MODEL_MAP.values()
-    if entry is not None
+    entry["model_path"] for entry in IPADAPTER_MODEL_MAP.values() if entry is not None
 )
 
-_KNOWN_ENCODER_PATHS: frozenset = frozenset({
-    "h94/IP-Adapter/models/image_encoder",
-    "h94/IP-Adapter/sdxl_models/image_encoder",
-})
+_KNOWN_ENCODER_PATHS: frozenset = frozenset(
+    {
+        "h94/IP-Adapter/models/image_encoder",
+        "h94/IP-Adapter/sdxl_models/image_encoder",
+    }
+)
 
 
 def _normalize_model_type(detected_model_type: str, is_sdxl: bool) -> Optional[str]:
@@ -183,10 +186,7 @@ def resolve_ipadapter_paths(
 
     # Resolve encoder path (only if it's a known HF encoder — custom encoders untouched)
     if current_encoder_path in _KNOWN_ENCODER_PATHS and current_encoder_path != correct_encoder_path:
-        logger.info(
-            f"IP-Adapter: resolving image encoder "
-            f"'{current_encoder_path}' → '{correct_encoder_path}'."
-        )
+        logger.info(f"IP-Adapter: resolving image encoder '{current_encoder_path}' → '{correct_encoder_path}'.")
         cfg["image_encoder_path"] = correct_encoder_path
 
     return cfg
@@ -209,7 +209,9 @@ class IPAdapterModule(OrchestratorUser):
 
         def _embedding_hook(ctx: EmbedsCtx) -> EmbedsCtx:
             # Fetch cached image token embeddings (prompt, negative)
-            cached: Optional[Tuple[torch.Tensor, torch.Tensor]] = stream._param_updater.get_cached_embeddings(style_key)
+            cached: Optional[Tuple[torch.Tensor, torch.Tensor]] = stream._param_updater.get_cached_embeddings(
+                style_key
+            )
             image_prompt_tokens: Optional[torch.Tensor] = None
             image_negative_tokens: Optional[torch.Tensor] = None
             if cached is not None:
@@ -220,7 +222,9 @@ class IPAdapterModule(OrchestratorUser):
             batch_size = ctx.prompt_embeds.shape[0]
             if image_prompt_tokens is None:
                 image_prompt_tokens = torch.zeros(
-                    (batch_size, num_tokens, hidden_dim), dtype=ctx.prompt_embeds.dtype, device=ctx.prompt_embeds.device
+                    (batch_size, num_tokens, hidden_dim),
+                    dtype=ctx.prompt_embeds.dtype,
+                    device=ctx.prompt_embeds.device,
                 )
             else:
                 if image_prompt_tokens.shape[1] != num_tokens:
@@ -242,7 +246,9 @@ class IPAdapterModule(OrchestratorUser):
             if neg_with_image is not None:
                 if image_negative_tokens is None:
                     image_negative_tokens = torch.zeros(
-                        (neg_with_image.shape[0], num_tokens, hidden_dim), dtype=neg_with_image.dtype, device=neg_with_image.device
+                        (neg_with_image.shape[0], num_tokens, hidden_dim),
+                        dtype=neg_with_image.dtype,
+                        device=neg_with_image.device,
                     )
                 else:
                     if image_negative_tokens.shape[0] != neg_with_image.shape[0]:
@@ -291,14 +297,14 @@ class IPAdapterModule(OrchestratorUser):
 
         # Create IP-Adapter and install processors into UNet (FaceID-aware)
         ip_kwargs = {
-            'pipe': stream.pipe,
-            'ipadapter_ckpt_path': resolved_ip_path,
-            'image_encoder_path': resolved_encoder_path,
-            'device': stream.device,
-            'dtype': stream.dtype,
+            "pipe": stream.pipe,
+            "ipadapter_ckpt_path": resolved_ip_path,
+            "image_encoder_path": resolved_encoder_path,
+            "device": stream.device,
+            "dtype": stream.dtype,
         }
         if self.config.type == IPAdapterType.FACEID and self.config.insightface_model_name:
-            ip_kwargs['insightface_model_name'] = self.config.insightface_model_name
+            ip_kwargs["insightface_model_name"] = self.config.insightface_model_name
             print(
                 f"IPAdapterModule.install: Initializing FaceID IP-Adapter with InsightFace model: {self.config.insightface_model_name}"
             )
@@ -311,6 +317,7 @@ class IPAdapterModule(OrchestratorUser):
         # AttnProcessor2_0 which accepts kvo_cache and returns (hidden_states, kvo_cache).
         try:
             from diffusers.models.attention_processor import AttnProcessor2_0 as NativeAttnProcessor2_0
+
             attn_procs = stream.pipe.unet.attn_processors
             for name in attn_procs:
                 if name.endswith("attn1.processor"):
@@ -324,6 +331,7 @@ class IPAdapterModule(OrchestratorUser):
         if self.config.type == IPAdapterType.FACEID:
             try:
                 from streamdiffusion.preprocessing.processors.faceid_embedding import FaceIDEmbeddingPreprocessor
+
                 embedding_preprocessor = FaceIDEmbeddingPreprocessor(
                     ipadapter=ipadapter,
                     device=stream.device,
@@ -357,11 +365,11 @@ class IPAdapterModule(OrchestratorUser):
 
         # Expose IPAdapter instance as single source of truth
         try:
-            setattr(stream, 'ipadapter', ipadapter)
+            setattr(stream, "ipadapter", ipadapter)
             # Extend IPAdapter with our custom attributes since diffusers IPAdapter doesn't expose current state
-            setattr(ipadapter, 'weight_type', self.config.weight_type)  # For build_layer_weights
-            setattr(ipadapter, 'scale', float(self.config.scale))       # Track current scale
-            setattr(ipadapter, 'enabled', bool(self.config.enabled))    # Track enabled state
+            setattr(ipadapter, "weight_type", self.config.weight_type)  # For build_layer_weights
+            setattr(ipadapter, "scale", float(self.config.scale))  # Track current scale
+            setattr(ipadapter, "enabled", bool(self.config.enabled))  # Track enabled state
         except Exception:
             pass
 
@@ -389,7 +397,10 @@ class IPAdapterModule(OrchestratorUser):
             from huggingface_hub import hf_hub_download, snapshot_download
         except Exception as e:
             import logging
-            logging.getLogger(__name__).error(f"IPAdapterModule: huggingface_hub required to resolve '{model_path}': {e}")
+
+            logging.getLogger(__name__).error(
+                f"IPAdapterModule: huggingface_hub required to resolve '{model_path}': {e}"
+            )
             raise
 
         parts = model_path.split("/")
@@ -419,28 +430,28 @@ class IPAdapterModule(OrchestratorUser):
         - For PyTorch UNet with installed IP processors, modulate per-layer processor scale by time factor
         """
         _last_enabled_state = None  # Track previous enabled state to avoid redundant updates
-        
+
         def _unet_hook(ctx: StepCtx) -> UnetKwargsDelta:
             # If no IP-Adapter installed, do nothing
-            if not hasattr(stream, 'ipadapter') or stream.ipadapter is None:
+            if not hasattr(stream, "ipadapter") or stream.ipadapter is None:
                 return UnetKwargsDelta()
 
             # Check if IPAdapter is enabled
-            enabled = getattr(stream.ipadapter, 'enabled', True)
+            enabled = getattr(stream.ipadapter, "enabled", True)
 
             # Read base weight and weight type from IPAdapter instance
             try:
-                base_weight = float(getattr(stream.ipadapter, 'scale', 1.0)) if enabled else 0.0
+                base_weight = float(getattr(stream.ipadapter, "scale", 1.0)) if enabled else 0.0
             except Exception:
                 base_weight = 0.0 if not enabled else 1.0
-            weight_type = getattr(stream.ipadapter, 'weight_type', None)
+            weight_type = getattr(stream.ipadapter, "weight_type", None)
 
             # Determine total steps and current step index for time scheduling
             total_steps = None
             try:
-                if hasattr(stream, 'denoising_steps_num') and isinstance(stream.denoising_steps_num, int):
+                if hasattr(stream, "denoising_steps_num") and isinstance(stream.denoising_steps_num, int):
                     total_steps = int(stream.denoising_steps_num)
-                elif hasattr(stream, 't_list') and stream.t_list is not None:
+                elif hasattr(stream, "t_list") and stream.t_list is not None:
                     total_steps = len(stream.t_list)
             except Exception:
                 total_steps = None
@@ -449,6 +460,7 @@ class IPAdapterModule(OrchestratorUser):
             if total_steps is not None and ctx.step_index is not None:
                 try:
                     from diffusers_ipadapter.ip_adapter.attention_processor import build_time_weight_factor
+
                     time_factor = float(build_time_weight_factor(weight_type, int(ctx.step_index), int(total_steps)))
                 except Exception:
                     # Do not add fallback mechanisms
@@ -456,18 +468,20 @@ class IPAdapterModule(OrchestratorUser):
 
             # TensorRT engine path: supply ipadapter_scale vector via extra kwargs
             try:
-                is_trt_unet = hasattr(stream, 'unet') and hasattr(stream.unet, 'engine') and hasattr(stream.unet, 'stream')
+                is_trt_unet = (
+                    hasattr(stream, "unet") and hasattr(stream.unet, "engine") and hasattr(stream.unet, "stream")
+                )
             except Exception:
                 is_trt_unet = False
 
-            if is_trt_unet and getattr(stream.unet, 'use_ipadapter', False):
+            if is_trt_unet and getattr(stream.unet, "use_ipadapter", False):
                 try:
                     from diffusers_ipadapter.ip_adapter.attention_processor import build_layer_weights
                 except Exception:
                     # If helper unavailable, do not construct weights here
                     build_layer_weights = None  # type: ignore
 
-                num_ip_layers = getattr(stream.unet, 'num_ip_layers', None)
+                num_ip_layers = getattr(stream.unet, "num_ip_layers", None)
                 if isinstance(num_ip_layers, int) and num_ip_layers > 0:
                     weights_tensor = None
                     try:
@@ -476,24 +490,26 @@ class IPAdapterModule(OrchestratorUser):
                     except Exception:
                         weights_tensor = None
                     if weights_tensor is None:
-                        weights_tensor = torch.full((num_ip_layers,), float(base_weight), dtype=torch.float32, device=stream.device)
+                        weights_tensor = torch.full(
+                            (num_ip_layers,), float(base_weight), dtype=torch.float32, device=stream.device
+                        )
                     # Apply per-step time factor
                     try:
                         weights_tensor = weights_tensor * float(time_factor)
                     except Exception:
                         pass
-                    return UnetKwargsDelta(extra_unet_kwargs={'ipadapter_scale': weights_tensor})
+                    return UnetKwargsDelta(extra_unet_kwargs={"ipadapter_scale": weights_tensor})
 
             # PyTorch UNet path: modulate installed processor scales by time factor and enabled state
             try:
                 nonlocal _last_enabled_state
                 # Only process if we need to make changes (time scaling or state transition)
-                needs_update = (time_factor != 1.0 or enabled != _last_enabled_state)
-                if needs_update and hasattr(stream.pipe, 'unet') and hasattr(stream.pipe.unet, 'attn_processors'):
+                needs_update = time_factor != 1.0 or enabled != _last_enabled_state
+                if needs_update and hasattr(stream.pipe, "unet") and hasattr(stream.pipe.unet, "attn_processors"):
                     _last_enabled_state = enabled
                     for proc in stream.pipe.unet.attn_processors.values():
-                        if hasattr(proc, 'scale') and hasattr(proc, '_ip_layer_index'):
-                            base_val = getattr(proc, '_base_scale', proc.scale)
+                        if hasattr(proc, "scale") and hasattr(proc, "_ip_layer_index"):
+                            base_val = getattr(proc, "_base_scale", proc.scale)
                             # Apply both enabled state and time factor
                             final_scale = float(base_val) * float(time_factor) if enabled else 0.0
                             proc.scale = final_scale
@@ -503,4 +519,3 @@ class IPAdapterModule(OrchestratorUser):
             return UnetKwargsDelta()
 
         return _unet_hook
-

--- a/src/streamdiffusion/modules/ipadapter_module.py
+++ b/src/streamdiffusion/modules/ipadapter_module.py
@@ -58,10 +58,7 @@ IPADAPTER_MODEL_MAP: Dict[tuple, Optional[Dict[str, str]]] = {
         "model_path": "h94/IP-Adapter-FaceID/ip-adapter-faceid_sd15.bin",
         "image_encoder_path": "h94/IP-Adapter/models/image_encoder",
     },
-    ("SD2.1", IPAdapterType.REGULAR): {
-        "model_path": "h94/IP-Adapter/models/ip-adapter_sd21.bin",
-        "image_encoder_path": "h94/IP-Adapter/models/image_encoder",
-    },
+    ("SD2.1", IPAdapterType.REGULAR): None,  # not available from h94 (ip-adapter_sd21.bin was never released)
     ("SD2.1", IPAdapterType.PLUS): None,    # not available from h94
     ("SD2.1", IPAdapterType.FACEID): None,  # not available from h94
     ("SDXL", IPAdapterType.REGULAR): {
@@ -162,7 +159,12 @@ def resolve_ipadapter_paths(
         target_entry = IPADAPTER_MODEL_MAP.get((norm_type, adapter_type))
 
     if target_entry is None:
-        logger.error(f"IP-Adapter: no mapping found for ({norm_type}, {adapter_type}) — leaving config unchanged.")
+        logger.warning(
+            f"IP-Adapter: no compatible adapter exists for {detected_model_type} "
+            f"(type='{adapter_type.value}'). No IP-Adapter was released for this architecture. "
+            f"IP-Adapter will be disabled for this model."
+        )
+        cfg["enabled"] = False
         return cfg
 
     correct_model_path = target_entry["model_path"]

--- a/src/streamdiffusion/modules/ipadapter_module.py
+++ b/src/streamdiffusion/modules/ipadapter_module.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Tuple, Any
+from typing import Dict, Optional, Tuple, Any
 from enum import Enum
 import torch
 
@@ -38,6 +38,156 @@ class IPAdapterConfig:
 
     type: IPAdapterType = IPAdapterType.REGULAR
     insightface_model_name: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# IP-Adapter model path mapping by base model architecture and adapter type
+# ---------------------------------------------------------------------------
+# None means the variant is unavailable for that architecture — callers fall
+# back to REGULAR automatically.
+IPADAPTER_MODEL_MAP: Dict[tuple, Optional[Dict[str, str]]] = {
+    ("SD1.5", IPAdapterType.REGULAR): {
+        "model_path": "h94/IP-Adapter/models/ip-adapter_sd15.bin",
+        "image_encoder_path": "h94/IP-Adapter/models/image_encoder",
+    },
+    ("SD1.5", IPAdapterType.PLUS): {
+        "model_path": "h94/IP-Adapter/models/ip-adapter-plus_sd15.safetensors",
+        "image_encoder_path": "h94/IP-Adapter/models/image_encoder",
+    },
+    ("SD1.5", IPAdapterType.FACEID): {
+        "model_path": "h94/IP-Adapter-FaceID/ip-adapter-faceid_sd15.bin",
+        "image_encoder_path": "h94/IP-Adapter/models/image_encoder",
+    },
+    ("SD2.1", IPAdapterType.REGULAR): {
+        "model_path": "h94/IP-Adapter/models/ip-adapter_sd21.bin",
+        "image_encoder_path": "h94/IP-Adapter/models/image_encoder",
+    },
+    ("SD2.1", IPAdapterType.PLUS): None,    # not available from h94
+    ("SD2.1", IPAdapterType.FACEID): None,  # not available from h94
+    ("SDXL", IPAdapterType.REGULAR): {
+        "model_path": "h94/IP-Adapter/sdxl_models/ip-adapter_sdxl.bin",
+        "image_encoder_path": "h94/IP-Adapter/sdxl_models/image_encoder",
+    },
+    ("SDXL", IPAdapterType.PLUS): {
+        "model_path": "h94/IP-Adapter/sdxl_models/ip-adapter-plus_sdxl_vit-h.safetensors",
+        "image_encoder_path": "h94/IP-Adapter/sdxl_models/image_encoder",
+    },
+    ("SDXL", IPAdapterType.FACEID): {
+        "model_path": "h94/IP-Adapter-FaceID/ip-adapter-faceid_sdxl.bin",
+        "image_encoder_path": "h94/IP-Adapter/sdxl_models/image_encoder",
+    },
+}
+
+# Set of all known HF model paths — used to distinguish known vs custom paths.
+# Custom/local paths are never overridden.
+_KNOWN_IPADAPTER_PATHS: frozenset = frozenset(
+    entry["model_path"]
+    for entry in IPADAPTER_MODEL_MAP.values()
+    if entry is not None
+)
+
+_KNOWN_ENCODER_PATHS: frozenset = frozenset({
+    "h94/IP-Adapter/models/image_encoder",
+    "h94/IP-Adapter/sdxl_models/image_encoder",
+})
+
+
+def _normalize_model_type(detected_model_type: str, is_sdxl: bool) -> Optional[str]:
+    """Map model detection strings to IPADAPTER_MODEL_MAP keys."""
+    if is_sdxl:
+        return "SDXL"
+    return {
+        "SD1.5": "SD1.5",
+        "SD15": "SD1.5",
+        "SD2.1": "SD2.1",
+        "SD21": "SD2.1",
+        "SDXL": "SDXL",
+    }.get(detected_model_type)
+
+
+def resolve_ipadapter_paths(
+    cfg: Dict[str, Any],
+    detected_model_type: str,
+    is_sdxl: bool,
+) -> Dict[str, Any]:
+    """Validate and auto-resolve IP-Adapter model/encoder paths for the detected base model.
+
+    Mutates *cfg* in-place and returns it. Custom/local paths are never overridden.
+
+    Args:
+        cfg: Single IP-Adapter config dict (keys: ipadapter_model_path, image_encoder_path, type, ...).
+        detected_model_type: Value from detect_model() e.g. "SD1.5", "SD2.1", "SDXL".
+        is_sdxl: Whether the base model is SDXL-family (takes precedence over detected_model_type).
+
+    Returns:
+        The (potentially mutated) cfg dict.
+    """
+    current_model_path = cfg.get("ipadapter_model_path") or ""
+    current_encoder_path = cfg.get("image_encoder_path") or ""
+
+    # Parse adapter type, default to REGULAR
+    try:
+        adapter_type = IPAdapterType(cfg.get("type", "regular"))
+    except ValueError:
+        adapter_type = IPAdapterType.REGULAR
+
+    # Normalize to map key; unknown types are left unchanged
+    norm_type = _normalize_model_type(detected_model_type, is_sdxl)
+    if norm_type is None:
+        logger.warning(
+            f"IP-Adapter auto-resolution: unknown model type '{detected_model_type}' — "
+            f"cannot validate compatibility. Ensure ipadapter_model_path is correct for this model."
+        )
+        return cfg
+
+    # Custom/local path — respect it, only log info
+    if current_model_path and current_model_path not in _KNOWN_IPADAPTER_PATHS:
+        logger.info(
+            f"IP-Adapter: custom model path '{current_model_path}' — "
+            f"skipping auto-resolution (manual compatibility check required for {detected_model_type})."
+        )
+        return cfg
+
+    # Look up the correct entry for this architecture + type
+    target_entry = IPADAPTER_MODEL_MAP.get((norm_type, adapter_type))
+
+    # Variant unavailable for this architecture — fall back to REGULAR with warning
+    if target_entry is None:
+        logger.warning(
+            f"IP-Adapter type '{adapter_type.value}' is not available for {detected_model_type}. "
+            f"Falling back to 'regular' adapter type."
+        )
+        adapter_type = IPAdapterType.REGULAR
+        cfg["type"] = adapter_type.value
+        target_entry = IPADAPTER_MODEL_MAP.get((norm_type, adapter_type))
+
+    if target_entry is None:
+        logger.error(f"IP-Adapter: no mapping found for ({norm_type}, {adapter_type}) — leaving config unchanged.")
+        return cfg
+
+    correct_model_path = target_entry["model_path"]
+    correct_encoder_path = target_entry["image_encoder_path"]
+
+    # Resolve model path
+    if current_model_path != correct_model_path:
+        logger.warning(
+            f"IP-Adapter auto-resolution: '{current_model_path}' is incompatible with "
+            f"{detected_model_type} (cross_attention_dim mismatch). "
+            f"Resolving to '{correct_model_path}'."
+        )
+        cfg["ipadapter_model_path"] = correct_model_path
+    else:
+        logger.info(f"IP-Adapter: '{current_model_path}' is compatible with {detected_model_type}.")
+
+    # Resolve encoder path (only if it's a known HF encoder — custom encoders untouched)
+    if current_encoder_path in _KNOWN_ENCODER_PATHS and current_encoder_path != correct_encoder_path:
+        logger.info(
+            f"IP-Adapter: resolving image encoder "
+            f"'{current_encoder_path}' → '{correct_encoder_path}'."
+        )
+        cfg["image_encoder_path"] = correct_encoder_path
+
+    return cfg
 
 
 class IPAdapterModule(OrchestratorUser):

--- a/src/streamdiffusion/modules/latent_processing_module.py
+++ b/src/streamdiffusion/modules/latent_processing_module.py
@@ -1,54 +1,55 @@
-from typing import List, Optional, Any, Dict
+from typing import Any, Dict, List
+
 import torch
 
-from ..preprocessing.orchestrator_user import OrchestratorUser
 from ..hooks import LatentCtx, LatentHook
+from ..preprocessing.orchestrator_user import OrchestratorUser
 
 
 class LatentProcessingModule(OrchestratorUser):
     """
     Shared base class for latent domain processing modules.
-    
+
     Handles sequential chain execution for both preprocessing and postprocessing
     timing variants. Processing domain is always latent tensors.
     """
-    
+
     def __init__(self):
         """Initialize latent processing module."""
         self.processors = []
-        
+
     def _process_latent_chain(self, input_latent: torch.Tensor) -> torch.Tensor:
         """Execute sequential chain of processors in latent domain.
-        
+
         Uses the shared orchestrator's sequential chain processing.
         """
         if not self.processors:
             return input_latent
-            
+
         ordered_processors = self._get_ordered_processors()
         return self._preprocessing_orchestrator.execute_pipeline_chain(
             input_latent, ordered_processors, processing_domain="latent"
         )
-    
+
     def add_processor(self, proc_config: Dict[str, Any]) -> None:
         """Add a processor using the existing registry, following ControlNet pattern."""
         from streamdiffusion.preprocessing.processors import get_preprocessor
-        
-        processor_type = proc_config.get('type')
+
+        processor_type = proc_config.get("type")
         if not processor_type:
             raise ValueError("Processor config missing 'type' field")
-        
+
         # Check if processor is enabled (default to True, same as ControlNet)
-        enabled = proc_config.get('enabled', True)
-        
+        enabled = proc_config.get("enabled", True)
+
         # Create processor using existing registry (same as ControlNet)
         # LatentProcessingModule uses 'latent' normalization context (works in latent space)
-        processor = get_preprocessor(processor_type, pipeline_ref=self._stream, normalization_context='latent')
-        
+        processor = get_preprocessor(processor_type, pipeline_ref=self._stream, normalization_context="latent")
+
         # Apply parameters (same pattern as ControlNet)
-        processor_params = proc_config.get('params', {})
+        processor_params = proc_config.get("params", {})
         if processor_params:
-            if hasattr(processor, 'params') and isinstance(getattr(processor, 'params'), dict):
+            if hasattr(processor, "params") and isinstance(getattr(processor, "params"), dict):
                 processor.params.update(processor_params)
             for name, value in processor_params.items():
                 try:
@@ -56,62 +57,66 @@ class LatentProcessingModule(OrchestratorUser):
                         setattr(processor, name, value)
                 except Exception:
                     pass
-        
+
         # Set order for sequential execution
-        order = proc_config.get('order', len(self.processors))
-        setattr(processor, 'order', order)
-        
+        order = proc_config.get("order", len(self.processors))
+        setattr(processor, "order", order)
+
         # Set enabled state
-        setattr(processor, 'enabled', enabled)
-        
+        setattr(processor, "enabled", enabled)
+
         # Pipeline reference is now automatically handled by the factory function
-        
+
         self.processors.append(processor)
-    
+
     def _get_ordered_processors(self) -> List[Any]:
         """Return enabled processors in execution order based on their order attribute."""
         # Filter for enabled processors first, then sort by order
-        enabled_processors = [p for p in self.processors if getattr(p, 'enabled', True)]
-        return sorted(enabled_processors, key=lambda p: getattr(p, 'order', 0))
+        enabled_processors = [p for p in self.processors if getattr(p, "enabled", True)]
+        return sorted(enabled_processors, key=lambda p: getattr(p, "order", 0))
 
 
 class LatentPreprocessingModule(LatentProcessingModule):
     """
     Latent domain preprocessing module - executes after VAE encoding, before diffusion.
-    
+
     Timing: After encode_image(), before predict_x0_batch()
     """
-    
+
     def install(self, stream) -> None:
         """Install module by registering hook with stream and attaching orchestrator."""
         self.attach_orchestrator(stream)
         self._stream = stream  # Store stream reference like ControlNet module does
         stream.latent_preprocessing_hooks.append(self.build_latent_hook())
-    
+
     def build_latent_hook(self) -> LatentHook:
         """Build hook function that processes latent context."""
+
         def hook(ctx: LatentCtx) -> LatentCtx:
             ctx.latent = self._process_latent_chain(ctx.latent)
             return ctx
+
         return hook
 
 
 class LatentPostprocessingModule(LatentProcessingModule):
     """
     Latent domain postprocessing module - executes after diffusion, before VAE decoding.
-    
+
     Timing: After predict_x0_batch(), before decode_image()
     """
-    
+
     def install(self, stream) -> None:
         """Install module by registering hook with stream and attaching orchestrator."""
         self.attach_orchestrator(stream)
         self._stream = stream  # Store stream reference like ControlNet module does
         stream.latent_postprocessing_hooks.append(self.build_latent_hook())
-    
+
     def build_latent_hook(self) -> LatentHook:
         """Build hook function that processes latent context."""
+
         def hook(ctx: LatentCtx) -> LatentCtx:
             ctx.latent = self._process_latent_chain(ctx.latent)
             return ctx
+
         return hook

--- a/src/streamdiffusion/pip_utils.py
+++ b/src/streamdiffusion/pip_utils.py
@@ -17,7 +17,6 @@ uv = shutil.which("uv")
 def _check_torch_installed():
     try:
         import torch
-        import torchvision  # type: ignore
     except Exception:
         msg = (
             "Missing required pre-installed packages: torch, torchvision\n"
@@ -28,13 +27,16 @@ def _check_torch_installed():
         raise RuntimeError(msg)
 
     if not torch.version.cuda:
-        raise RuntimeError("Detected CPU-only PyTorch. Install CUDA-enabled torch/vision/audio before installing this package.")
+        raise RuntimeError(
+            "Detected CPU-only PyTorch. Install CUDA-enabled torch/vision/audio before installing this package."
+        )
 
 
 def get_cuda_version() -> str | None:
     _check_torch_installed()
 
     import torch
+
     return torch.version.cuda
 
 
@@ -67,7 +69,7 @@ def is_installed(package: str) -> bool:
 
 def run_python(command: str, env: Dict[str, str] | None = None) -> str:
     run_kwargs = {
-        "args": f"\"{python}\" {command}",
+        "args": f'"{python}" {command}',
         "shell": True,
         "env": os.environ if env is None else env,
         "encoding": "utf8",

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -110,6 +110,13 @@ class StreamDiffusion:
         self._noise_buf = None  # pre-allocated buffer for per-step noise in TCD non-batched path
         self._image_decode_buf = None  # pre-allocated buffer for VAE decode output (avoids .clone())
         self._prev_image_buf = None  # pre-allocated buffer for skip-frame image cache
+        self._combined_latent_buf = None  # pre-allocated: avoids torch.cat in predict_x0_batch
+        self._alpha_next = None  # pre-computed: cat([alpha_prod_t_sqrt[1:], ones[0:1]])
+        self._beta_next = None   # pre-computed: cat([beta_prod_t_sqrt[1:], ones[0:1]])
+        self._init_noise_rotated = None  # pre-computed: cat([init_noise[1:], init_noise[0:1]])
+        self._unet_kwargs: dict = {"return_dict": False}  # pre-allocated: avoids per-frame dict creation
+        self._cfg_latent_buf = None  # pre-allocated: avoids torch.concat for CFG latent doubling
+        self._cfg_t_buf = None       # pre-allocated: avoids torch.concat for CFG timestep doubling
 
         self.pipe = pipe
         self.image_processor = VaeImageProcessor(pipe.vae_scale_factor)
@@ -531,6 +538,46 @@ class StreamDiffusion:
         self.c_skip = self.c_skip.to(self.device)
         self.c_out = self.c_out.to(self.device)
 
+        # Pre-compute shifted alpha/beta/init_noise (eliminates 5 mallocs + 8 kernel launches per frame)
+        if self.use_denoising_batch and (self.cfg_type == "self" or self.cfg_type == "initialize"):
+            self._alpha_next = torch.cat(
+                [self.alpha_prod_t_sqrt[1:], torch.ones_like(self.alpha_prod_t_sqrt[0:1])], dim=0
+            )
+            self._beta_next = torch.cat(
+                [self.beta_prod_t_sqrt[1:], torch.ones_like(self.beta_prod_t_sqrt[0:1])], dim=0
+            )
+            self._init_noise_rotated = torch.cat([self.init_noise[1:], self.init_noise[0:1]], dim=0)
+        else:
+            self._alpha_next = None
+            self._beta_next = None
+            self._init_noise_rotated = None
+
+        # Pre-allocate combined latent buffer (eliminates 1 malloc + copy kernel per frame)
+        if self.denoising_steps_num > 1:
+            self._combined_latent_buf = torch.empty(
+                (self.batch_size, 4, self.latent_height, self.latent_width),
+                dtype=self.dtype,
+                device=self.device,
+            )
+        else:
+            self._combined_latent_buf = None
+
+        # Pre-allocate CFG expansion buffers (eliminates torch.concat mallocs for latent/timestep doubling)
+        if self.guidance_scale > 1.0 and (self.cfg_type == "initialize" or self.cfg_type == "full"):
+            cfg_batch = (1 + self.batch_size) if self.cfg_type == "initialize" else (2 * self.batch_size)
+            self._cfg_latent_buf = torch.empty(
+                (cfg_batch, 4, self.latent_height, self.latent_width),
+                dtype=self.dtype,
+                device=self.device,
+            )
+            self._cfg_t_buf = torch.empty(cfg_batch, dtype=self.sub_timesteps_tensor.dtype, device=self.device)
+        else:
+            self._cfg_latent_buf = None
+            self._cfg_t_buf = None
+
+        # Seed _unet_kwargs with the constant key so per-frame code only updates values
+        self._unet_kwargs = {"return_dict": False}
+
     def _get_scheduler_scalings(self, timestep):
         """Get LCM/TCD-specific scaling factors for boundary conditions."""
         if isinstance(self.scheduler, LCMScheduler):
@@ -620,21 +667,28 @@ class StreamDiffusion:
         idx: Optional[int] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if self.guidance_scale > 1.0 and (self.cfg_type == "initialize"):
-            x_t_latent_plus_uc = torch.concat([x_t_latent[0:1], x_t_latent], dim=0)
-            t_list = torch.concat([t_list[0:1], t_list], dim=0)
+            # Pre-allocated buf avoids torch.concat malloc for CFG latent doubling
+            self._cfg_latent_buf[:1].copy_(x_t_latent[0:1])
+            self._cfg_latent_buf[1:].copy_(x_t_latent)
+            x_t_latent_plus_uc = self._cfg_latent_buf
+            self._cfg_t_buf[:1].copy_(t_list[0:1])
+            self._cfg_t_buf[1:].copy_(t_list)
+            t_list = self._cfg_t_buf
         elif self.guidance_scale > 1.0 and (self.cfg_type == "full"):
-            x_t_latent_plus_uc = torch.concat([x_t_latent, x_t_latent], dim=0)
-            t_list = torch.concat([t_list, t_list], dim=0)
+            self._cfg_latent_buf[:len(x_t_latent)].copy_(x_t_latent)
+            self._cfg_latent_buf[len(x_t_latent):].copy_(x_t_latent)
+            x_t_latent_plus_uc = self._cfg_latent_buf
+            self._cfg_t_buf[:len(t_list)].copy_(t_list)
+            self._cfg_t_buf[len(t_list):].copy_(t_list)
+            t_list = self._cfg_t_buf
         else:
             x_t_latent_plus_uc = x_t_latent
 
-        # Prepare UNet call arguments
-        unet_kwargs = {
-            "sample": x_t_latent_plus_uc,
-            "timestep": t_list,
-            "encoder_hidden_states": self.prompt_embeds,
-            "return_dict": False,
-        }
+        # Prepare UNet call arguments (update pre-allocated dict in-place: avoids per-frame dict malloc)
+        self._unet_kwargs["sample"] = x_t_latent_plus_uc
+        self._unet_kwargs["timestep"] = t_list
+        self._unet_kwargs["encoder_hidden_states"] = self.prompt_embeds
+        unet_kwargs = self._unet_kwargs
 
         # Add SDXL-specific conditioning if this is an SDXL model
         if self.is_sdxl and hasattr(self, "add_text_embeds") and hasattr(self, "add_time_ids"):
@@ -784,9 +838,7 @@ class StreamDiffusion:
 
         if self.guidance_scale > 1.0 and (self.cfg_type == "initialize"):
             noise_pred_text = model_pred[1:]
-            self.stock_noise = torch.concat(
-                [model_pred[0:1], self.stock_noise[1:]], dim=0
-            )  # ここコメントアウトでself out cfg
+            self.stock_noise[0:1].copy_(model_pred[0:1])  # in-place: eliminates 1 malloc + copy kernel
         elif self.guidance_scale > 1.0 and (self.cfg_type == "full"):
             noise_pred_uncond, noise_pred_text = model_pred.chunk(2)
         else:
@@ -807,24 +859,9 @@ class StreamDiffusion:
             if self.cfg_type == "self" or self.cfg_type == "initialize":
                 scaled_noise = self.beta_prod_t_sqrt * self.stock_noise
                 delta_x = self.scheduler_step_batch(model_pred, scaled_noise, idx)
-                alpha_next = torch.concat(
-                    [
-                        self.alpha_prod_t_sqrt[1:],
-                        torch.ones_like(self.alpha_prod_t_sqrt[0:1]),
-                    ],
-                    dim=0,
-                )
-                delta_x = alpha_next * delta_x
-                beta_next = torch.concat(
-                    [
-                        self.beta_prod_t_sqrt[1:],
-                        torch.ones_like(self.beta_prod_t_sqrt[0:1]),
-                    ],
-                    dim=0,
-                )
-                delta_x = delta_x / beta_next
-                init_noise = torch.concat([self.init_noise[1:], self.init_noise[0:1]], dim=0)
-                self.stock_noise = init_noise + delta_x
+                delta_x = self._alpha_next * delta_x
+                delta_x = delta_x / self._beta_next
+                self.stock_noise = self._init_noise_rotated + delta_x
 
         else:
             # denoised_batch = self.scheduler.step(model_pred, t_list[0], x_t_latent).denoised
@@ -842,8 +879,10 @@ class StreamDiffusion:
 
         # Circular buffer: overwrite the oldest slot without shifting or cloning.
         # The attention processor reads all slots as an unordered K/V bag, so slot order is irrelevant.
+        # Use self.cache_maxframes (not tensor shape) so that when the buffer is allocated at
+        # max_cache_maxframes but the logical window is smaller, writes stay within the active range.
         for i, new_kv in enumerate(kvo_cache_out):
-            cache_size = self.kvo_cache[i].shape[1]
+            cache_size = self.cache_maxframes
             write_slot = (self.frame_idx // self.cache_interval - 1) % cache_size
             self.kvo_cache[i][:, write_slot].copy_(new_kv.squeeze(1))
 
@@ -875,7 +914,10 @@ class StreamDiffusion:
         if self.use_denoising_batch and isinstance(self.scheduler, LCMScheduler):
             t_list = self.sub_timesteps_tensor
             if self.denoising_steps_num > 1:
-                x_t_latent = torch.cat((x_t_latent, prev_latent_batch), dim=0)
+                # Copy into pre-allocated buffer: eliminates 1 malloc + copy kernel vs torch.cat
+                self._combined_latent_buf[:self.frame_bff_size].copy_(x_t_latent)
+                self._combined_latent_buf[self.frame_bff_size:].copy_(prev_latent_batch)
+                x_t_latent = self._combined_latent_buf
                 self.stock_noise = torch.cat((self.init_noise[0:1], self.stock_noise[:-1]), dim=0)
             x_0_pred_batch, model_pred = self.unet_step(x_t_latent, t_list)
 

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -1005,7 +1005,7 @@ class StreamDiffusion:
         self.prev_latent_result = x_0_pred_out.clone()
 
         
-        x_output = self.decode_image(x_0_pred_out)
+        x_output = self.decode_image(x_0_pred_out).clone()
 
         # IMAGE POSTPROCESSING HOOKS: After VAE decoding, before final output
         x_output = self._apply_image_postprocessing_hooks(x_output)
@@ -1098,7 +1098,7 @@ class StreamDiffusion:
         self.prev_latent_result = x_0_pred_out.clone()
 
         
-        x_output = self.decode_image(x_0_pred_out)
+        x_output = self.decode_image(x_0_pred_out).clone()
 
         # IMAGE POSTPROCESSING HOOKS: After VAE decoding, before final output
         x_output = self._apply_image_postprocessing_hooks(x_output)

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -102,6 +102,8 @@ class StreamDiffusion:
         self.similar_filter = SimilarImageFilter()
         self.prev_image_result = None
         self.prev_latent_result = None
+        self._latent_cache = None   # pre-allocated buffer; avoids per-frame CUDA malloc for prev_latent_result
+        self._noise_buf = None      # pre-allocated buffer for per-step noise in TCD non-batched path
 
         self.pipe = pipe
         self.image_processor = VaeImageProcessor(pipe.vae_scale_factor)
@@ -949,12 +951,12 @@ class StreamDiffusion:
                     x_0_pred, model_pred = self.unet_step(sample, t, idx)
                     if idx < len(self.sub_timesteps_tensor) - 1:
                         if self.do_add_noise:
-                            sample = self.alpha_prod_t_sqrt[
-                                idx + 1
-                            ] * x_0_pred + self.beta_prod_t_sqrt[
-                                idx + 1
-                            ] * torch.randn_like(
-                                x_0_pred, device=self.device, dtype=self.dtype
+                            if self._noise_buf is None:
+                                self._noise_buf = torch.empty_like(x_0_pred)
+                            self._noise_buf.normal_()
+                            sample = (
+                                self.alpha_prod_t_sqrt[idx + 1] * x_0_pred
+                                + self.beta_prod_t_sqrt[idx + 1] * self._noise_buf
                             )
                         else:
                             sample = self.alpha_prod_t_sqrt[idx + 1] * x_0_pred
@@ -1001,10 +1003,12 @@ class StreamDiffusion:
         # LATENT POSTPROCESSING HOOKS: After diffusion, before VAE decoding
         x_0_pred_out = self._apply_latent_postprocessing_hooks(x_0_pred_out)
         
-        # Store latent result for latent feedback processors
-        self.prev_latent_result = x_0_pred_out.clone()
+        # Store latent result for latent feedback processors (reuse pre-allocated buffer)
+        if self._latent_cache is None:
+            self._latent_cache = torch.empty_like(x_0_pred_out)
+        self._latent_cache.copy_(x_0_pred_out)
+        self.prev_latent_result = self._latent_cache
 
-        
         x_output = self.decode_image(x_0_pred_out).clone()
 
         # IMAGE POSTPROCESSING HOOKS: After VAE decoding, before final output
@@ -1094,8 +1098,11 @@ class StreamDiffusion:
         # LATENT POSTPROCESSING HOOKS: After diffusion, before VAE decoding
         x_0_pred_out = self._apply_latent_postprocessing_hooks(x_0_pred_out)
         
-        # Store latent result for latent feedback processors
-        self.prev_latent_result = x_0_pred_out.clone()
+        # Store latent result for latent feedback processors (reuse pre-allocated buffer)
+        if self._latent_cache is None:
+            self._latent_cache = torch.empty_like(x_0_pred_out)
+        self._latent_cache.copy_(x_0_pred_out)
+        self.prev_latent_result = self._latent_cache
 
         
         x_output = self.decode_image(x_0_pred_out).clone()
@@ -1152,8 +1159,11 @@ class StreamDiffusion:
         # LATENT POSTPROCESSING HOOKS: After diffusion, before VAE decoding
         x_0_pred_out = self._apply_latent_postprocessing_hooks(x_0_pred_out)
         
-        # Store latent result for latent feedback processors
-        self.prev_latent_result = x_0_pred_out.clone()
+        # Store latent result for latent feedback processors (reuse pre-allocated buffer)
+        if self._latent_cache is None:
+            self._latent_cache = torch.empty_like(x_0_pred_out)
+        self._latent_cache.copy_(x_0_pred_out)
+        self.prev_latent_result = self._latent_cache
 
         
         x_output = self.decode_image(x_0_pred_out)

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -115,6 +115,7 @@ class StreamDiffusion:
 
         self.inference_time_ema = 0
         self.similar_filter_sleep_fraction = 0.025
+        self.last_frame_was_skipped = False  # True when similar filter skipped inference this frame
 
         # Initialize SDXL-specific attributes
         if self.is_sdxl:
@@ -989,9 +990,11 @@ class StreamDiffusion:
             if self.similar_image_filter:
                 x = self.similar_filter(x)
                 if x is None:
+                    self.last_frame_was_skipped = True
                     time.sleep(self.inference_time_ema * self.similar_filter_sleep_fraction)
                     return self.prev_image_result
-            
+
+            self.last_frame_was_skipped = False
             x_t_latent = self.encode_image(x)
             
             # LATENT PREPROCESSING HOOKS: After VAE encoding, before diffusion

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -625,14 +625,18 @@ class StreamDiffusion:
         idx: Optional[int] = None,
     ) -> torch.Tensor:
         if idx is None:
+            # Upcast division to fp32 — alpha_prod_t_sqrt can be small at early timesteps,
+            # causing fp16 rounding artifacts; cast result back to original dtype.
             F_theta = (
-                x_t_latent_batch - self.beta_prod_t_sqrt * model_pred_batch
-            ) / self.alpha_prod_t_sqrt
+                (x_t_latent_batch - self.beta_prod_t_sqrt * model_pred_batch).float()
+                / self.alpha_prod_t_sqrt.float()
+            ).to(x_t_latent_batch.dtype)
             denoised_batch = self.c_out * F_theta + self.c_skip * x_t_latent_batch
         else:
             F_theta = (
-                x_t_latent_batch - self.beta_prod_t_sqrt[idx] * model_pred_batch
-            ) / self.alpha_prod_t_sqrt[idx]
+                (x_t_latent_batch - self.beta_prod_t_sqrt[idx] * model_pred_batch).float()
+                / self.alpha_prod_t_sqrt[idx].float()
+            ).to(x_t_latent_batch.dtype)
             denoised_batch = (
                 self.c_out[idx] * F_theta + self.c_skip[idx] * x_t_latent_batch
             )
@@ -883,7 +887,7 @@ class StreamDiffusion:
             device=self.device,
             dtype=self.vae.dtype,
         )
-        with torch.autocast("cuda", dtype=torch.float16):
+        with torch.autocast("cuda", dtype=self.dtype):
             img_latent = retrieve_latents(self.vae.encode(image_tensors), self.generator)
         
         img_latent = img_latent * self.vae.config.scaling_factor
@@ -894,7 +898,7 @@ class StreamDiffusion:
 
     def decode_image(self, x_0_pred_out: torch.Tensor) -> torch.Tensor:
         scaled_latent = x_0_pred_out / self.vae.config.scaling_factor
-        with torch.autocast("cuda", dtype=torch.float16):
+        with torch.autocast("cuda", dtype=self.dtype):
             output_latent = self.vae.decode(scaled_latent, return_dict=False)[0]
         return output_latent
 

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -1,27 +1,35 @@
+import logging
 import time
-from typing import List, Optional, Union, Any, Dict, Tuple, Literal
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import numpy as np
 import PIL.Image
 import torch
-from diffusers import LCMScheduler, TCDScheduler, StableDiffusionPipeline
+from diffusers import LCMScheduler, StableDiffusionPipeline, TCDScheduler
 from diffusers.image_processor import VaeImageProcessor
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion_img2img import (
     retrieve_latents,
 )
 
-from streamdiffusion.model_detection import detect_model
 from streamdiffusion.hooks import (
-    EmbedsCtx, StepCtx, UnetKwargsDelta, ImageCtx, LatentCtx,
-    EmbeddingHook, UnetHook, ImageHook, LatentHook
+    EmbeddingHook,
+    EmbedsCtx,
+    ImageCtx,
+    ImageHook,
+    LatentCtx,
+    LatentHook,
+    StepCtx,
+    UnetHook,
+    UnetKwargsDelta,
 )
 from streamdiffusion.image_filter import SimilarImageFilter
+from streamdiffusion.model_detection import detect_model
 from streamdiffusion.stream_parameter_updater import StreamParameterUpdater
 
-import logging
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
 
 class StreamDiffusion:
     def __init__(
@@ -64,11 +72,11 @@ class StreamDiffusion:
 
         # Detect model type
         detection_result = detect_model(pipe.unet, pipe)
-        self.model_type = detection_result['model_type']
-        self.is_sdxl = detection_result['is_sdxl']
-        self.is_turbo = detection_result['is_turbo']
-        self.detection_confidence = detection_result['confidence']
-    
+        self.model_type = detection_result["model_type"]
+        self.is_sdxl = detection_result["is_sdxl"]
+        self.is_turbo = detection_result["is_turbo"]
+        self.detection_confidence = detection_result["confidence"]
+
         # TCD scheduler is incompatible with denoising batch optimization due to Strategic Stochastic Sampling
         # Force sequential processing for TCD
         if scheduler == "tcd":
@@ -81,13 +89,9 @@ class StreamDiffusion:
             self.use_denoising_batch = True
             self.batch_size = self.denoising_steps_num * frame_buffer_size
             if self.cfg_type == "initialize":
-                self.trt_unet_batch_size = (
-                    self.denoising_steps_num + 1
-                ) * self.frame_bff_size
+                self.trt_unet_batch_size = (self.denoising_steps_num + 1) * self.frame_bff_size
             elif self.cfg_type == "full":
-                self.trt_unet_batch_size = (
-                    2 * self.denoising_steps_num * self.frame_bff_size
-                )
+                self.trt_unet_batch_size = 2 * self.denoising_steps_num * self.frame_bff_size
             else:
                 self.trt_unet_batch_size = self.denoising_steps_num * frame_buffer_size
         else:
@@ -102,13 +106,15 @@ class StreamDiffusion:
         self.similar_filter = SimilarImageFilter()
         self.prev_image_result = None
         self.prev_latent_result = None
-        self._latent_cache = None   # pre-allocated buffer; avoids per-frame CUDA malloc for prev_latent_result
-        self._noise_buf = None      # pre-allocated buffer for per-step noise in TCD non-batched path
+        self._latent_cache = None  # pre-allocated buffer; avoids per-frame CUDA malloc for prev_latent_result
+        self._noise_buf = None  # pre-allocated buffer for per-step noise in TCD non-batched path
+        self._image_decode_buf = None  # pre-allocated buffer for VAE decode output (avoids .clone())
+        self._prev_image_buf = None  # pre-allocated buffer for skip-frame image cache
 
         self.pipe = pipe
         self.image_processor = VaeImageProcessor(pipe.vae_scale_factor)
         self.scheduler = self._initialize_scheduler(scheduler, sampler, pipe.scheduler.config)
-        
+
         self.text_encoder = pipe.text_encoder
         self.unet = pipe.unet
         self.vae = pipe.vae
@@ -128,19 +134,19 @@ class StreamDiffusion:
         # Hook containers (step 1: introduced but initially no-op)
         self.embedding_hooks: List[EmbeddingHook] = []
         self.unet_hooks: List[UnetHook] = []
-        
+
         # Phase 1: Core Pipeline Hooks (Immediate Priority)
         self.image_preprocessing_hooks: List[ImageHook] = []
         self.latent_preprocessing_hooks: List[LatentHook] = []
         self.latent_postprocessing_hooks: List[LatentHook] = []
-        
+
         # Phase 2: Quality & Performance Hooks
         self.image_postprocessing_hooks: List[ImageHook] = []
         self.image_filtering_hooks: List[ImageHook] = []
-        
+
         # Cache TensorRT detection to avoid repeated hasattr checks
         self._is_unet_tensorrt = None
-        
+
         # Cache SDXL conditioning tensors to avoid repeated torch.cat/repeat operations
         self._sdxl_conditioning_cache: Dict[str, torch.Tensor] = {}
         self._cached_batch_size: Optional[int] = None
@@ -165,15 +171,15 @@ class StreamDiffusion:
             "beta": {"beta_schedule": "scaled_linear"},
             "karras": {},  # Karras sigmas handled per scheduler
         }
-        
+
         # Get sampler-specific configuration
         sampler_params = sampler_config.get(sampler_type, {})
-        
+
         # Set original_inference_steps to 100 to allow flexible num_inference_steps updates
         # This prevents "original_steps x strength < num_inference_steps" errors when
         # dynamically changing num_inference_steps in production without pipeline restarts
-        sampler_params['original_inference_steps'] = 100
-        
+        sampler_params["original_inference_steps"] = 100
+
         if scheduler_type == "lcm":
             return LCMScheduler.from_config(config, **sampler_params)
         elif scheduler_type == "tcd":
@@ -185,29 +191,34 @@ class StreamDiffusion:
     def _check_unet_tensorrt(self) -> bool:
         """Cache TensorRT detection to avoid repeated hasattr calls"""
         if self._is_unet_tensorrt is None:
-            self._is_unet_tensorrt = hasattr(self.unet, 'engine') and hasattr(self.unet, 'stream')
+            self._is_unet_tensorrt = hasattr(self.unet, "engine") and hasattr(self.unet, "stream")
         return self._is_unet_tensorrt
 
-    def _get_cached_sdxl_conditioning(self, batch_size: int, cfg_type: str, guidance_scale: float) -> Optional[Dict[str, torch.Tensor]]:
+    def _get_cached_sdxl_conditioning(
+        self, batch_size: int, cfg_type: str, guidance_scale: float
+    ) -> Optional[Dict[str, torch.Tensor]]:
         """Retrieve cached SDXL conditioning tensors if configuration matches"""
-        if (self._cached_batch_size == batch_size and 
-            self._cached_cfg_type == cfg_type and 
-            self._cached_guidance_scale == guidance_scale and
-            len(self._sdxl_conditioning_cache) > 0):
+        if (
+            self._cached_batch_size == batch_size
+            and self._cached_cfg_type == cfg_type
+            and self._cached_guidance_scale == guidance_scale
+            and len(self._sdxl_conditioning_cache) > 0
+        ):
             return {
-                'text_embeds': self._sdxl_conditioning_cache.get('text_embeds'),
-                'time_ids': self._sdxl_conditioning_cache.get('time_ids')
+                "text_embeds": self._sdxl_conditioning_cache.get("text_embeds"),
+                "time_ids": self._sdxl_conditioning_cache.get("time_ids"),
             }
         return None
 
-    def _cache_sdxl_conditioning(self, batch_size: int, cfg_type: str, guidance_scale: float, 
-                                text_embeds: torch.Tensor, time_ids: torch.Tensor) -> None:
+    def _cache_sdxl_conditioning(
+        self, batch_size: int, cfg_type: str, guidance_scale: float, text_embeds: torch.Tensor, time_ids: torch.Tensor
+    ) -> None:
         """Cache SDXL conditioning tensors for reuse"""
         self._cached_batch_size = batch_size
         self._cached_cfg_type = cfg_type
         self._cached_guidance_scale = guidance_scale
-        self._sdxl_conditioning_cache['text_embeds'] = text_embeds.clone()
-        self._sdxl_conditioning_cache['time_ids'] = time_ids.clone()
+        self._sdxl_conditioning_cache["text_embeds"] = text_embeds.clone()
+        self._sdxl_conditioning_cache["time_ids"] = time_ids.clone()
 
     def _build_sdxl_conditioning(self, batch_size: int) -> Dict[str, torch.Tensor]:
         """Build SDXL conditioning tensors with optimized tensor operations"""
@@ -219,7 +230,7 @@ class StreamDiffusion:
             cond_text = self.add_text_embeds[1:2]
             uncond_time = self.add_time_ids[0:1]
             cond_time = self.add_time_ids[1:2]
-            
+
             if batch_size > 1:
                 cond_text_repeated = cond_text.expand(batch_size - 1, -1).contiguous()
                 cond_time_repeated = cond_time.expand(batch_size - 1, -1).contiguous()
@@ -228,7 +239,7 @@ class StreamDiffusion:
             else:
                 add_text_embeds = uncond_text
                 add_time_ids = uncond_time
-                
+
         elif self.guidance_scale > 1.0 and (self.cfg_type == "full"):
             # For full mode: repeat both uncond and cond for each latent
             repeat_factor = batch_size // 2
@@ -240,13 +251,7 @@ class StreamDiffusion:
             source_time = self.add_time_ids[1:2] if self.add_time_ids.shape[0] > 1 else self.add_time_ids
             add_text_embeds = source_text.expand(batch_size, -1).contiguous()
             add_time_ids = source_time.expand(batch_size, -1).contiguous()
-        return {
-            'text_embeds': add_text_embeds,
-            'time_ids': add_time_ids
-        }
-
-
-
+        return {"text_embeds": add_text_embeds, "time_ids": add_time_ids}
 
     def load_lora(
         self,
@@ -254,9 +259,7 @@ class StreamDiffusion:
         adapter_name: Optional[Any] = None,
         **kwargs,
     ) -> None:
-        self._load_lora_with_offline_fallback(
-            pretrained_lora_model_name_or_path_or_dict, adapter_name, **kwargs
-        )
+        self._load_lora_with_offline_fallback(pretrained_lora_model_name_or_path_or_dict, adapter_name, **kwargs)
 
     def _load_lora_with_offline_fallback(
         self,
@@ -363,7 +366,7 @@ class StreamDiffusion:
 
         # Handle SDXL vs SD1.5/SD2.1 text encoding differently
         if self.is_sdxl:
-            # SDXL encode_prompt returns 4 values: 
+            # SDXL encode_prompt returns 4 values:
             # (prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, negative_pooled_prompt_embeds)
             encoder_output = self.pipe.encode_prompt(
                 prompt=prompt,
@@ -380,40 +383,38 @@ class StreamDiffusion:
                 lora_scale=None,
                 clip_skip=None,
             )
-            
+
             if len(encoder_output) >= 4:
-                prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, negative_pooled_prompt_embeds = encoder_output[:4]
-                
+                prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, negative_pooled_prompt_embeds = (
+                    encoder_output[:4]
+                )
+
                 # Set up prompt embeddings for the UNet (base before hooks)
                 base_prompt_embeds = prompt_embeds.repeat(self.batch_size, 1, 1)
-                
+
                 # Handle CFG for prompt embeddings
                 if self.use_denoising_batch and self.cfg_type == "full":
                     uncond_prompt_embeds = negative_prompt_embeds.repeat(self.batch_size, 1, 1)
                 elif self.cfg_type == "initialize":
                     uncond_prompt_embeds = negative_prompt_embeds.repeat(self.frame_bff_size, 1, 1)
 
-                if self.guidance_scale > 1.0 and (
-                    self.cfg_type == "initialize" or self.cfg_type == "full"
-                ):
-                    base_prompt_embeds = torch.cat(
-                        [uncond_prompt_embeds, base_prompt_embeds], dim=0
-                    )
-                
+                if self.guidance_scale > 1.0 and (self.cfg_type == "initialize" or self.cfg_type == "full"):
+                    base_prompt_embeds = torch.cat([uncond_prompt_embeds, base_prompt_embeds], dim=0)
+
                 # Set up SDXL-specific conditioning (added_cond_kwargs)
                 if do_classifier_free_guidance:
                     self.add_text_embeds = torch.cat([negative_pooled_prompt_embeds, pooled_prompt_embeds], dim=0)
                 else:
                     self.add_text_embeds = pooled_prompt_embeds
-                
+
                 # Create time conditioning for SDXL micro-conditioning
                 original_size = (self.height, self.width)
                 target_size = (self.height, self.width)
                 crops_coords_top_left = (0, 0)
-                
+
                 add_time_ids = list(original_size + crops_coords_top_left + target_size)
                 add_time_ids = torch.tensor([add_time_ids], dtype=self.dtype, device=self.device)
-                
+
                 if do_classifier_free_guidance:
                     self.add_time_ids = torch.cat([add_time_ids, add_time_ids], dim=0)
                 else:
@@ -445,12 +446,8 @@ class StreamDiffusion:
             elif self.cfg_type == "initialize":
                 uncond_prompt_embeds = encoder_output[1].repeat(self.frame_bff_size, 1, 1)
 
-            if self.guidance_scale > 1.0 and (
-                self.cfg_type == "initialize" or self.cfg_type == "full"
-            ):
-                base_prompt_embeds = torch.cat(
-                    [uncond_prompt_embeds, base_prompt_embeds], dim=0
-                )
+            if self.guidance_scale > 1.0 and (self.cfg_type == "initialize" or self.cfg_type == "full"):
+                base_prompt_embeds = torch.cat([uncond_prompt_embeds, base_prompt_embeds], dim=0)
 
             # Run embedding hooks (no-op unless modules register)
             embeds_ctx = EmbedsCtx(prompt_embeds=base_prompt_embeds, negative_prompt_embeds=None)
@@ -470,9 +467,7 @@ class StreamDiffusion:
         for t in self.t_list:
             self.sub_timesteps.append(self.timesteps[t])
 
-        sub_timesteps_tensor = torch.tensor(
-            self.sub_timesteps, dtype=torch.long, device=self.device
-        )
+        sub_timesteps_tensor = torch.tensor(self.sub_timesteps, dtype=torch.long, device=self.device)
         self.sub_timesteps_tensor = torch.repeat_interleave(
             sub_timesteps_tensor,
             repeats=self.frame_bff_size if self.use_denoising_batch else 1,
@@ -494,16 +489,8 @@ class StreamDiffusion:
             c_skip_list.append(c_skip)
             c_out_list.append(c_out)
 
-        self.c_skip = (
-            torch.stack(c_skip_list)
-            .view(len(self.t_list), 1, 1, 1)
-            .to(dtype=self.dtype, device=self.device)
-        )
-        self.c_out = (
-            torch.stack(c_out_list)
-            .view(len(self.t_list), 1, 1, 1)
-            .to(dtype=self.dtype, device=self.device)
-        )
+        self.c_skip = torch.stack(c_skip_list).view(len(self.t_list), 1, 1, 1).to(dtype=self.dtype, device=self.device)
+        self.c_out = torch.stack(c_out_list).view(len(self.t_list), 1, 1, 1).to(dtype=self.dtype, device=self.device)
 
         alpha_prod_t_sqrt_list = []
         beta_prod_t_sqrt_list = []
@@ -518,9 +505,7 @@ class StreamDiffusion:
             .to(dtype=self.dtype, device=self.device)
         )
         beta_prod_t_sqrt = (
-            torch.stack(beta_prod_t_sqrt_list)
-            .view(len(self.t_list), 1, 1, 1)
-            .to(dtype=self.dtype, device=self.device)
+            torch.stack(beta_prod_t_sqrt_list).view(len(self.t_list), 1, 1, 1).to(dtype=self.dtype, device=self.device)
         )
         self.alpha_prod_t_sqrt = torch.repeat_interleave(
             alpha_prod_t_sqrt,
@@ -532,7 +517,7 @@ class StreamDiffusion:
             repeats=self.frame_bff_size if self.use_denoising_batch else 1,
             dim=0,
         )
-        #NOTE: this is a hack. Pipeline needs a major refactor along with stream parameter updater. 
+        # NOTE: this is a hack. Pipeline needs a major refactor along with stream parameter updater.
         self.update_prompt(prompt)
 
         # Only collapse tensors to scalars for LCM non-batched mode
@@ -561,14 +546,7 @@ class StreamDiffusion:
 
     @torch.inference_mode()
     def update_prompt(self, prompt: str) -> None:
-        self._param_updater.update_stream_params(
-            prompt_list=[(prompt, 1.0)],
-            prompt_interpolation_method="linear"
-        )
-
-    
-
-
+        self._param_updater.update_stream_params(prompt_list=[(prompt, 1.0)], prompt_interpolation_method="linear")
 
     def get_normalize_prompt_weights(self) -> bool:
         """Get the current prompt weight normalization setting."""
@@ -578,14 +556,14 @@ class StreamDiffusion:
         """Get the current seed weight normalization setting."""
         return self._param_updater.get_normalize_seed_weights()
 
-
-
-
-
-    def set_scheduler(self, scheduler: Literal["lcm", "tcd"] = None, sampler: Literal["simple", "sgm uniform", "normal", "ddim", "beta", "karras"] = None) -> None:
+    def set_scheduler(
+        self,
+        scheduler: Literal["lcm", "tcd"] = None,
+        sampler: Literal["simple", "sgm uniform", "normal", "ddim", "beta", "karras"] = None,
+    ) -> None:
         """
         Change the scheduler and/or sampler at runtime.
-        
+
         Parameters
         ----------
         scheduler : str, optional
@@ -597,7 +575,7 @@ class StreamDiffusion:
             self.scheduler_type = scheduler
         if sampler is not None:
             self.sampler_type = sampler
-            
+
         self.scheduler = self._initialize_scheduler(self.scheduler_type, self.sampler_type, self.pipe.scheduler.config)
         logger.info(f"Scheduler changed to {self.scheduler_type} with {self.sampler_type} sampler")
 
@@ -605,18 +583,13 @@ class StreamDiffusion:
         """Return True if scheduler uses LCM-style consistency boundary-condition math."""
         return isinstance(self.scheduler, LCMScheduler)
 
-
-
     def add_noise(
         self,
         original_samples: torch.Tensor,
         noise: torch.Tensor,
         t_index: int,
     ) -> torch.Tensor:
-        noisy_samples = (
-            self.alpha_prod_t_sqrt[t_index] * original_samples
-            + self.beta_prod_t_sqrt[t_index] * noise
-        )
+        noisy_samples = self.alpha_prod_t_sqrt[t_index] * original_samples + self.beta_prod_t_sqrt[t_index] * noise
         return noisy_samples
 
     def scheduler_step_batch(
@@ -629,8 +602,7 @@ class StreamDiffusion:
             # Upcast division to fp32 — alpha_prod_t_sqrt can be small at early timesteps,
             # causing fp16 rounding artifacts; cast result back to original dtype.
             F_theta = (
-                (x_t_latent_batch - self.beta_prod_t_sqrt * model_pred_batch).float()
-                / self.alpha_prod_t_sqrt.float()
+                (x_t_latent_batch - self.beta_prod_t_sqrt * model_pred_batch).float() / self.alpha_prod_t_sqrt.float()
             ).to(x_t_latent_batch.dtype)
             denoised_batch = self.c_out * F_theta + self.c_skip * x_t_latent_batch
         else:
@@ -638,9 +610,7 @@ class StreamDiffusion:
                 (x_t_latent_batch - self.beta_prod_t_sqrt[idx] * model_pred_batch).float()
                 / self.alpha_prod_t_sqrt[idx].float()
             ).to(x_t_latent_batch.dtype)
-            denoised_batch = (
-                self.c_out[idx] * F_theta + self.c_skip[idx] * x_t_latent_batch
-            )
+            denoised_batch = self.c_out[idx] * F_theta + self.c_skip[idx] * x_t_latent_batch
         return denoised_batch
 
     def unet_step(
@@ -660,37 +630,38 @@ class StreamDiffusion:
 
         # Prepare UNet call arguments
         unet_kwargs = {
-            'sample': x_t_latent_plus_uc,
-            'timestep': t_list,
-            'encoder_hidden_states': self.prompt_embeds,
-            'return_dict': False,
+            "sample": x_t_latent_plus_uc,
+            "timestep": t_list,
+            "encoder_hidden_states": self.prompt_embeds,
+            "return_dict": False,
         }
-        
+
         # Add SDXL-specific conditioning if this is an SDXL model
-        if self.is_sdxl and hasattr(self, 'add_text_embeds') and hasattr(self, 'add_time_ids'):
+        if self.is_sdxl and hasattr(self, "add_text_embeds") and hasattr(self, "add_time_ids"):
             if self.add_text_embeds is not None and self.add_time_ids is not None:
                 # Handle batching for CFG - replicate conditioning to match batch size
                 batch_size = x_t_latent_plus_uc.shape[0]
-                
+
                 # Use optimized caching system for SDXL conditioning tensors
-                cached_conditioning = self._get_cached_sdxl_conditioning(batch_size, self.cfg_type, self.guidance_scale)
+                cached_conditioning = self._get_cached_sdxl_conditioning(
+                    batch_size, self.cfg_type, self.guidance_scale
+                )
                 if cached_conditioning is not None:
                     # Cache hit - reuse existing tensors
-                    add_text_embeds = cached_conditioning['text_embeds']
-                    add_time_ids = cached_conditioning['time_ids']
+                    add_text_embeds = cached_conditioning["text_embeds"]
+                    add_time_ids = cached_conditioning["time_ids"]
                 else:
                     # Cache miss - build new tensors using optimized operations
                     conditioning = self._build_sdxl_conditioning(batch_size)
-                    add_text_embeds = conditioning['text_embeds']
-                    add_time_ids = conditioning['time_ids']
+                    add_text_embeds = conditioning["text_embeds"]
+                    add_time_ids = conditioning["time_ids"]
                     # Cache for future use
-                    self._cache_sdxl_conditioning(batch_size, self.cfg_type, self.guidance_scale, add_text_embeds, add_time_ids)
-                
-                unet_kwargs['added_cond_kwargs'] = {
-                    'text_embeds': add_text_embeds,
-                    'time_ids': add_time_ids
-                }
-        
+                    self._cache_sdxl_conditioning(
+                        batch_size, self.cfg_type, self.guidance_scale, add_text_embeds, add_time_ids
+                    )
+
+                unet_kwargs["added_cond_kwargs"] = {"text_embeds": add_text_embeds, "time_ids": add_time_ids}
+
         # Allow modules to contribute additional UNet kwargs via hooks
         try:
             step_ctx = StepCtx(
@@ -698,7 +669,7 @@ class StreamDiffusion:
                 t_list=t_list,
                 step_index=idx if isinstance(idx, int) else (int(idx) if idx is not None else None),
                 guidance_mode=self.cfg_type if self.guidance_scale > 1.0 else "none",
-                sdxl_cond=unet_kwargs.get('added_cond_kwargs', None)
+                sdxl_cond=unet_kwargs.get("added_cond_kwargs", None),
             )
             extra_from_hooks = {}
             for hook in self.unet_hooks:
@@ -706,42 +677,40 @@ class StreamDiffusion:
                 if delta is None:
                     continue
                 if delta.down_block_additional_residuals is not None:
-                    unet_kwargs['down_block_additional_residuals'] = delta.down_block_additional_residuals
+                    unet_kwargs["down_block_additional_residuals"] = delta.down_block_additional_residuals
                 if delta.mid_block_additional_residual is not None:
-                    unet_kwargs['mid_block_additional_residual'] = delta.mid_block_additional_residual
+                    unet_kwargs["mid_block_additional_residual"] = delta.mid_block_additional_residual
                 if delta.added_cond_kwargs is not None:
                     # Merge SDXL cond if both exist
-                    base_added = unet_kwargs.get('added_cond_kwargs', {})
+                    base_added = unet_kwargs.get("added_cond_kwargs", {})
                     base_added.update(delta.added_cond_kwargs)
-                    unet_kwargs['added_cond_kwargs'] = base_added
-                if getattr(delta, 'extra_unet_kwargs', None):
+                    unet_kwargs["added_cond_kwargs"] = base_added
+                if getattr(delta, "extra_unet_kwargs", None):
                     # Merge extra kwargs from hooks (e.g., ipadapter_scale)
                     try:
                         extra_from_hooks.update(delta.extra_unet_kwargs)
                     except Exception:
                         pass
             if extra_from_hooks:
-                unet_kwargs['extra_unet_kwargs'] = extra_from_hooks
+                unet_kwargs["extra_unet_kwargs"] = extra_from_hooks
         except Exception as e:
             logger.error(f"unet_step: unet hook failed: {e}")
             raise
 
         # Extract potential ControlNet residual kwargs and generic extra kwargs (e.g., ipadapter_scale)
-        hook_down_res = unet_kwargs.get('down_block_additional_residuals', None)
-        hook_mid_res = unet_kwargs.get('mid_block_additional_residual', None)
-        hook_extra_kwargs = unet_kwargs.get('extra_unet_kwargs', None) if 'extra_unet_kwargs' in unet_kwargs else None
+        hook_down_res = unet_kwargs.get("down_block_additional_residuals", None)
+        hook_mid_res = unet_kwargs.get("mid_block_additional_residual", None)
+        hook_extra_kwargs = unet_kwargs.get("extra_unet_kwargs", None) if "extra_unet_kwargs" in unet_kwargs else None
 
         # Call UNet with appropriate conditioning
         if self.is_sdxl:
             try:
-
-                
                 # Detect UNet type and use appropriate calling convention
-                added_cond_kwargs = unet_kwargs.get('added_cond_kwargs', {})
-                
+                added_cond_kwargs = unet_kwargs.get("added_cond_kwargs", {})
+
                 # Check if this is a TensorRT engine or PyTorch UNet
                 is_tensorrt_engine = self._check_unet_tensorrt()
-                
+
                 if is_tensorrt_engine:
                     # TensorRT engine expects positional args + kwargs. IP-Adapter scale vector, if any, is provided by hooks via extra_unet_kwargs
                     extra_kwargs = {}
@@ -750,41 +719,42 @@ class StreamDiffusion:
 
                     # Include ControlNet residuals if provided by hooks
                     if hook_down_res is not None:
-                        extra_kwargs['down_block_additional_residuals'] = hook_down_res
+                        extra_kwargs["down_block_additional_residuals"] = hook_down_res
                     if hook_mid_res is not None:
-                        extra_kwargs['mid_block_additional_residual'] = hook_mid_res
+                        extra_kwargs["mid_block_additional_residual"] = hook_mid_res
 
                     model_pred, kvo_cache_out = self.unet(
-                        unet_kwargs['sample'],                    # latent_model_input (positional)
-                        unet_kwargs['timestep'],                  # timestep (positional)
-                        unet_kwargs['encoder_hidden_states'],     # encoder_hidden_states (positional)
+                        unet_kwargs["sample"],  # latent_model_input (positional)
+                        unet_kwargs["timestep"],  # timestep (positional)
+                        unet_kwargs["encoder_hidden_states"],  # encoder_hidden_states (positional)
                         kvo_cache=self.kvo_cache,
                         **extra_kwargs,
                         # For TRT engines, ensure SDXL cond shapes match engine builds; if engine expects 81 tokens (77+4), append dummy image tokens when none
-                        **added_cond_kwargs                       # SDXL conditioning as kwargs
+                        **added_cond_kwargs,  # SDXL conditioning as kwargs
                     )
                     self.update_kvo_cache(kvo_cache_out)
                 else:
                     # PyTorch UNet expects diffusers-style named arguments. Any processor scaling is handled by IP-Adapter hook
 
-                    call_kwargs = dict(
-                        sample=unet_kwargs['sample'],
-                        timestep=unet_kwargs['timestep'],
-                        encoder_hidden_states=unet_kwargs['encoder_hidden_states'],
-                        added_cond_kwargs=added_cond_kwargs,
-                        return_dict=False,
-                    )
+                    call_kwargs = {
+                        "sample": unet_kwargs["sample"],
+                        "timestep": unet_kwargs["timestep"],
+                        "encoder_hidden_states": unet_kwargs["encoder_hidden_states"],
+                        "added_cond_kwargs": added_cond_kwargs,
+                        "return_dict": False,
+                    }
                     # Include ControlNet residuals if present
                     if hook_down_res is not None:
-                        call_kwargs['down_block_additional_residuals'] = hook_down_res
+                        call_kwargs["down_block_additional_residuals"] = hook_down_res
                     if hook_mid_res is not None:
-                        call_kwargs['mid_block_additional_residual'] = hook_mid_res
+                        call_kwargs["mid_block_additional_residual"] = hook_mid_res
                     model_pred = self.unet(**call_kwargs)[0]
                     # No restoration for per-layer scale; next step will set again via updater/time factor
-                
+
             except Exception as e:
                 logger.error(f"[PIPELINE] unet_step: *** ERROR: SDXL UNet call failed: {e} ***")
                 import traceback
+
                 traceback.print_exc()
                 raise
         else:
@@ -798,9 +768,9 @@ class StreamDiffusion:
 
             # Include ControlNet residuals if present
             if hook_down_res is not None:
-                ip_scale_kw['down_block_additional_residuals'] = hook_down_res
+                ip_scale_kw["down_block_additional_residuals"] = hook_down_res
             if hook_mid_res is not None:
-                ip_scale_kw['mid_block_additional_residual'] = hook_mid_res
+                ip_scale_kw["mid_block_additional_residual"] = hook_mid_res
 
             model_pred, kvo_cache_out = self.unet(
                 x_t_latent_plus_uc,
@@ -821,23 +791,19 @@ class StreamDiffusion:
             noise_pred_uncond, noise_pred_text = model_pred.chunk(2)
         else:
             noise_pred_text = model_pred
-            
-        if self.guidance_scale > 1.0 and (
-            self.cfg_type == "self" or self.cfg_type == "initialize"
-        ):
+
+        if self.guidance_scale > 1.0 and (self.cfg_type == "self" or self.cfg_type == "initialize"):
             noise_pred_uncond = self.stock_noise * self.delta
-            
+
         if self.guidance_scale > 1.0 and self.cfg_type != "none":
-            model_pred = noise_pred_uncond + self.guidance_scale * (
-                noise_pred_text - noise_pred_uncond
-            )
+            model_pred = noise_pred_uncond + self.guidance_scale * (noise_pred_text - noise_pred_uncond)
         else:
             model_pred = noise_pred_text
 
         # compute the previous noisy sample x_t -> x_t-1
         if self.use_denoising_batch:
             denoised_batch = self.scheduler_step_batch(model_pred, x_t_latent, idx)
-            
+
             if self.cfg_type == "self" or self.cfg_type == "initialize":
                 scaled_noise = self.beta_prod_t_sqrt * self.stock_noise
                 delta_x = self.scheduler_step_batch(model_pred, scaled_noise, idx)
@@ -857,9 +823,7 @@ class StreamDiffusion:
                     dim=0,
                 )
                 delta_x = delta_x / beta_next
-                init_noise = torch.concat(
-                    [self.init_noise[1:], self.init_noise[0:1]], dim=0
-                )
+                init_noise = torch.concat([self.init_noise[1:], self.init_noise[0:1]], dim=0)
                 self.stock_noise = init_noise + delta_x
 
         else:
@@ -890,11 +854,11 @@ class StreamDiffusion:
         )
         with torch.autocast("cuda", dtype=self.dtype):
             img_latent = retrieve_latents(self.vae.encode(image_tensors), self.generator)
-        
+
         img_latent = img_latent * self.vae.config.scaling_factor
-        
+
         x_t_latent = self.add_noise(img_latent, self.init_noise[0], 0)
-        
+
         return x_t_latent
 
     def decode_image(self, x_0_pred_out: torch.Tensor) -> torch.Tensor:
@@ -905,16 +869,14 @@ class StreamDiffusion:
 
     def predict_x0_batch(self, x_t_latent: torch.Tensor) -> torch.Tensor:
         prev_latent_batch = self.x_t_latent_buffer
-        
+
         # LCM supports our denoising-batch trick. TCD must use standard scheduler.step() sequentially
         # but now properly processes ControlNet hooks through unet_step()
         if self.use_denoising_batch and isinstance(self.scheduler, LCMScheduler):
             t_list = self.sub_timesteps_tensor
             if self.denoising_steps_num > 1:
                 x_t_latent = torch.cat((x_t_latent, prev_latent_batch), dim=0)
-                self.stock_noise = torch.cat(
-                    (self.init_noise[0:1], self.stock_noise[:-1]), dim=0
-                )
+                self.stock_noise = torch.cat((self.init_noise[0:1], self.stock_noise[:-1]), dim=0)
             x_0_pred_batch, model_pred = self.unet_step(x_t_latent, t_list)
 
             if self.denoising_steps_num > 1:
@@ -925,9 +887,7 @@ class StreamDiffusion:
                         + self.beta_prod_t_sqrt[1:] * self.init_noise[1:]
                     )
                 else:
-                    self.x_t_latent_buffer = (
-                        self.alpha_prod_t_sqrt[1:] * x_0_pred_batch[:-1]
-                    )
+                    self.x_t_latent_buffer = self.alpha_prod_t_sqrt[1:] * x_0_pred_batch[:-1]
             else:
                 x_0_pred_out = x_0_pred_batch
                 self.x_t_latent_buffer = None
@@ -944,15 +904,25 @@ class StreamDiffusion:
                 # For TCD, use the same UNet calling logic as LCM to ensure ControlNet hooks are processed
                 if isinstance(self.scheduler, TCDScheduler):
                     # Use unet_step to process ControlNet hooks and get proper noise prediction
-                    t_expanded = t.view(1,).repeat(self.frame_bff_size,)
+                    t_expanded = t.view(
+                        1,
+                    ).repeat(
+                        self.frame_bff_size,
+                    )
                     x_0_pred, model_pred = self.unet_step(sample, t_expanded, idx)
-                    
+
                     # Apply TCD scheduler step to the guided noise prediction
                     step_out = self.scheduler.step(model_pred, t, sample)
-                    sample = getattr(step_out, "prev_sample", step_out[0] if isinstance(step_out, (tuple, list)) else step_out)
+                    sample = getattr(
+                        step_out, "prev_sample", step_out[0] if isinstance(step_out, (tuple, list)) else step_out
+                    )
                 else:
                     # Original LCM logic for non-batched mode
-                    t = t.view(1,).repeat(self.frame_bff_size,)
+                    t = t.view(
+                        1,
+                    ).repeat(
+                        self.frame_bff_size,
+                    )
                     x_0_pred, model_pred = self.unet_step(sample, t, idx)
                     if idx < len(self.sub_timesteps_tensor) - 1:
                         if self.do_add_noise:
@@ -972,21 +942,17 @@ class StreamDiffusion:
         return x_0_pred_out
 
     @torch.inference_mode()
-    def __call__(
-        self, x: Union[torch.Tensor, PIL.Image.Image, np.ndarray] = None
-    ) -> torch.Tensor:
+    def __call__(self, x: Union[torch.Tensor, PIL.Image.Image, np.ndarray] = None) -> torch.Tensor:
         start = torch.cuda.Event(enable_timing=True)
         end = torch.cuda.Event(enable_timing=True)
         start.record()
-        
+
         if x is not None:
-            x = self.image_processor.preprocess(x, self.height, self.width).to(
-                device=self.device, dtype=self.dtype
-            )
-            
+            x = self.image_processor.preprocess(x, self.height, self.width).to(device=self.device, dtype=self.dtype)
+
             # IMAGE PREPROCESSING HOOKS: After built-in preprocessing, before filtering
             x = self._apply_image_preprocessing_hooks(x)
-            
+
             if self.similar_image_filter:
                 x = self.similar_filter(x)
                 if x is None:
@@ -996,7 +962,7 @@ class StreamDiffusion:
 
             self.last_frame_was_skipped = False
             x_t_latent = self.encode_image(x)
-            
+
             # LATENT PREPROCESSING HOOKS: After VAE encoding, before diffusion
             x_t_latent = self._apply_latent_preprocessing_hooks(x_t_latent)
         else:
@@ -1004,94 +970,101 @@ class StreamDiffusion:
             x_t_latent = torch.randn((1, 4, self.latent_height, self.latent_width)).to(
                 device=self.device, dtype=self.dtype
             )
-        
+
         x_0_pred_out = self.predict_x0_batch(x_t_latent)
-        
+
         # LATENT POSTPROCESSING HOOKS: After diffusion, before VAE decoding
         x_0_pred_out = self._apply_latent_postprocessing_hooks(x_0_pred_out)
-        
+
         # Store latent result for latent feedback processors (reuse pre-allocated buffer)
         if self._latent_cache is None:
             self._latent_cache = torch.empty_like(x_0_pred_out)
         self._latent_cache.copy_(x_0_pred_out)
         self.prev_latent_result = self._latent_cache
 
-        x_output = self.decode_image(x_0_pred_out).clone()
+        _decoded = self.decode_image(x_0_pred_out)
+        if self._image_decode_buf is None:
+            self._image_decode_buf = torch.empty_like(_decoded)
+        self._image_decode_buf.copy_(_decoded)
+        x_output = self._image_decode_buf
 
         # IMAGE POSTPROCESSING HOOKS: After VAE decoding, before final output
         x_output = self._apply_image_postprocessing_hooks(x_output)
 
-        # Clone for skip-frame cache — TRT VAE buffer is reused on next decode call
-        self.prev_image_result = x_output.clone()
+        # Copy into pre-allocated skip-frame cache — TRT VAE buffer is reused on next decode call
+        if self._prev_image_buf is None:
+            self._prev_image_buf = torch.empty_like(x_output)
+        self._prev_image_buf.copy_(x_output)
+        self.prev_image_result = self._prev_image_buf
         end.record()
         end.synchronize()  # Wait only for this event, not all streams globally
         inference_time = start.elapsed_time(end) / 1000
         self.inference_time_ema = 0.9 * self.inference_time_ema + 0.1 * inference_time
-        
+
         return x_output
 
     # =========================================================================
     # Pipeline Hook Helper Methods (Phase 3: Performance-Optimized Hot Path)
     # =========================================================================
-    
+
     def _apply_image_preprocessing_hooks(self, x: torch.Tensor) -> torch.Tensor:
         """Apply image preprocessing hooks with minimal hot path overhead."""
         # Early exit - zero overhead when no hooks registered
         if not self.image_preprocessing_hooks:
             return x
-        
+
         # Single context object creation to minimize allocation overhead
         image_ctx = ImageCtx(image=x, width=self.width, height=self.height)
-        
+
         # Direct iteration - no additional function calls
         for hook in self.image_preprocessing_hooks:
             image_ctx = hook(image_ctx)
-        
+
         return image_ctx.image
-    
+
     def _apply_image_postprocessing_hooks(self, x: torch.Tensor) -> torch.Tensor:
         """Apply image postprocessing hooks with minimal hot path overhead."""
         # Early exit - zero overhead when no hooks registered
         if not self.image_postprocessing_hooks:
             return x
-        
+
         # Single context object creation to minimize allocation overhead
         image_ctx = ImageCtx(image=x, width=self.width, height=self.height)
-        
+
         # Direct iteration - no additional function calls
         for hook in self.image_postprocessing_hooks:
             image_ctx = hook(image_ctx)
-        
+
         return image_ctx.image
-    
+
     def _apply_latent_preprocessing_hooks(self, latent: torch.Tensor) -> torch.Tensor:
         """Apply latent preprocessing hooks with minimal hot path overhead."""
         # Early exit - zero overhead when no hooks registered
         if not self.latent_preprocessing_hooks:
             return latent
-        
+
         # Single context object creation to minimize allocation overhead
         latent_ctx = LatentCtx(latent=latent)
-        
+
         # Direct iteration - no additional function calls
         for hook in self.latent_preprocessing_hooks:
             latent_ctx = hook(latent_ctx)
-        
+
         return latent_ctx.latent
-    
+
     def _apply_latent_postprocessing_hooks(self, latent: torch.Tensor) -> torch.Tensor:
         """Apply latent postprocessing hooks with minimal hot path overhead."""
-        # Early exit - zero overhead when no hooks registered  
+        # Early exit - zero overhead when no hooks registered
         if not self.latent_postprocessing_hooks:
             return latent
-        
+
         # Single context object creation to minimize allocation overhead
         latent_ctx = LatentCtx(latent=latent)
-        
+
         # Direct iteration - no additional function calls
         for hook in self.latent_postprocessing_hooks:
             latent_ctx = hook(latent_ctx)
-        
+
         return latent_ctx.latent
 
     @torch.inference_mode()
@@ -1101,18 +1074,21 @@ class StreamDiffusion:
                 device=self.device, dtype=self.dtype
             )
         )
-        
+
         # LATENT POSTPROCESSING HOOKS: After diffusion, before VAE decoding
         x_0_pred_out = self._apply_latent_postprocessing_hooks(x_0_pred_out)
-        
+
         # Store latent result for latent feedback processors (reuse pre-allocated buffer)
         if self._latent_cache is None:
             self._latent_cache = torch.empty_like(x_0_pred_out)
         self._latent_cache.copy_(x_0_pred_out)
         self.prev_latent_result = self._latent_cache
 
-        
-        x_output = self.decode_image(x_0_pred_out).clone()
+        _decoded = self.decode_image(x_0_pred_out)
+        if self._image_decode_buf is None:
+            self._image_decode_buf = torch.empty_like(_decoded)
+        self._image_decode_buf.copy_(_decoded)
+        x_output = self._image_decode_buf
 
         # IMAGE POSTPROCESSING HOOKS: After VAE decoding, before final output
         x_output = self._apply_image_postprocessing_hooks(x_output)
@@ -1126,26 +1102,31 @@ class StreamDiffusion:
             device=self.device,
             dtype=self.dtype,
         )
-        
+
         # Prepare UNet call arguments
         unet_kwargs = {
-            'sample': x_t_latent,
-            'timestep': self.sub_timesteps_tensor,
-            'encoder_hidden_states': self.prompt_embeds,
-            'return_dict': False,
+            "sample": x_t_latent,
+            "timestep": self.sub_timesteps_tensor,
+            "encoder_hidden_states": self.prompt_embeds,
+            "return_dict": False,
         }
-        
+
         # Add SDXL-specific conditioning if this is an SDXL model
-        if self.is_sdxl and hasattr(self, 'add_text_embeds') and hasattr(self, 'add_time_ids'):
+        if self.is_sdxl and hasattr(self, "add_text_embeds") and hasattr(self, "add_time_ids"):
             if self.add_text_embeds is not None and self.add_time_ids is not None:
                 # For txt2img, replicate conditioning to match batch size
-                add_text_embeds = self.add_text_embeds[1:2].repeat(batch_size, 1) if self.add_text_embeds.shape[0] > 1 else self.add_text_embeds.repeat(batch_size, 1)
-                add_time_ids = self.add_time_ids[1:2].repeat(batch_size, 1) if self.add_time_ids.shape[0] > 1 else self.add_time_ids.repeat(batch_size, 1)
-                
-                unet_kwargs['added_cond_kwargs'] = {
-                    'text_embeds': add_text_embeds,
-                    'time_ids': add_time_ids
-                }
+                add_text_embeds = (
+                    self.add_text_embeds[1:2].repeat(batch_size, 1)
+                    if self.add_text_embeds.shape[0] > 1
+                    else self.add_text_embeds.repeat(batch_size, 1)
+                )
+                add_time_ids = (
+                    self.add_time_ids[1:2].repeat(batch_size, 1)
+                    if self.add_time_ids.shape[0] > 1
+                    else self.add_time_ids.repeat(batch_size, 1)
+                )
+
+                unet_kwargs["added_cond_kwargs"] = {"text_embeds": add_text_embeds, "time_ids": add_time_ids}
 
         # Call UNet with appropriate conditioning
         if self.is_sdxl:
@@ -1158,24 +1139,21 @@ class StreamDiffusion:
                 encoder_hidden_states=self.prompt_embeds,
                 return_dict=False,
             )
-            
-        x_0_pred_out = (
-            x_t_latent - self.beta_prod_t_sqrt * model_pred
-        ) / self.alpha_prod_t_sqrt
-        
+
+        x_0_pred_out = (x_t_latent - self.beta_prod_t_sqrt * model_pred) / self.alpha_prod_t_sqrt
+
         # LATENT POSTPROCESSING HOOKS: After diffusion, before VAE decoding
         x_0_pred_out = self._apply_latent_postprocessing_hooks(x_0_pred_out)
-        
+
         # Store latent result for latent feedback processors (reuse pre-allocated buffer)
         if self._latent_cache is None:
             self._latent_cache = torch.empty_like(x_0_pred_out)
         self._latent_cache.copy_(x_0_pred_out)
         self.prev_latent_result = self._latent_cache
 
-        
         x_output = self.decode_image(x_0_pred_out)
-        
+
         # IMAGE POSTPROCESSING HOOKS: After VAE decoding, before final output
         x_output = self._apply_image_postprocessing_hooks(x_output)
-        
+
         return x_output

--- a/src/streamdiffusion/preprocessing/__init__.py
+++ b/src/streamdiffusion/preprocessing/__init__.py
@@ -1,13 +1,14 @@
-from .preprocessing_orchestrator import PreprocessingOrchestrator
-from .postprocessing_orchestrator import PostprocessingOrchestrator
-from .pipeline_preprocessing_orchestrator import PipelinePreprocessingOrchestrator
 from .base_orchestrator import BaseOrchestrator
 from .orchestrator_user import OrchestratorUser
+from .pipeline_preprocessing_orchestrator import PipelinePreprocessingOrchestrator
+from .postprocessing_orchestrator import PostprocessingOrchestrator
+from .preprocessing_orchestrator import PreprocessingOrchestrator
+
 
 __all__ = [
     "PreprocessingOrchestrator",
     "PostprocessingOrchestrator",
     "PipelinePreprocessingOrchestrator",
     "BaseOrchestrator",
-    "OrchestratorUser"
+    "OrchestratorUser",
 ]

--- a/src/streamdiffusion/preprocessing/base_orchestrator.py
+++ b/src/streamdiffusion/preprocessing/base_orchestrator.py
@@ -1,144 +1,148 @@
-import torch
-from typing import List, Optional, Union, Dict, Any, Tuple, Callable, TypeVar, Generic
-from abc import ABC, abstractmethod
-import numpy as np
 import concurrent.futures
 import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Generic, Optional, TypeVar
+
+import torch
+
 
 logger = logging.getLogger(__name__)
 
 # Type variables for generic orchestrator
-T = TypeVar('T')  # Input type (e.g., ControlImage for preprocessing)
-R = TypeVar('R')  # Result type (e.g., List[torch.Tensor] for preprocessing)
+T = TypeVar("T")  # Input type (e.g., ControlImage for preprocessing)
+R = TypeVar("R")  # Result type (e.g., List[torch.Tensor] for preprocessing)
 
 
 class BaseOrchestrator(Generic[T, R], ABC):
     """
     Generic base orchestrator for parallelized and pipelined processing.
-    
+
     Handles thread pool management, pipeline state, and inter-frame pipelining
     while leaving domain-specific processing logic to subclasses.
-    
+
     Type Parameters:
         T: Input type for processing operations
         R: Result type returned from processing operations
     """
-    
-    def __init__(self, device: str = "cuda", dtype: torch.dtype = torch.float16, max_workers: int = 4, timeout_ms: float = 10.0, pipeline_ref: Optional[Any] = None):
+
+    def __init__(
+        self,
+        device: str = "cuda",
+        dtype: torch.dtype = torch.float16,
+        max_workers: int = 4,
+        timeout_ms: float = 10.0,
+        pipeline_ref: Optional[Any] = None,
+    ):
         self.device = device
         self.dtype = dtype
         self.timeout_ms = timeout_ms
         self.pipeline_ref = pipeline_ref
         self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
-        
+
         # Pipeline state for pipelined processing
         self._next_frame_future = None
         self._next_frame_result = None
-        
+
         # CUDA stream for background processing to avoid GPU contention
         self._background_stream = None
         device_str = str(device)
         if device_str.startswith("cuda") and torch.cuda.is_available():
             self._background_stream = torch.cuda.Stream()
-    
 
-    
     def cleanup(self) -> None:
         """Cleanup thread pool and CUDA stream resources"""
-        if hasattr(self, '_executor'):
+        if hasattr(self, "_executor"):
             self._executor.shutdown(wait=True)
-        
+
         # Cleanup CUDA stream if it exists
-        if hasattr(self, '_background_stream') and self._background_stream is not None:
+        if hasattr(self, "_background_stream") and self._background_stream is not None:
             # Synchronize the stream before cleanup
             torch.cuda.synchronize()
             self._background_stream = None
-    
+
     def __del__(self):
         """Cleanup on destruction"""
         try:
             self.cleanup()
         except:
             pass
-    
+
     @abstractmethod
     def _should_use_sync_processing(self, *args, **kwargs) -> bool:
         """
         Determine if synchronous processing should be used instead of pipelined.
-        
+
         Subclasses implement domain-specific logic (e.g., feedback preprocessor detection).
-        
+
         Returns:
             True if sync processing should be used, False for pipelined processing
         """
         pass
-    
+
     @abstractmethod
     def _process_frame_background(self, *args, **kwargs) -> Dict[str, Any]:
         """
         Process a frame in the background thread.
-        
+
         Subclasses implement their specific processing logic here.
-        
+
         Returns:
             Dictionary containing processing results and status
         """
         pass
-    
+
     def process_pipelined(self, input_data: T, *args, **kwargs) -> R:
         """
         Process input with intelligent pipelining.
-        
+
         Automatically falls back to sync processing when required by domain logic,
         otherwise uses pipelined processing for performance.
-        
+
         Args:
             input_data: Input data to process
             *args, **kwargs: Additional arguments passed to processing methods
-        
+
         Returns:
             Processing results
         """
         # Check if sync processing is required (domain-specific logic)
         if self._should_use_sync_processing(*args, **kwargs):
             return self.process_sync(input_data, *args, **kwargs)
-        
+
         # Use pipelined processing
         # Wait for previous frame processing; non-blocking with short timeout
         self._wait_for_previous_processing()
-        
+
         # Start next frame processing in background
         self._start_next_frame_processing(input_data, *args, **kwargs)
-        
+
         # Apply current frame processing results if available; otherwise signal no update
         return self._apply_current_frame_processing(*args, **kwargs)
-    
+
     @abstractmethod
     def process_sync(self, input_data: T, *args, **kwargs) -> R:
         """
         Process input synchronously.
-        
+
         Subclasses implement their specific synchronous processing logic.
-        
+
         Args:
             input_data: Input data to process
             *args, **kwargs: Additional arguments passed to processing methods
-        
+
         Returns:
             Processing results
         """
         pass
-    
+
     def _start_next_frame_processing(self, input_data: T, *args, **kwargs) -> None:
         """Start processing for next frame in background thread"""
         # Submit background processing
-        self._next_frame_future = self._executor.submit(
-            self._process_frame_background, input_data, *args, **kwargs
-        )
-    
+        self._next_frame_future = self._executor.submit(self._process_frame_background, input_data, *args, **kwargs)
+
     def _wait_for_previous_processing(self) -> None:
         """Wait for previous frame processing with configurable timeout"""
-        if hasattr(self, '_next_frame_future') and self._next_frame_future is not None:
+        if hasattr(self, "_next_frame_future") and self._next_frame_future is not None:
             try:
                 # Use configurable timeout based on orchestrator type
                 self._next_frame_result = self._next_frame_future.result(timeout=self.timeout_ms / 1000.0)
@@ -150,52 +154,52 @@ class BaseOrchestrator(Generic[T, R], ABC):
                 self._next_frame_result = None
         else:
             self._next_frame_result = None
-    
+
     def _apply_current_frame_processing(self, processors=None, *args, **kwargs) -> R:
         """
         Apply processing results from previous iteration.
-        
+
         Default implementation provides common fallback logic for tensor-to-tensor orchestrators.
         Subclasses can override this method for specialized behavior.
-        
+
         Args:
             processors: List of processors/postprocessors to apply (parameter name varies by subclass)
             *args, **kwargs: Additional arguments
-            
+
         Returns:
             Processing results, or processed current input if no results available
         """
-        if not hasattr(self, '_next_frame_result') or self._next_frame_result is None:
+        if not hasattr(self, "_next_frame_result") or self._next_frame_result is None:
             # First frame or no background results - process current input synchronously
-            if hasattr(self, '_current_input_tensor') and self._current_input_tensor is not None:
+            if hasattr(self, "_current_input_tensor") and self._current_input_tensor is not None:
                 if processors:
                     return self.process_sync(self._current_input_tensor, processors)
                 else:
                     return self._current_input_tensor
-            
+
             # If we don't have current input stored, we have an issue
             class_name = self.__class__.__name__
             logger.error(f"{class_name}: No background results and no current input tensor available")
             raise RuntimeError(f"{class_name}: No processing results available")
-        
+
         result = self._next_frame_result
-        if result['status'] != 'success':
+        if result["status"] != "success":
             class_name = self.__class__.__name__
             logger.warning(f"{class_name}: Background processing failed: {result.get('error', 'Unknown error')}")
             # Process current input synchronously on error
-            if hasattr(self, '_current_input_tensor') and self._current_input_tensor is not None:
+            if hasattr(self, "_current_input_tensor") and self._current_input_tensor is not None:
                 if processors:
                     return self.process_sync(self._current_input_tensor, processors)
                 else:
                     return self._current_input_tensor
             raise RuntimeError(f"{class_name}: Background processing failed and no fallback available")
-        
-        return result['result']
-    
+
+        return result["result"]
+
     def _set_background_stream_context(self):
         """
         Set CUDA stream context for background processing.
-        
+
         Returns:
             The original stream to restore later, or None if no background stream
         """
@@ -204,11 +208,11 @@ class BaseOrchestrator(Generic[T, R], ABC):
             torch.cuda.set_stream(self._background_stream)
             return original_stream
         return None
-    
+
     def _restore_stream_context(self, original_stream):
         """
         Restore the original CUDA stream context.
-        
+
         Args:
             original_stream: The stream to restore, or None to do nothing
         """

--- a/src/streamdiffusion/preprocessing/orchestrator_user.py
+++ b/src/streamdiffusion/preprocessing/orchestrator_user.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Optional
 
-from .preprocessing_orchestrator import PreprocessingOrchestrator
-from .postprocessing_orchestrator import PostprocessingOrchestrator
 from .pipeline_preprocessing_orchestrator import PipelinePreprocessingOrchestrator
+from .postprocessing_orchestrator import PostprocessingOrchestrator
+from .preprocessing_orchestrator import PreprocessingOrchestrator
 
 
 class OrchestratorUser:
@@ -20,32 +20,36 @@ class OrchestratorUser:
     def attach_orchestrator(self, stream) -> None:
         """Attach preprocessing orchestrator (backward compatibility)."""
         self.attach_preprocessing_orchestrator(stream)
-    
+
     def attach_preprocessing_orchestrator(self, stream) -> None:
         """Attach shared preprocessing orchestrator from stream."""
-        orchestrator = getattr(stream, 'preprocessing_orchestrator', None)
+        orchestrator = getattr(stream, "preprocessing_orchestrator", None)
         if orchestrator is None:
             # Lazy-create on stream once, on first user that needs it
-            orchestrator = PreprocessingOrchestrator(device=stream.device, dtype=stream.dtype, max_workers=4, pipeline_ref=stream)
-            setattr(stream, 'preprocessing_orchestrator', orchestrator)
+            orchestrator = PreprocessingOrchestrator(
+                device=stream.device, dtype=stream.dtype, max_workers=4, pipeline_ref=stream
+            )
+            setattr(stream, "preprocessing_orchestrator", orchestrator)
         self._preprocessing_orchestrator = orchestrator
-    
+
     def attach_postprocessing_orchestrator(self, stream) -> None:
         """Attach shared postprocessing orchestrator from stream."""
-        orchestrator = getattr(stream, 'postprocessing_orchestrator', None)
+        orchestrator = getattr(stream, "postprocessing_orchestrator", None)
         if orchestrator is None:
             # Lazy-create on stream once, on first user that needs it
-            orchestrator = PostprocessingOrchestrator(device=stream.device, dtype=stream.dtype, max_workers=4, pipeline_ref=stream)
-            setattr(stream, 'postprocessing_orchestrator', orchestrator)
+            orchestrator = PostprocessingOrchestrator(
+                device=stream.device, dtype=stream.dtype, max_workers=4, pipeline_ref=stream
+            )
+            setattr(stream, "postprocessing_orchestrator", orchestrator)
         self._postprocessing_orchestrator = orchestrator
-    
+
     def attach_pipeline_preprocessing_orchestrator(self, stream) -> None:
         """Attach shared pipeline preprocessing orchestrator from stream."""
-        orchestrator = getattr(stream, 'pipeline_preprocessing_orchestrator', None)
+        orchestrator = getattr(stream, "pipeline_preprocessing_orchestrator", None)
         if orchestrator is None:
             # Lazy-create on stream once, on first user that needs it
-            orchestrator = PipelinePreprocessingOrchestrator(device=stream.device, dtype=stream.dtype, max_workers=4, pipeline_ref=stream)
-            setattr(stream, 'pipeline_preprocessing_orchestrator', orchestrator)
+            orchestrator = PipelinePreprocessingOrchestrator(
+                device=stream.device, dtype=stream.dtype, max_workers=4, pipeline_ref=stream
+            )
+            setattr(stream, "pipeline_preprocessing_orchestrator", orchestrator)
         self._pipeline_preprocessing_orchestrator = orchestrator
-
-

--- a/src/streamdiffusion/preprocessing/pipeline_preprocessing_orchestrator.py
+++ b/src/streamdiffusion/preprocessing/pipeline_preprocessing_orchestrator.py
@@ -1,32 +1,42 @@
-import torch
-from typing import List, Dict, Any, Optional
 import logging
+from typing import Any, Dict, List, Optional
+
+import torch
+
 from .base_orchestrator import BaseOrchestrator
 
+
 logger = logging.getLogger(__name__)
+
 
 class PipelinePreprocessingOrchestrator(BaseOrchestrator[torch.Tensor, torch.Tensor]):
     """
     Orchestrates pipeline input preprocessing with parallelization and pipelining.
-    
+
     Handles preprocessing of input tensors before they enter the diffusion pipeline.
-    
+
     Tensor ranges:
     - Input: Receives [-1, 1] tensors from image_processor.preprocess()
     - Processors: Work in [-1, 1] space when normalization_context='pipeline'
     - Output: Returns [-1, 1] tensors for pipeline processing
-    
+
     Note: Processors created with normalization_context='pipeline' expect and preserve
     [-1, 1] range. No automatic conversion happens in this orchestrator.
     """
-    
-    def __init__(self, device: str = "cuda", dtype: torch.dtype = torch.float16, max_workers: int = 4, pipeline_ref: Optional[Any] = None):
+
+    def __init__(
+        self,
+        device: str = "cuda",
+        dtype: torch.dtype = torch.float16,
+        max_workers: int = 4,
+        pipeline_ref: Optional[Any] = None,
+    ):
         # Pipeline preprocessing: 10ms timeout for responsive processing
         super().__init__(device, dtype, max_workers, timeout_ms=10.0, pipeline_ref=pipeline_ref)
-        
+
         # Pipeline preprocessing specific state
         self._current_input_tensor = None  # For BaseOrchestrator fallback logic
-    
+
     def _should_use_sync_processing(self, *args, **kwargs) -> bool:
         """
         Determine if synchronous processing should be used instead of pipelined.
@@ -44,123 +54,102 @@ class PipelinePreprocessingOrchestrator(BaseOrchestrator[torch.Tensor, torch.Ten
         if not processors:
             return False
         for proc in processors:
-            if proc is not None and getattr(proc, 'requires_sync_processing', False):
+            if proc is not None and getattr(proc, "requires_sync_processing", False):
                 return True
         return False
-    
-    def process_pipelined(self, 
-                        input_tensor: torch.Tensor,
-                        processors: List[Any],
-                        *args, **kwargs) -> torch.Tensor:
+
+    def process_pipelined(self, input_tensor: torch.Tensor, processors: List[Any], *args, **kwargs) -> torch.Tensor:
         """
         Process input with intelligent pipelining.
-        
+
         Overrides base method to store current input tensor for fallback logic.
         """
         # Store current input for fallback logic
         self._current_input_tensor = input_tensor
-        
+
         # RACE CONDITION FIX: Check if there are actually enabled processors
         # Filter to only enabled processors (same logic as _get_ordered_processors)
-        enabled_processors = [p for p in processors if getattr(p, 'enabled', True)] if processors else []
-        
+        enabled_processors = [p for p in processors if getattr(p, "enabled", True)] if processors else []
+
         if not enabled_processors:
             return input_tensor
-        
+
         # Call parent implementation
         return super().process_pipelined(input_tensor, processors, *args, **kwargs)
-    
-    def process_sync(self, 
-                   input_tensor: torch.Tensor,
-                   processors: List[Any]) -> torch.Tensor:
+
+    def process_sync(self, input_tensor: torch.Tensor, processors: List[Any]) -> torch.Tensor:
         """
         Process pipeline input tensor synchronously through preprocessors.
-        
+
         Implementation of BaseOrchestrator.process_sync for pipeline preprocessing.
-        
+
         Args:
             input_tensor: Input tensor to preprocess (already normalized)
             processors: List of preprocessor instances
-            
+
         Returns:
             Preprocessed tensor ready for pipeline processing
         """
         if not processors:
             return input_tensor
-        
+
         # Sequential application of processors
         current_tensor = input_tensor
         for processor in processors:
             if processor is not None:
                 current_tensor = self._apply_single_processor(current_tensor, processor)
-        
+
         return current_tensor
-    
-    def _process_frame_background(self, 
-                                input_tensor: torch.Tensor,
-                                processors: List[Any]) -> Dict[str, Any]:
+
+    def _process_frame_background(self, input_tensor: torch.Tensor, processors: List[Any]) -> Dict[str, Any]:
         """
         Process a frame in the background thread.
-        
+
         Implementation of BaseOrchestrator._process_frame_background for pipeline preprocessing.
-        
+
         Returns:
             Dictionary containing processing results and status
         """
         try:
             # Set CUDA stream for background processing
             original_stream = self._set_background_stream_context()
-            
+
             if not processors:
-                return {
-                    'result': input_tensor,
-                    'status': 'success'
-                }
-            
+                return {"result": input_tensor, "status": "success"}
+
             # Process processors sequentially (most pipeline preprocessing is dependent)
             current_tensor = input_tensor
             for processor in processors:
                 if processor is not None:
                     current_tensor = self._apply_single_processor(current_tensor, processor)
-            
-            return {
-                'result': current_tensor,
-                'status': 'success'
-            }
-            
+
+            return {"result": current_tensor, "status": "success"}
+
         except Exception as e:
             logger.error(f"PipelinePreprocessingOrchestrator: Background processing failed: {e}")
             # Return original input tensor on error
-            return {
-                'result': input_tensor,
-                'error': str(e),
-                'status': 'error'
-            }
+            return {"result": input_tensor, "error": str(e), "status": "error"}
         finally:
             # Restore original CUDA stream
             self._restore_stream_context(original_stream)
-    
-    
-    
-    def _apply_single_processor(self, 
-                              input_tensor: torch.Tensor, 
-                              processor: Any) -> torch.Tensor:
+
+    def _apply_single_processor(self, input_tensor: torch.Tensor, processor: Any) -> torch.Tensor:
         """
         Apply a single processor to the input tensor.
-        
+
         Args:
             input_tensor: Input tensor to process
             processor: Processor instance
-            
+
         Returns:
             Processed tensor
         """
         try:
             # Apply processor
-            if hasattr(processor, 'process_tensor'):
+            if hasattr(processor, "process_tensor"):
                 # Prefer tensor processing method
                 result = processor.process_tensor(input_tensor)
-            elif hasattr(processor, 'process'):
+            elif hasattr(processor, "process"):
                 # Use general process method
                 result = processor.process(input_tensor)
             elif callable(processor):
@@ -169,18 +158,18 @@ class PipelinePreprocessingOrchestrator(BaseOrchestrator[torch.Tensor, torch.Ten
             else:
                 logger.warning(f"PipelinePreprocessingOrchestrator: Unknown processor type: {type(processor)}")
                 return input_tensor
-            
+
             # Ensure result is a tensor
             if isinstance(result, torch.Tensor):
                 return result
             else:
                 logger.warning(f"PipelinePreprocessingOrchestrator: Processor returned non-tensor: {type(result)}")
                 return input_tensor
-                
+
         except Exception as e:
             logger.error(f"PipelinePreprocessingOrchestrator: Processor failed: {e}")
             return input_tensor  # Return original on error
-    
+
     def clear_cache(self) -> None:
         """Clear preprocessing cache"""
         pass

--- a/src/streamdiffusion/preprocessing/postprocessing_orchestrator.py
+++ b/src/streamdiffusion/preprocessing/postprocessing_orchestrator.py
@@ -1,7 +1,10 @@
-import torch
-from typing import List, Optional, Union, Dict, Any
 import logging
+from typing import Any, Dict, List, Optional
+
+import torch
+
 from .base_orchestrator import BaseOrchestrator
+
 
 logger = logging.getLogger(__name__)
 
@@ -9,44 +12,49 @@ logger = logging.getLogger(__name__)
 class PostprocessingOrchestrator(BaseOrchestrator[torch.Tensor, torch.Tensor]):
     """
     Orchestrates postprocessing with parallelization and pipelining.
-    
+
     Handles super-resolution, enhancement, style transfer, and other postprocessing operations
     that are applied to generated images after diffusion.
     """
-    
-    def __init__(self, device: str = "cuda", dtype: torch.dtype = torch.float16, max_workers: int = 4, pipeline_ref: Optional[Any] = None):
+
+    def __init__(
+        self,
+        device: str = "cuda",
+        dtype: torch.dtype = torch.float16,
+        max_workers: int = 4,
+        pipeline_ref: Optional[Any] = None,
+    ):
         # Postprocessing: 50ms timeout for quality-critical operations like upscaling
         super().__init__(device, dtype, max_workers, timeout_ms=20.0, pipeline_ref=pipeline_ref)
-        
+
         # Postprocessing-specific state
-        self._last_input_tensor = None
+        # Cache uses data_ptr + shape for O(1) identity check instead of torch.equal (O(N))
+        self._last_input_ptr = None
+        self._last_input_shape = None
         self._last_processed_result = None
         self._current_input_tensor = None  # For BaseOrchestrator fallback logic
-        
 
-    
-    def process_pipelined(self, 
-                        input_tensor: torch.Tensor,
-                        postprocessors: List[Any],
-                        *args, **kwargs) -> torch.Tensor:
+    def process_pipelined(
+        self, input_tensor: torch.Tensor, postprocessors: List[Any], *args, **kwargs
+    ) -> torch.Tensor:
         """
         Process input with intelligent pipelining.
-        
+
         Overrides base method to store current input tensor for fallback logic.
         """
         # Store current input for fallback logic
         self._current_input_tensor = input_tensor
-        
+
         # RACE CONDITION FIX: Check if there are actually enabled processors
         # Filter to only enabled processors (same logic as _get_ordered_processors)
-        enabled_processors = [p for p in postprocessors if getattr(p, 'enabled', True)] if postprocessors else []
-        
+        enabled_processors = [p for p in postprocessors if getattr(p, "enabled", True)] if postprocessors else []
+
         if not enabled_processors:
             return input_tensor
-        
+
         # Call parent implementation
         return super().process_pipelined(input_tensor, postprocessors, *args, **kwargs)
-    
+
     def _should_use_sync_processing(self, *args, **kwargs) -> bool:
         """
         Determine if synchronous processing should be used instead of pipelined.
@@ -68,25 +76,22 @@ class PostprocessingOrchestrator(BaseOrchestrator[torch.Tensor, torch.Tensor]):
             if proc is not None and getattr(proc, 'requires_sync_processing', False):
                 return True
         return False
-    
-    def process_sync(self, 
-                   input_tensor: torch.Tensor,
-                   postprocessors: List[Any],
-                   *args, **kwargs) -> torch.Tensor:
+
+    def process_sync(self, input_tensor: torch.Tensor, postprocessors: List[Any], *args, **kwargs) -> torch.Tensor:
         """
         Process tensor through postprocessors synchronously.
-        
+
         Args:
             input_tensor: Input tensor to postprocess (typically from diffusion output)
             postprocessors: List of postprocessor instances
             *args, **kwargs: Additional arguments for postprocessors
-            
+
         Returns:
             Postprocessed tensor
         """
         if not postprocessors:
             return input_tensor
-        
+
         # Use same stream context as background processing for consistency
         original_stream = self._set_background_stream_context()
         try:
@@ -95,92 +100,83 @@ class PostprocessingOrchestrator(BaseOrchestrator[torch.Tensor, torch.Tensor]):
             for postprocessor in postprocessors:
                 if postprocessor is not None:
                     current_tensor = self._apply_single_postprocessor(current_tensor, postprocessor)
-            
+
             return current_tensor
         finally:
             self._restore_stream_context(original_stream)
-    
-    def _process_frame_background(self, 
-                                input_tensor: torch.Tensor,
-                                postprocessors: List[Any],
-                                *args, **kwargs) -> Dict[str, Any]:
+
+    def _process_frame_background(
+        self, input_tensor: torch.Tensor, postprocessors: List[Any], *args, **kwargs
+    ) -> Dict[str, Any]:
         """
         Process a frame in the background thread.
-        
+
         Implementation of BaseOrchestrator._process_frame_background for postprocessing.
-        
+
         Returns:
             Dictionary containing processing results and status
         """
         try:
             # Set CUDA stream for background processing
             original_stream = self._set_background_stream_context()
-            
+
             if not postprocessors:
-                return {
-                    'result': input_tensor,
-                    'status': 'success'
-                }
-            
-            # Check for cache hit (same input tensor)
-            cache_hit = False
-            if (self._last_input_tensor is not None and self._last_processed_result is not None):
-                if input_tensor.device == self._last_input_tensor.device:
-                    # Same device - direct comparison
-                    cache_hit = torch.equal(input_tensor, self._last_input_tensor)
-                else:
-                    # Different devices - move cached tensor to input device for comparison
-                    cached_on_input_device = self._last_input_tensor.to(device=input_tensor.device, dtype=input_tensor.dtype)
-                    cache_hit = torch.equal(input_tensor, cached_on_input_device)
-            
+                return {"result": input_tensor, "status": "success"}
+
+            # Check for cache hit using data_ptr + shape — O(1) vs torch.equal's O(N).
+            # TRT engines reuse the same output buffer each frame, so data_ptr identity
+            # reliably detects whether the input is the same buffer as last frame.
+            cache_hit = (
+                self._last_input_ptr is not None
+                and self._last_processed_result is not None
+                and input_tensor.data_ptr() == self._last_input_ptr
+                and input_tensor.shape == self._last_input_shape
+            )
+
             if cache_hit:
                 return {
-                    'result': self._last_processed_result,  # Return previously processed result
-                    'status': 'success',
-                    'cache_hit': True
+                    "result": self._last_processed_result,
+                    "status": "success",
+                    "cache_hit": True,
                 }
-            
-            # Update cache with current input tensor
-            self._last_input_tensor = input_tensor.clone()
-            
+
+            # Update cache — store ptr + shape, no tensor clone needed
+            self._last_input_ptr = input_tensor.data_ptr()
+            self._last_input_shape = input_tensor.shape
+
             # Process postprocessors in parallel if multiple, sequential if single
             if len(postprocessors) > 1:
                 result = self._process_postprocessors_parallel(input_tensor, postprocessors)
             else:
                 result = self._apply_single_postprocessor(input_tensor, postprocessors[0])
-            
+
             # Cache the processed result for future cache hits
             self._last_processed_result = result
-            
-            return {
-                'result': result,
-                'status': 'success'
-            }
-            
+
+            return {"result": result, "status": "success"}
+
         except Exception as e:
             logger.error(f"PostprocessingOrchestrator: Background processing failed: {e}")
             return {
-                'result': input_tensor,  # Return original on error
-                'error': str(e),
-                'status': 'error'
+                "result": input_tensor,  # Return original on error
+                "error": str(e),
+                "status": "error",
             }
         finally:
             # Restore original CUDA stream
             self._restore_stream_context(original_stream)
-        
-    def _process_postprocessors_parallel(self, 
-                                       input_tensor: torch.Tensor, 
-                                       postprocessors: List[Any]) -> torch.Tensor:
+
+    def _process_postprocessors_parallel(self, input_tensor: torch.Tensor, postprocessors: List[Any]) -> torch.Tensor:
         """
         Process multiple postprocessors in parallel.
-        
+
         Note: This applies postprocessors sequentially for now, but could be extended
         to support parallel processing for independent postprocessors in the future.
-        
+
         Args:
             input_tensor: Input tensor to process
             postprocessors: List of postprocessor instances
-            
+
         Returns:
             Processed tensor
         """
@@ -190,37 +186,37 @@ class PostprocessingOrchestrator(BaseOrchestrator[torch.Tensor, torch.Tensor]):
         for postprocessor in postprocessors:
             if postprocessor is not None:
                 current_tensor = self._apply_single_postprocessor(current_tensor, postprocessor)
-        
+
         return current_tensor
-    
-    def _apply_single_postprocessor(self, 
-                                  input_tensor: torch.Tensor, 
-                                  postprocessor: Any) -> torch.Tensor:
+
+    def _apply_single_postprocessor(self, input_tensor: torch.Tensor, postprocessor: Any) -> torch.Tensor:
         """
         Apply a single postprocessor to the input tensor.
-        
-        Handles normalization conversion between VAE output range [-1,1] and 
+
+        Handles normalization conversion between VAE output range [-1,1] and
         processor input range [0,1], then converts back to VAE range.
-        
+
         Args:
             input_tensor: Input tensor from VAE (range [-1,1])
             postprocessor: Postprocessor instance
-            
+
         Returns:
             Processed tensor in VAE range [-1,1]
         """
         try:
             # Ensure tensor is on correct device and dtype
             processed_tensor = input_tensor.to(device=self.device, dtype=self.dtype)
-            
-            logger.debug(f"_apply_single_postprocessor: Converting tensor from VAE range [-1,1] to processor range [0,1]")
+
+            logger.debug(
+                "_apply_single_postprocessor: Converting tensor from VAE range [-1,1] to processor range [0,1]"
+            )
             processor_input = (processed_tensor / 2.0 + 0.5).clamp(0, 1)
-            
+
             # Apply postprocessor
-            if hasattr(postprocessor, 'process_tensor'):
+            if hasattr(postprocessor, "process_tensor"):
                 # Prefer tensor processing if available
                 processor_output = postprocessor.process_tensor(processor_input)
-            elif hasattr(postprocessor, 'process'):
+            elif hasattr(postprocessor, "process"):
                 # Fallback to general process method
                 processor_output = postprocessor.process(processor_input)
             elif callable(postprocessor):
@@ -229,25 +225,28 @@ class PostprocessingOrchestrator(BaseOrchestrator[torch.Tensor, torch.Tensor]):
             else:
                 logger.warning(f"PostprocessingOrchestrator: Unknown postprocessor type: {type(postprocessor)}")
                 return processed_tensor
-            
+
             # Ensure result is a tensor
             if isinstance(processor_output, torch.Tensor):
                 # CRITICAL: Convert back from processor output range [0,1] to VAE input range [-1,1]
-                logger.debug(f"_apply_single_postprocessor: Converting result from processor range [0,1] back to VAE range [-1,1]")
+                logger.debug(
+                    "_apply_single_postprocessor: Converting result from processor range [0,1] back to VAE range [-1,1]"
+                )
                 result = (processor_output - 0.5) * 2.0  # Convert [0,1] -> [-1,1]
-                
+
                 return result.to(device=self.device, dtype=self.dtype)
             else:
-                logger.warning(f"PostprocessingOrchestrator: Postprocessor returned non-tensor: {type(processor_output)}")
+                logger.warning(
+                    f"PostprocessingOrchestrator: Postprocessor returned non-tensor: {type(processor_output)}"
+                )
                 return processed_tensor
-                
+
         except Exception as e:
             logger.error(f"PostprocessingOrchestrator: Postprocessor failed: {e}")
             return input_tensor  # Return original on error
-    
+
     def clear_cache(self) -> None:
         """Clear postprocessing cache"""
-        self._last_input_tensor = None
+        self._last_input_ptr = None
+        self._last_input_shape = None
         self._last_processed_result = None
-    
-

--- a/src/streamdiffusion/preprocessing/postprocessing_orchestrator.py
+++ b/src/streamdiffusion/preprocessing/postprocessing_orchestrator.py
@@ -73,7 +73,7 @@ class PostprocessingOrchestrator(BaseOrchestrator[torch.Tensor, torch.Tensor]):
         if not processors:
             return False
         for proc in processors:
-            if proc is not None and getattr(proc, 'requires_sync_processing', False):
+            if proc is not None and getattr(proc, "requires_sync_processing", False):
                 return True
         return False
 

--- a/src/streamdiffusion/preprocessing/preprocessing_orchestrator.py
+++ b/src/streamdiffusion/preprocessing/preprocessing_orchestrator.py
@@ -1,12 +1,14 @@
-import torch
-from typing import List, Optional, Union, Dict, Any, Tuple, Callable
-from PIL import Image
-import numpy as np
-import concurrent.futures
 import logging
-from diffusers.utils import load_image
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import torch
 import torchvision.transforms as transforms
+from diffusers.utils import load_image
+from PIL import Image
+
 from .base_orchestrator import BaseOrchestrator
+
 
 logger = logging.getLogger(__name__)
 
@@ -17,40 +19,45 @@ ControlImage = Union[str, Image.Image, np.ndarray, torch.Tensor]
 class PreprocessingOrchestrator(BaseOrchestrator[ControlImage, List[Optional[torch.Tensor]]]):
     """
     Orchestrates module preprocessing with typical orchestrator pipelining, but with additional intraframe parallelization, caching, and optimization.
-    Modules (IPAdapter, Controlnet) share intraframe parallelism. 
+    Modules (IPAdapter, Controlnet) share intraframe parallelism.
     Handles image format conversion (while most are GPU native,some preprocessors are CPU only), preprocessor execution, and result caching.
     """
-    
-    def __init__(self, device: str = "cuda", dtype: torch.dtype = torch.float16, max_workers: int = 4, pipeline_ref: Optional[Any] = None):
+
+    def __init__(
+        self,
+        device: str = "cuda",
+        dtype: torch.dtype = torch.float16,
+        max_workers: int = 4,
+        pipeline_ref: Optional[Any] = None,
+    ):
         # Preprocessing: 10ms timeout for fast frame-skipping behavior
         super().__init__(device, dtype, max_workers, timeout_ms=10.0, pipeline_ref=pipeline_ref)
-        
+
         # Caching
         self._preprocessed_cache: Dict[str, torch.Tensor] = {}
         self._last_input_frame = None
-        
+
         # Optimized transforms
         self._cached_transform = transforms.ToTensor()
-        
+
         # Cache pipelining decision to avoid hot path checks
         self._preprocessors_cache_key = None
         self._has_feedback_cache = False
-        
 
-        
-    
-    #Abstract method implementations
-    def process_sync(self, 
-                   control_image: ControlImage,
-                   preprocessors: List[Optional[Any]],
-                   scales: List[float] = None,
-                   stream_width: int = None,
-                   stream_height: int = None,
-                   index: Optional[int] = None,
-                   processing_type: str = "controlnet") -> Union[List[Optional[torch.Tensor]], List[Tuple[torch.Tensor, torch.Tensor]]]:
+    # Abstract method implementations
+    def process_sync(
+        self,
+        control_image: ControlImage,
+        preprocessors: List[Optional[Any]],
+        scales: List[float] = None,
+        stream_width: int = None,
+        stream_height: int = None,
+        index: Optional[int] = None,
+        processing_type: str = "controlnet",
+    ) -> Union[List[Optional[torch.Tensor]], List[Tuple[torch.Tensor, torch.Tensor]]]:
         """
         Process images synchronously for ControlNet or IPAdapter preprocessing.
-        
+
         Args:
             control_image: Input image to process
             preprocessors: List of preprocessor instances
@@ -59,7 +66,7 @@ class PreprocessingOrchestrator(BaseOrchestrator[ControlImage, List[Optional[tor
             stream_height: Target height for processing
             index: If specified, only process this single ControlNet index (ControlNet only)
             processing_type: "controlnet" or "ipadapter" to specify processing mode
-            
+
         Returns:
             ControlNet: List of processed tensors for each ControlNet
             IPAdapter: List of (positive_embeds, negative_embeds) tuples
@@ -80,410 +87,390 @@ class PreprocessingOrchestrator(BaseOrchestrator[ControlImage, List[Optional[tor
             )
         else:
             raise ValueError(f"Invalid processing_type: {processing_type}. Must be 'controlnet' or 'ipadapter'")
-    
+
     def _should_use_sync_processing(self, *args, **kwargs) -> bool:
         """
         Check for pipeline-aware preprocessors that require sync processing.
-        
-        Pipeline-aware preprocessors (feedback, temporal, etc.) need synchronous processing 
+
+        Pipeline-aware preprocessors (feedback, temporal, etc.) need synchronous processing
         to avoid temporal artifacts and ensure access to previous pipeline outputs.
-        
+
         Args:
             *args: Arguments from process_pipelined call (preprocessors, scales, stream_width, stream_height)
             **kwargs: Keyword arguments
-            
+
         Returns:
             True if pipeline-aware preprocessors detected, False otherwise
         """
         # Extract preprocessors from args - they're the first argument after control_image
         if len(args) < 1:
             return False
-        
+
         preprocessors = args[0]  # preprocessors is first arg after control_image
         return self._check_pipeline_aware_cached(preprocessors)
 
-    def _process_frame_background(self, 
-                                control_image: ControlImage,
-                                *args, **kwargs) -> Dict[str, Any]:
+    def _process_frame_background(self, control_image: ControlImage, *args, **kwargs) -> Dict[str, Any]:
         """
         Process a frame in the background thread.
-        
+
         Implementation of BaseOrchestrator._process_frame_background for ControlNet preprocessing.
         Automatically detects processing mode based on current state.
-        
+
         Returns:
             Dictionary containing processing results and status
         """
         try:
             # Set CUDA stream for background processing
             original_stream = self._set_background_stream_context()
-            
+
             # Check if last argument is "ipadapter" processing type
             if args and len(args) >= 5 and args[4] == "ipadapter":
                 # Handle embedding preprocessing
                 embedding_preprocessors = args[0]
-                stream_width = args[2]  
+                stream_width = args[2]
                 stream_height = args[3]
-                
+
                 # Prepare processing data
                 control_variants = self._prepare_input_variants(control_image, thread_safe=True)
-                
+
                 # Process using existing IPAdapter logic
                 try:
                     results = self._process_ipadapter_preprocessors_parallel(
                         embedding_preprocessors, control_variants, stream_width, stream_height
                     )
-                    return {
-                        'results': results,
-                        'status': 'success'
-                    }
+                    return {"results": results, "status": "success"}
                 except Exception as e:
                     import traceback
+
                     traceback.print_exc()
-                    return {
-                        'error': str(e),
-                        'status': 'error'
-                    }
-            elif hasattr(self, '_current_processing_mode') and self._current_processing_mode == "embedding":
+                    return {"error": str(e), "status": "error"}
+            elif hasattr(self, "_current_processing_mode") and self._current_processing_mode == "embedding":
                 # Handle embedding preprocessing (legacy path)
                 embedding_preprocessors = args[0]
-                stream_width = args[2]  
+                stream_width = args[2]
                 stream_height = args[3]
-                
+
                 # Prepare processing data
                 control_variants = self._prepare_input_variants(control_image, thread_safe=True)
-                
+
                 # Process using existing IPAdapter logic
                 try:
                     results = self._process_ipadapter_preprocessors_parallel(
                         embedding_preprocessors, control_variants, stream_width, stream_height
                     )
-                    return {
-                        'results': results,
-                        'status': 'success'
-                    }
+                    return {"results": results, "status": "success"}
                 except Exception as e:
                     import traceback
+
                     traceback.print_exc()
-                    return {
-                        'error': str(e),
-                        'status': 'error'
-                    }
+                    return {"error": str(e), "status": "error"}
             else:
                 # Handle ControlNet preprocessing (default mode)
                 preprocessors = args[0]
                 scales = args[1]
                 stream_width = args[2]
                 stream_height = args[3]
-                
+
                 # Check if any processing is needed
                 if not any(scale > 0 for scale in scales):
-                    return {'status': 'success', 'results': [None] * len(preprocessors)}
-                #TODO: can we reuse similarity filter here?
-                if (self._last_input_frame is not None and 
-                    isinstance(control_image, (torch.Tensor, np.ndarray, Image.Image)) and 
-                    control_image is self._last_input_frame):
-                    return {'status': 'success', 'results': []}  # Signal no update needed
-                
+                    return {"status": "success", "results": [None] * len(preprocessors)}
+                # TODO: can we reuse similarity filter here?
+                if (
+                    self._last_input_frame is not None
+                    and isinstance(control_image, (torch.Tensor, np.ndarray, Image.Image))
+                    and control_image is self._last_input_frame
+                ):
+                    return {"status": "success", "results": []}  # Signal no update needed
+
                 self._last_input_frame = control_image
-                
+
                 # Prepare processing data
                 preprocessor_groups = self._group_preprocessors(preprocessors, scales)
                 active_indices = [i for i, scale in enumerate(scales) if scale > 0]
-                
+
                 if not active_indices:
-                    return {'status': 'success', 'results': [None] * len(preprocessors)}
-                
+                    return {"status": "success", "results": [None] * len(preprocessors)}
+
                 # Optimize input preparation
                 control_variants = self._prepare_input_variants(control_image, thread_safe=True)
-                
+
                 # Process using unified parallel logic
                 processed_images = self._process_controlnet_preprocessors_parallel(
                     preprocessor_groups, control_variants, stream_width, stream_height, preprocessors
                 )
-                
-                return {
-                    'results': processed_images,
-                    'status': 'success'
-                }
-                
+
+                return {"results": processed_images, "status": "success"}
+
         except Exception as e:
             logger.error(f"PreprocessingOrchestrator: Background processing failed: {e}")
-            return {
-                'error': str(e),
-                'status': 'error'
-            }
+            return {"error": str(e), "status": "error"}
         finally:
             # Restore original CUDA stream
             self._restore_stream_context(original_stream)
-    
-    def _apply_current_frame_processing(self, 
-                                      preprocessors: List[Optional[Any]] = None,
-                                      scales: List[float] = None, 
-                                      *args, **kwargs) -> List[Optional[torch.Tensor]]:
+
+    def _apply_current_frame_processing(
+        self, preprocessors: List[Optional[Any]] = None, scales: List[float] = None, *args, **kwargs
+    ) -> List[Optional[torch.Tensor]]:
         """
         Apply processing results from previous iteration.
-        
+
         Overrides BaseOrchestrator._apply_current_frame_processing for module preprocessing.
-        
+
         Returns:
             List of processed tensors, or empty list to signal no update needed
         """
-        if not hasattr(self, '_next_frame_result') or self._next_frame_result is None:
+        if not hasattr(self, "_next_frame_result") or self._next_frame_result is None:
             # Return empty list to signal no update needed
             return []
-        
+
         # Handle case where preprocessors is None
         if preprocessors is None:
             return []
-        
+
         processed_images = [None] * len(preprocessors)
-        
+
         result = self._next_frame_result
-        if result['status'] != 'success':
+        if result["status"] != "success":
             # Return empty list to signal no update needed on error
             return []
-        
+
         # Handle case where no update is needed (cached input)
-        if 'results' in result and len(result['results']) == 0:
+        if "results" in result and len(result["results"]) == 0:
             return []
-        
+
         # Get the processed results directly
-        processed_images = result.get('results', [])
+        processed_images = result.get("results", [])
         if not processed_images:
             return []
-        
+
         return processed_images
-    
-    #Controlnet methods
-    def prepare_control_image(self,
-                            control_image: Union[str, Image.Image, np.ndarray, torch.Tensor],
-                            preprocessor: Optional[Any],
-                            target_width: int,
-                            target_height: int) -> torch.Tensor:
+
+    # Controlnet methods
+    def prepare_control_image(
+        self,
+        control_image: Union[str, Image.Image, np.ndarray, torch.Tensor],
+        preprocessor: Optional[Any],
+        target_width: int,
+        target_height: int,
+    ) -> torch.Tensor:
         """
         Prepare a single control image for ControlNet input with format conversion and preprocessing.
-        
+
         Args:
             control_image: Input image in various formats
             preprocessor: Optional preprocessor to apply
             target_width: Target width for the output tensor
             target_height: Target height for the output tensor
-            
+
         Returns:
             Processed tensor ready for ControlNet
         """
         # Load image if path
         if isinstance(control_image, str):
             control_image = load_image(control_image)
-        
+
         # Fast tensor processing path
         if isinstance(control_image, torch.Tensor):
             return self._process_tensor_input(control_image, preprocessor, target_width, target_height)
-        
+
         # Apply preprocessor to non-tensor inputs
         if preprocessor is not None:
             control_image = preprocessor.process(control_image)
-        
+
         # Convert to tensor
         return self._convert_to_tensor(control_image, target_width, target_height)
-     
-    def _process_multiple_controlnets_sync(self,
-                                         control_image: Union[str, Image.Image, np.ndarray, torch.Tensor],
-                                         preprocessors: List[Optional[Any]],
-                                         scales: List[float],
-                                         stream_width: int,
-                                         stream_height: int) -> List[Optional[torch.Tensor]]:
+
+    def _process_multiple_controlnets_sync(
+        self,
+        control_image: Union[str, Image.Image, np.ndarray, torch.Tensor],
+        preprocessors: List[Optional[Any]],
+        scales: List[float],
+        stream_width: int,
+        stream_height: int,
+    ) -> List[Optional[torch.Tensor]]:
         """Process multiple ControlNets synchronously with parallel execution"""
         # Check if any processing is needed
         if not any(scale > 0 for scale in scales):
             return [None] * len(preprocessors)
-        
-        #TODO: can we reuse similarity filter here?
+
+        # TODO: can we reuse similarity filter here?
         # Check cache for same input - return early without changing anything
-        if (self._last_input_frame is not None and 
-            isinstance(control_image, (torch.Tensor, np.ndarray, Image.Image)) and 
-            control_image is self._last_input_frame):
+        if (
+            self._last_input_frame is not None
+            and isinstance(control_image, (torch.Tensor, np.ndarray, Image.Image))
+            and control_image is self._last_input_frame
+        ):
             # Return empty list to signal no update needed
             return []
-        
+
         self._last_input_frame = control_image
         self.clear_cache()
-        
+
         # Prepare input variants for optimal processing
         control_variants = self._prepare_input_variants(control_image, stream_width, stream_height)
-        
+
         # Group preprocessors to avoid duplicate work
         preprocessor_groups = self._group_preprocessors(preprocessors, scales)
-        
+
         if not preprocessor_groups:
             return [None] * len(preprocessors)
-        
+
         # Process groups using parallel logic (efficient for 1 or many items)
         return self._process_controlnet_preprocessors_parallel(
             preprocessor_groups, control_variants, stream_width, stream_height, preprocessors
         )
-   
-    def _process_single_controlnet(self,
-                                 control_image: Union[str, Image.Image, np.ndarray, torch.Tensor],
-                                 preprocessors: List[Optional[Any]],
-                                 scales: List[float],
-                                 stream_width: int,
-                                 stream_height: int,
-                                 index: int) -> List[Optional[torch.Tensor]]:
+
+    def _process_single_controlnet(
+        self,
+        control_image: Union[str, Image.Image, np.ndarray, torch.Tensor],
+        preprocessors: List[Optional[Any]],
+        scales: List[float],
+        stream_width: int,
+        stream_height: int,
+        index: int,
+    ) -> List[Optional[torch.Tensor]]:
         """Process a single ControlNet by index"""
         if not (0 <= index < len(preprocessors)):
             raise IndexError(f"ControlNet index {index} out of range")
-        
+
         if scales[index] == 0:
             return [None] * len(preprocessors)
-        
+
         processed_images = [None] * len(preprocessors)
-        processed_image = self.prepare_control_image(
-            control_image, preprocessors[index], stream_width, stream_height
-        )
+        processed_image = self.prepare_control_image(control_image, preprocessors[index], stream_width, stream_height)
         processed_images[index] = processed_image
-        
+
         return processed_images
-     
-    def _process_controlnet_preprocessors_parallel(self,
-                               preprocessor_groups: Dict[str, Dict[str, Any]],
-                               control_variants: Dict[str, Any],
-                               stream_width: int,
-                               stream_height: int,
-                               preprocessors: List[Optional[Any]]) -> List[Optional[torch.Tensor]]:
+
+    def _process_controlnet_preprocessors_parallel(
+        self,
+        preprocessor_groups: Dict[str, Dict[str, Any]],
+        control_variants: Dict[str, Any],
+        stream_width: int,
+        stream_height: int,
+        preprocessors: List[Optional[Any]],
+    ) -> List[Optional[torch.Tensor]]:
         """Process ControlNet preprocessor groups in parallel"""
         futures = [
             self._executor.submit(
-                self._process_single_preprocessor_group,
-                prep_key, group, control_variants, stream_width, stream_height
+                self._process_single_preprocessor_group, prep_key, group, control_variants, stream_width, stream_height
             )
             for prep_key, group in preprocessor_groups.items()
         ]
-        
+
         processed_images = [None] * len(preprocessors)
-        
+
         for future in futures:
             result = future.result()
-            if result and result['processed_image'] is not None:
-                prep_key = result['prep_key']
-                processed_image = result['processed_image']
-                indices = result['indices']
-                
+            if result and result["processed_image"] is not None:
+                prep_key = result["prep_key"]
+                processed_image = result["processed_image"]
+                indices = result["indices"]
+
                 # Cache and assign
                 cache_key = f"prep_{prep_key}"
                 self._preprocessed_cache[cache_key] = processed_image
                 for index in indices:
                     processed_images[index] = processed_image
-        
+
         return processed_images
-    
-    #IPAdapter methods
-    def _process_multiple_ipadapters_sync(self, 
-                              control_image: ControlImage,
-                              preprocessors: List[Optional[Any]],
-                              stream_width: int,
-                              stream_height: int) -> List[Tuple[torch.Tensor, torch.Tensor]]:
+
+    # IPAdapter methods
+    def _process_multiple_ipadapters_sync(
+        self, control_image: ControlImage, preprocessors: List[Optional[Any]], stream_width: int, stream_height: int
+    ) -> List[Tuple[torch.Tensor, torch.Tensor]]:
         """
         Process IPAdapter preprocessors synchronously.
-        
+
         This is the implementation that was previously in process_ipadapter_preprocessors().
         """
         if not preprocessors:
             return []
-        
+
         # For IPAdapter preprocessing, we don't skip on cache hits - we need the actual embeddings
         # (Unlike spatial preprocessing where empty list means "no update needed")
-        
+
         # Prepare input variants for processing
         control_variants = self._prepare_input_variants(control_image, stream_width, stream_height)
-        
+
         # Process using parallel logic (efficient for 1 or many items)
         results = self._process_ipadapter_preprocessors_parallel(
             preprocessors, control_variants, stream_width, stream_height
         )
-        
+
         return results
-   
-    def _process_ipadapter_preprocessors_parallel(self,
-                                                ipadapter_preprocessors: List[Any],
-                                                control_variants: Dict[str, Any],
-                                                stream_width: int,
-                                                stream_height: int) -> List[Tuple[torch.Tensor, torch.Tensor]]:
+
+    def _process_ipadapter_preprocessors_parallel(
+        self,
+        ipadapter_preprocessors: List[Any],
+        control_variants: Dict[str, Any],
+        stream_width: int,
+        stream_height: int,
+    ) -> List[Tuple[torch.Tensor, torch.Tensor]]:
         """Process multiple IPAdapter preprocessors in parallel"""
         futures = [
             self._executor.submit(
-                self._process_single_ipadapter,
-                i, preprocessor, control_variants, stream_width, stream_height
+                self._process_single_ipadapter, i, preprocessor, control_variants, stream_width, stream_height
             )
             for i, preprocessor in enumerate(ipadapter_preprocessors)
         ]
-        
+
         results = [None] * len(ipadapter_preprocessors)
-        
+
         for future in futures:
             result = future.result()
-            if result and result['embeddings'] is not None:
-                index = result['index']
-                embeddings = result['embeddings']
+            if result and result["embeddings"] is not None:
+                index = result["index"]
+                embeddings = result["embeddings"]
                 results[index] = embeddings
-        
+
         return results
-    
-    def _process_single_ipadapter(self,
-                                             index: int,
-                                             preprocessor: Any,
-                                             control_variants: Dict[str, Any],
-                                             stream_width: int,
-                                             stream_height: int) -> Optional[Dict[str, Any]]:
+
+    def _process_single_ipadapter(
+        self, index: int, preprocessor: Any, control_variants: Dict[str, Any], stream_width: int, stream_height: int
+    ) -> Optional[Dict[str, Any]]:
         """Process a single IPAdapter preprocessor"""
         try:
             # Use tensor processing if available and input is tensor
-            if (hasattr(preprocessor, 'process_tensor') and 
-                control_variants['tensor'] is not None):
-                embeddings = preprocessor.process_tensor(control_variants['tensor'])
-                return {
-                    'index': index,
-                    'embeddings': embeddings
-                }
-            
+            if hasattr(preprocessor, "process_tensor") and control_variants["tensor"] is not None:
+                embeddings = preprocessor.process_tensor(control_variants["tensor"])
+                return {"index": index, "embeddings": embeddings}
+
             # Use PIL processing for non-tensor inputs
-            if control_variants['image'] is not None:
-                embeddings = preprocessor.process(control_variants['image'])
-                return {
-                    'index': index,
-                    'embeddings': embeddings
-                }
-            
+            if control_variants["image"] is not None:
+                embeddings = preprocessor.process(control_variants["image"])
+                return {"index": index, "embeddings": embeddings}
+
             return None
-            
-        except Exception as e:
+
+        except Exception:
             import traceback
+
             traceback.print_exc()
             return None
 
-    #Helper methods
+    # Helper methods
     def _check_pipeline_aware_cached(self, preprocessors: List[Optional[Any]]) -> bool:
         """
         Efficiently check for pipeline-aware preprocessors using caching
-        
+
         Only performs expensive isinstance checks when preprocessor list actually changes.
         """
         # Create cache key from preprocessor identities
         cache_key = tuple(id(p) for p in preprocessors)
-        
+
         # Return cached result if preprocessors haven't changed
         if cache_key == self._preprocessors_cache_key:
             return self._has_feedback_cache  # Reuse cache variable for backward compatibility
-        
+
         # Preprocessors changed - recompute and cache
         self._preprocessors_cache_key = cache_key
         self._has_feedback_cache = False
-        
+
         try:
             # Check for the mixin or class attribute first
             for prep in preprocessors:
-                if prep is not None and getattr(prep, 'requires_sync_processing', False):
+                if prep is not None and getattr(prep, "requires_sync_processing", False):
                     self._has_feedback_cache = True
                     break
         except Exception:
@@ -491,6 +478,7 @@ class PreprocessingOrchestrator(BaseOrchestrator[ControlImage, List[Optional[tor
             try:
                 from .processors.feedback import FeedbackPreprocessor
                 from .processors.temporal_net import TemporalNetPreprocessor
+
                 for prep in preprocessors:
                     if isinstance(prep, (FeedbackPreprocessor, TemporalNetPreprocessor)):
                         self._has_feedback_cache = True
@@ -500,44 +488,43 @@ class PreprocessingOrchestrator(BaseOrchestrator[ControlImage, List[Optional[tor
                 for prep in preprocessors:
                     if prep is not None:
                         class_name = prep.__class__.__name__.lower()
-                        if any(name in class_name for name in ['feedback', 'temporal']):
+                        if any(name in class_name for name in ["feedback", "temporal"]):
                             self._has_feedback_cache = True
                             break
-        
+
         return self._has_feedback_cache
 
     def clear_cache(self) -> None:
         """Clear preprocessing cache"""
         self._preprocessed_cache.clear()
         self._last_input_frame = None
-    
+
     # =========================================================================
     # Pipeline Chain Processing Methods (For Hook System Compatibility)
     # =========================================================================
-    
-    def execute_pipeline_chain(self, 
-                              input_data: torch.Tensor, 
-                              processors: List[Any],
-                              processing_domain: str = "image") -> torch.Tensor:
+
+    def execute_pipeline_chain(
+        self, input_data: torch.Tensor, processors: List[Any], processing_domain: str = "image"
+    ) -> torch.Tensor:
         """Execute ordered sequential chain of processors for pipeline hooks.
-        
+
         This method provides compatibility with the hook system modules that
         expect sequential processor execution rather than pipelined processing.
-        
+
         Args:
             input_data: Input tensor (image or latent domain)
             processors: List of processor instances to execute in sequence
             processing_domain: "image" or "latent" to determine processing path
-            
+
         Returns:
             Processed tensor in same domain as input
         """
         if not processors:
             return input_data
-            
+
         result = input_data
         ordered_processors = self._order_processors(processors)
-        
+
         for processor in ordered_processors:
             try:
                 if processing_domain == "image":
@@ -550,58 +537,58 @@ class PreprocessingOrchestrator(BaseOrchestrator[ControlImage, List[Optional[tor
                 logger.error(f"execute_pipeline_chain: Processor {type(processor).__name__} failed: {e}")
                 # Continue with next processor rather than failing entire chain
                 continue
-                
+
         return result
-    
+
     def _order_processors(self, processors: List[Any]) -> List[Any]:
         """Order processors based on their configuration.
-        
+
         Processors can define an 'order' attribute to control execution sequence.
         """
-        return sorted(processors, key=lambda p: getattr(p, 'order', 0))
-    
+        return sorted(processors, key=lambda p: getattr(p, "order", 0))
+
     def _process_image_processor_chain(self, image_tensor: torch.Tensor, processor: Any) -> torch.Tensor:
         """Process single image processor in chain, handling tensor<->PIL conversion.
-        
+
         Leverages existing format conversion and processing logic.
         """
         # Convert tensor to PIL for processor (reuse existing conversion logic)
         try:
             # Use existing tensor to PIL conversion from prepare_control_image logic
             pil_image = self._tensor_to_pil_safe(image_tensor)
-            
+
             # Process using existing processor execution pattern
-            if hasattr(processor, 'process'):
+            if hasattr(processor, "process"):
                 processed_pil = processor.process(pil_image)
             else:
                 processed_pil = processor(pil_image)
-            
+
             # Convert back to tensor (reuse existing PIL to tensor logic)
             result_tensor = self._pil_to_tensor_safe(processed_pil, image_tensor.device, image_tensor.dtype)
             return result_tensor
-            
+
         except Exception as e:
             logger.error(f"_process_image_processor_chain: Failed processing {type(processor).__name__}: {e}")
             return image_tensor  # Return input unchanged on failure
-    
+
     def _process_latent_processor_chain(self, latent_tensor: torch.Tensor, processor: Any) -> torch.Tensor:
         """Process single latent processor in chain.
-        
+
         Direct tensor processing - no format conversion needed for latent domain.
         """
         try:
             # Latent processors work directly on tensors
-            if hasattr(processor, 'process_tensor'):
+            if hasattr(processor, "process_tensor"):
                 return processor.process_tensor(latent_tensor)
-            elif hasattr(processor, 'process'):
+            elif hasattr(processor, "process"):
                 return processor.process(latent_tensor)
             else:
                 return processor(latent_tensor)
-                
+
         except Exception as e:
             logger.error(f"_process_latent_processor_chain: Failed processing {type(processor).__name__}: {e}")
             return latent_tensor  # Return input unchanged on failure
-    
+
     def _tensor_to_pil_safe(self, tensor: torch.Tensor) -> Image.Image:
         """Convert tensor to PIL Image safely (reuse existing conversion logic)."""
         # Leverage existing tensor conversion from prepare_control_image
@@ -610,50 +597,48 @@ class PreprocessingOrchestrator(BaseOrchestrator[ControlImage, List[Optional[tor
         if tensor.dim() == 3 and tensor.shape[0] == 3:
             # Convert from CHW to HWC
             tensor = tensor.permute(1, 2, 0)
-        
+
         # CRITICAL FIX: Handle VAE output range [-1, 1] -> [0, 1] -> [0, 255]
         # VAE decode_image() outputs in [-1, 1] range, need to convert to [0, 1] first
         if tensor.min() < 0:
-            logger.debug(f"_tensor_to_pil_safe: Converting from VAE range [-1, 1] to [0, 1]")
+            logger.debug("_tensor_to_pil_safe: Converting from VAE range [-1, 1] to [0, 1]")
             tensor = (tensor / 2.0 + 0.5).clamp(0, 1)  # Convert [-1, 1] -> [0, 1]
-        
+
         # Ensure proper range [0, 1] -> [0, 255]
         if tensor.max() <= 1.0:
             tensor = tensor * 255.0
-        
+
         # Convert to numpy and then PIL
         numpy_image = tensor.detach().cpu().numpy().astype(np.uint8)
         return Image.fromarray(numpy_image)
-    
+
     def _pil_to_tensor_safe(self, pil_image: Image.Image, device: str, dtype: torch.dtype) -> torch.Tensor:
         """Convert PIL Image to tensor safely (reuse existing conversion logic)."""
         # Convert PIL to numpy
         numpy_image = np.array(pil_image)
-        
+
         # Convert to tensor and normalize to [0, 1]
         tensor = torch.from_numpy(numpy_image).float() / 255.0
-        
+
         # Convert HWC to CHW
         if tensor.dim() == 3:
             tensor = tensor.permute(2, 0, 1)
-        
+
         # Add batch dimension and move to device
         tensor = tensor.unsqueeze(0).to(device=device, dtype=dtype)
-        
+
         # CRITICAL: Convert back to VAE input range [-1, 1] for postprocessing
         # VAE expects inputs in [-1, 1] range, so convert [0, 1] -> [-1, 1]
         tensor = (tensor - 0.5) * 2.0  # Convert [0, 1] -> [-1, 1]
-        
+
         return tensor
-    
-    def _process_tensor_input(self,
-                            control_tensor: torch.Tensor,
-                            preprocessor: Optional[Any],
-                            target_width: int,
-                            target_height: int) -> torch.Tensor:
+
+    def _process_tensor_input(
+        self, control_tensor: torch.Tensor, preprocessor: Optional[Any], target_width: int, target_height: int
+    ) -> torch.Tensor:
         """Process tensor input with GPU acceleration when possible"""
         # Fast path for tensor input with GPU preprocessor
-        if preprocessor is not None and hasattr(preprocessor, 'process_tensor'):
+        if preprocessor is not None and hasattr(preprocessor, "process_tensor"):
             try:
                 processed_tensor = preprocessor.process_tensor(control_tensor)
                 # Ensure NCHW shape
@@ -662,155 +647,139 @@ class PreprocessingOrchestrator(BaseOrchestrator[ControlImage, List[Optional[tor
                 return processed_tensor.to(device=self.device, dtype=self.dtype)
             except Exception:
                 pass  # Fall through to standard processing
-        
+
         # Direct tensor passthrough (no preprocessor) - preprocessors handle their own sizing
         if preprocessor is None:
             # For passthrough, we still need basic format handling
             if control_tensor.dim() == 3:
                 control_tensor = control_tensor.unsqueeze(0)
             return control_tensor.to(device=self.device, dtype=self.dtype)
-        
+
         # Convert to PIL for preprocessor, then back to tensor
         if control_tensor.dim() == 4:
             control_tensor = control_tensor[0]
         if control_tensor.dim() == 3 and control_tensor.shape[0] in [1, 3]:
             control_tensor = control_tensor.permute(1, 2, 0)
-        
+
         if control_tensor.is_cuda:
             control_tensor = control_tensor.cpu()
-        
+
         control_array = control_tensor.numpy()
         if control_array.max() <= 1.0:
             control_array = (control_array * 255).astype(np.uint8)
-        
+
         control_image = Image.fromarray(control_array.astype(np.uint8))
         return self.prepare_control_image(control_image, preprocessor, target_width, target_height)
-     
-    def _convert_to_tensor(self,
-                         control_image: Union[Image.Image, np.ndarray],
-                         target_width: int,
-                         target_height: int) -> torch.Tensor:
+
+    def _convert_to_tensor(
+        self, control_image: Union[Image.Image, np.ndarray], target_width: int, target_height: int
+    ) -> torch.Tensor:
         """Convert PIL Image or numpy array to tensor - preprocessors handle their own sizing"""
         # Handle PIL Images - no resizing here, preprocessors handle their target size
         if isinstance(control_image, Image.Image):
             control_tensor = self._cached_transform(control_image).unsqueeze(0)
             return control_tensor.to(device=self.device, dtype=self.dtype)
-        
+
         # Handle numpy arrays
         if isinstance(control_image, np.ndarray):
             if control_image.max() <= 1.0:
                 control_image = (control_image * 255).astype(np.uint8)
             control_image = Image.fromarray(control_image)
             return self._convert_to_tensor(control_image, target_width, target_height)
-        
+
         raise ValueError(f"Unsupported control image type: {type(control_image)}")
-    
+
     def _to_tensor_safe(self, image: Image.Image) -> torch.Tensor:
         """Thread-safe tensor conversion from PIL Image"""
         return self._cached_transform(image).unsqueeze(0).to(device=self.device, dtype=self.dtype)
-    
-    def _prepare_input_variants(self,
-                              control_image: Union[str, Image.Image, np.ndarray, torch.Tensor],
-                              stream_width: int = None,
-                              stream_height: int = None,
-                              thread_safe: bool = False) -> Dict[str, Any]:
+
+    def _prepare_input_variants(
+        self,
+        control_image: Union[str, Image.Image, np.ndarray, torch.Tensor],
+        stream_width: int = None,
+        stream_height: int = None,
+        thread_safe: bool = False,
+    ) -> Dict[str, Any]:
         """Prepare optimized input variants for different processing paths
-        
+
         Args:
             control_image: Input image in various formats
             stream_width: Target width (unused, kept for backward compatibility)
             stream_height: Target height (unused, kept for backward compatibility)
             thread_safe: If True, use thread-safe key naming for background processing
-            
+
         Returns:
             Dictionary with 'tensor' and 'image'/'image_safe' keys
         """
-        image_key = 'image_safe' if thread_safe else 'image'
-        
+        image_key = "image_safe" if thread_safe else "image"
+
         if isinstance(control_image, torch.Tensor):
             return {
-                'tensor': control_image,
-                image_key: None  # Will create if needed
+                "tensor": control_image,
+                image_key: None,  # Will create if needed
             }
         elif isinstance(control_image, Image.Image):
             image_copy = control_image.copy()
-            return {
-                image_key: image_copy,
-                'tensor': self._to_tensor_safe(image_copy)
-            }
+            return {image_key: image_copy, "tensor": self._to_tensor_safe(image_copy)}
         elif isinstance(control_image, str):
             image_loaded = load_image(control_image)
-            return {
-                image_key: image_loaded,
-                'tensor': self._to_tensor_safe(image_loaded)
-            }
+            return {image_key: image_loaded, "tensor": self._to_tensor_safe(image_loaded)}
         else:
-            return {
-                image_key: control_image,
-                'tensor': None
-            }
-    
-    def _group_preprocessors(self,
-                           preprocessors: List[Optional[Any]],
-                           scales: List[float]) -> Dict[str, Dict[str, Any]]:
+            return {image_key: control_image, "tensor": None}
+
+    def _group_preprocessors(
+        self, preprocessors: List[Optional[Any]], scales: List[float]
+    ) -> Dict[str, Dict[str, Any]]:
         """Group preprocessors by type to avoid duplicate processing"""
         preprocessor_groups = {}
-        
+
         for i, scale in enumerate(scales):
             if scale > 0:
                 preprocessor = preprocessors[i]
-                preprocessor_key = id(preprocessor) if preprocessor is not None else 'passthrough'
-                
+                preprocessor_key = id(preprocessor) if preprocessor is not None else "passthrough"
+
                 if preprocessor_key not in preprocessor_groups:
-                    preprocessor_groups[preprocessor_key] = {
-                        'preprocessor': preprocessor,
-                        'indices': []
-                    }
-                preprocessor_groups[preprocessor_key]['indices'].append(i)
-        
+                    preprocessor_groups[preprocessor_key] = {"preprocessor": preprocessor, "indices": []}
+                preprocessor_groups[preprocessor_key]["indices"].append(i)
+
         return preprocessor_groups
 
-    def _process_single_preprocessor_group(self,
-                                         prep_key: str,
-                                         group: Dict[str, Any],
-                                         control_variants: Dict[str, Any],
-                                         stream_width: int,
-                                         stream_height: int) -> Optional[Dict[str, Any]]:
+    def _process_single_preprocessor_group(
+        self,
+        prep_key: str,
+        group: Dict[str, Any],
+        control_variants: Dict[str, Any],
+        stream_width: int,
+        stream_height: int,
+    ) -> Optional[Dict[str, Any]]:
         """Process a single preprocessor group with optimal input selection"""
         try:
-            preprocessor = group['preprocessor']
-            indices = group['indices']
-            
+            preprocessor = group["preprocessor"]
+            indices = group["indices"]
+
             # Try tensor processing first (fastest path)
-            if (preprocessor is not None and 
-                hasattr(preprocessor, 'process_tensor') and 
-                control_variants['tensor'] is not None):
+            if (
+                preprocessor is not None
+                and hasattr(preprocessor, "process_tensor")
+                and control_variants["tensor"] is not None
+            ):
                 try:
                     processed_image = self.prepare_control_image(
-                        control_variants['tensor'], preprocessor, stream_width, stream_height
+                        control_variants["tensor"], preprocessor, stream_width, stream_height
                     )
-                    return {
-                        'prep_key': prep_key,
-                        'indices': indices,
-                        'processed_image': processed_image
-                    }
+                    return {"prep_key": prep_key, "indices": indices, "processed_image": processed_image}
                 except Exception:
                     pass  # Fall through to PIL processing
-            
+
             # PIL processing fallback
-            if control_variants['image'] is not None:
+            if control_variants["image"] is not None:
                 processed_image = self.prepare_control_image(
-                    control_variants['image'], preprocessor, stream_width, stream_height
+                    control_variants["image"], preprocessor, stream_width, stream_height
                 )
-                return {
-                    'prep_key': prep_key,
-                    'indices': indices,
-                    'processed_image': processed_image
-                }
-            
+                return {"prep_key": prep_key, "indices": indices, "processed_image": processed_image}
+
             return None
-            
+
         except Exception as e:
             logger.error(f"PreprocessingOrchestrator: Preprocessor {prep_key} failed: {e}")
             return None
-

--- a/src/streamdiffusion/preprocessing/processors/__init__.py
+++ b/src/streamdiffusion/preprocessing/processors/__init__.py
@@ -1,26 +1,29 @@
-from .base import BasePreprocessor, PipelineAwareProcessor
 from typing import Any
+
+from .base import BasePreprocessor, PipelineAwareProcessor
+from .blur import BlurPreprocessor
 from .canny import CannyPreprocessor
 from .depth import DepthPreprocessor
-from .openpose import OpenPosePreprocessor
-from .lineart import LineartPreprocessor
-from .standard_lineart import StandardLineartPreprocessor
-from .passthrough import PassthroughPreprocessor
 from .external import ExternalPreprocessor
-from .soft_edge import SoftEdgePreprocessor
-from .hed import HEDPreprocessor
-from .ipadapter_embedding import IPAdapterEmbeddingPreprocessor
 from .faceid_embedding import FaceIDEmbeddingPreprocessor
 from .feedback import FeedbackPreprocessor
+from .hed import HEDPreprocessor
+from .ipadapter_embedding import IPAdapterEmbeddingPreprocessor
 from .latent_feedback import LatentFeedbackPreprocessor
-from .sharpen import SharpenPreprocessor
-from .upscale import UpscalePreprocessor
-from .blur import BlurPreprocessor
+from .lineart import LineartPreprocessor
+from .openpose import OpenPosePreprocessor
+from .passthrough import PassthroughPreprocessor
 from .realesrgan_trt import RealESRGANProcessor
+from .sharpen import SharpenPreprocessor
+from .soft_edge import SoftEdgePreprocessor
+from .standard_lineart import StandardLineartPreprocessor
+from .upscale import UpscalePreprocessor
+
 
 # Try to import TensorRT preprocessors - might not be available on all systems
 try:
     from .depth_tensorrt import DepthAnythingTensorrtPreprocessor
+
     DEPTH_TENSORRT_AVAILABLE = True
 except ImportError:
     DepthAnythingTensorrtPreprocessor = None
@@ -28,6 +31,7 @@ except ImportError:
 
 try:
     from .pose_tensorrt import YoloNasPoseTensorrtPreprocessor
+
     POSE_TENSORRT_AVAILABLE = True
 except ImportError:
     YoloNasPoseTensorrtPreprocessor = None
@@ -35,6 +39,7 @@ except ImportError:
 
 try:
     from .temporal_net_tensorrt import TemporalNetTensorRTPreprocessor
+
     TEMPORAL_NET_TENSORRT_AVAILABLE = True
 except ImportError:
     TemporalNetTensorRTPreprocessor = None
@@ -42,6 +47,7 @@ except ImportError:
 
 try:
     from .mediapipe_pose import MediaPipePosePreprocessor
+
     MEDIAPIPE_POSE_AVAILABLE = True
 except ImportError:
     MediaPipePosePreprocessor = None
@@ -49,6 +55,7 @@ except ImportError:
 
 try:
     from .mediapipe_segmentation import MediaPipeSegmentationPreprocessor
+
     MEDIAPIPE_SEGMENTATION_AVAILABLE = True
 except ImportError:
     MediaPipeSegmentationPreprocessor = None
@@ -71,7 +78,7 @@ _preprocessor_registry = {
     "upscale": UpscalePreprocessor,
     "blur": BlurPreprocessor,
     "realesrgan_trt": RealESRGANProcessor,
-}   
+}
 
 # Add TensorRT preprocessors if available
 if DEPTH_TENSORRT_AVAILABLE:
@@ -94,27 +101,29 @@ if MEDIAPIPE_SEGMENTATION_AVAILABLE:
 def get_preprocessor_class(name: str) -> type:
     """
     Get a preprocessor class by name
-    
+
     Args:
         name: Name of the preprocessor
-        
+
     Returns:
         Preprocessor class
-        
+
     Raises:
         ValueError: If preprocessor name is not found
     """
     if name not in _preprocessor_registry:
         available = ", ".join(_preprocessor_registry.keys())
         raise ValueError(f"Unknown preprocessor '{name}'. Available: {available}")
-    
+
     return _preprocessor_registry[name]
 
 
-def get_preprocessor(name: str, pipeline_ref: Any = None, normalization_context: str = 'controlnet', params: Any = None) -> BasePreprocessor:
+def get_preprocessor(
+    name: str, pipeline_ref: Any = None, normalization_context: str = "controlnet", params: Any = None
+) -> BasePreprocessor:
     """
     Get a preprocessor by name
-    
+
     Args:
         name: Name of the preprocessor
         pipeline_ref: Pipeline reference for pipeline-aware processors (required for some processors)
@@ -122,20 +131,25 @@ def get_preprocessor(name: str, pipeline_ref: Any = None, normalization_context:
             - 'controlnet': Expects/produces [0,1] range for ControlNet conditioning
             - 'pipeline': Expects/produces [-1,1] range for pipeline image processing
             - 'latent': Works in latent space (no normalization needed)
-        
+
     Returns:
         Preprocessor instance
-        
+
     Raises:
         ValueError: If preprocessor name is not found or pipeline_ref missing for pipeline-aware processor
     """
     processor_class = get_preprocessor_class(name)
-    
+
     # Check if this is a pipeline-aware processor
-    if hasattr(processor_class, 'requires_sync_processing') and processor_class.requires_sync_processing:
+    if hasattr(processor_class, "requires_sync_processing") and processor_class.requires_sync_processing:
         if pipeline_ref is None:
             raise ValueError(f"Processor '{name}' requires a pipeline_ref")
-        return processor_class(pipeline_ref=pipeline_ref, normalization_context=normalization_context, _registry_name=name, **(params or {}))
+        return processor_class(
+            pipeline_ref=pipeline_ref,
+            normalization_context=normalization_context,
+            _registry_name=name,
+            **(params or {}),
+        )
     else:
         return processor_class(normalization_context=normalization_context, _registry_name=name, **(params or {}))
 
@@ -143,7 +157,7 @@ def get_preprocessor(name: str, pipeline_ref: Any = None, normalization_context:
 def register_preprocessor(name: str, preprocessor_class):
     """
     Register a new preprocessor
-    
+
     Args:
         name: Name to register under
         preprocessor_class: Preprocessor class
@@ -160,7 +174,7 @@ __all__ = [
     "BasePreprocessor",
     "PipelineAwareProcessor",
     "CannyPreprocessor",
-    "DepthPreprocessor", 
+    "DepthPreprocessor",
     "OpenPosePreprocessor",
     "LineartPreprocessor",
     "StandardLineartPreprocessor",
@@ -195,13 +209,15 @@ if MEDIAPIPE_SEGMENTATION_AVAILABLE:
 
 
 # region Custom Processor Discovery
-import logging
-import os
 import importlib.util
 import inspect
+import logging
+import os
 from pathlib import Path
 
+
 _logger = logging.getLogger(__name__)
+
 
 def _discover_custom_processors():
     """Auto-discover custom processors from repo_root/custom_processors/ folder."""
@@ -216,7 +232,7 @@ def _discover_custom_processors():
             return
         _logger.info("Scanning custom_processors/ for custom processors...")
         for item in custom_dir.iterdir():
-            if not item.is_dir() or item.name.startswith(('.', '_')):
+            if not item.is_dir() or item.name.startswith((".", "_")):
                 continue
             manifest_file = item / "processors.yaml"
             if manifest_file.exists():
@@ -226,20 +242,22 @@ def _discover_custom_processors():
     except Exception as e:
         _logger.error(f"Custom processor discovery failed: {e}")
 
+
 def _load_processor_collection(collection_dir, manifest_file):
     """Load processors from a collection with processors.yaml manifest."""
     import yaml
+
     try:
-        with open(manifest_file, 'r') as f:
+        with open(manifest_file, "r") as f:
             manifest = yaml.safe_load(f)
-        processor_files = manifest.get('processors', [])
+        processor_files = manifest.get("processors", [])
         if not processor_files:
             _logger.warning(f"Collection '{collection_dir.name}' has empty processors list")
             return
         _logger.info(f"Loading collection '{collection_dir.name}' ({len(processor_files)} processors)")
         for proc_file in processor_files:
             if isinstance(proc_file, dict):
-                filename, enabled = proc_file.get('file'), proc_file.get('enabled', True)
+                filename, enabled = proc_file.get("file"), proc_file.get("enabled", True)
                 if not enabled:
                     continue
             else:
@@ -252,24 +270,28 @@ def _load_processor_collection(collection_dir, manifest_file):
     except Exception as e:
         _logger.error(f"Failed to load collection {collection_dir.name}: {e}")
 
+
 def _load_processor_folder_auto(folder):
     """Auto-discover processors by scanning for .py files (no manifest)."""
     _logger.info(f"Auto-scanning folder: {folder.name}")
     for py_file in folder.glob("*.py"):
-        if py_file.name.startswith('_') or py_file.name in ['base.py', 'setup.py']:
+        if py_file.name.startswith("_") or py_file.name in ["base.py", "setup.py"]:
             continue
         _load_processor_from_file(py_file, py_file.stem)
+
 
 def _load_processor_from_file(file_path, proc_name):
     """Load and register a processor class from a Python file."""
     try:
         spec = importlib.util.spec_from_file_location(
-            f"custom_processors.{file_path.parent.name}.{file_path.stem}", file_path)
+            f"custom_processors.{file_path.parent.name}.{file_path.stem}", file_path
+        )
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
 
         found_classes = [
-            (name, obj) for name, obj in inspect.getmembers(module, inspect.isclass)
+            (name, obj)
+            for name, obj in inspect.getmembers(module, inspect.isclass)
             if issubclass(obj, (BasePreprocessor, PipelineAwareProcessor))
             and obj not in [BasePreprocessor, PipelineAwareProcessor]
         ]
@@ -283,6 +305,7 @@ def _load_processor_from_file(file_path, proc_name):
         _logger.info(f"  Registered: {proc_name} ({found_classes[0][0]})")
     except Exception as e:
         _logger.error(f"  Failed to load {file_path.name}: {e}")
+
 
 _discover_custom_processors()
 # endregion

--- a/src/streamdiffusion/preprocessing/processors/base.py
+++ b/src/streamdiffusion/preprocessing/processors/base.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import Union, Dict, Any, Tuple, Optional
+from typing import Any, Dict, Tuple, Union
+
+import numpy as np
 import torch
 import torch.nn.functional as F
-import numpy as np
 from PIL import Image
 
 
@@ -10,12 +11,11 @@ class BasePreprocessor(ABC):
     """
     Base class for ControlNet preprocessors with template method pattern
     """
-    
-    
-    def __init__(self, normalization_context: str = 'controlnet', **kwargs):
+
+    def __init__(self, normalization_context: str = "controlnet", **kwargs):
         """
         Initialize the preprocessor
-        
+
         Args:
             normalization_context: Context for normalization handling.
                 - 'controlnet': Expects/produces [0,1] range for ControlNet conditioning
@@ -25,15 +25,15 @@ class BasePreprocessor(ABC):
         """
         self.params = kwargs
         self.normalization_context = normalization_context
-        self.device = kwargs.get('device', 'cuda' if torch.cuda.is_available() else 'cpu')
-        self.dtype = kwargs.get('dtype', torch.float16)
-    
+        self.device = kwargs.get("device", "cuda" if torch.cuda.is_available() else "cpu")
+        self.dtype = kwargs.get("dtype", torch.float16)
+
     @classmethod
     def get_preprocessor_metadata(cls) -> Dict[str, Any]:
         """
         Get comprehensive metadata for this preprocessor.
         Subclasses should override this to define their specific metadata.
-        
+
         Returns:
             Dictionary containing:
             - display_name: Human-readable name
@@ -45,9 +45,9 @@ class BasePreprocessor(ABC):
             "display_name": cls.__name__.replace("Preprocessor", ""),
             "description": f"Preprocessor for {cls.__name__.replace('Preprocessor', '').lower()}",
             "parameters": {},
-            "use_cases": []
+            "use_cases": [],
         }
-    
+
     def process(self, image: Union[Image.Image, np.ndarray, torch.Tensor]) -> Image.Image:
         """
         Template method - handles all common operations
@@ -55,7 +55,7 @@ class BasePreprocessor(ABC):
         image = self.validate_input(image)
         processed = self._process_core(image)
         return self._ensure_target_size(processed)
-    
+
     def process_tensor(self, image_tensor: torch.Tensor) -> torch.Tensor:
         """
         Template method for GPU tensor processing
@@ -63,14 +63,14 @@ class BasePreprocessor(ABC):
         tensor = self.validate_tensor_input(image_tensor)
         processed = self._process_tensor_core(tensor)
         return self._ensure_target_size_tensor(processed)
-    
+
     @abstractmethod
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Subclasses implement ONLY their specific algorithm
         """
         pass
-    
+
     def _process_tensor_core(self, tensor: torch.Tensor) -> torch.Tensor:
         """
         Optional GPU processing (fallback to PIL if not overridden)
@@ -78,7 +78,7 @@ class BasePreprocessor(ABC):
         pil_image = self.tensor_to_pil(tensor)
         processed_pil = self._process_core(pil_image)
         return self.pil_to_tensor(processed_pil)
-    
+
     def _ensure_target_size(self, image: Image.Image) -> Image.Image:
         """
         Centralized PIL resize logic
@@ -87,7 +87,7 @@ class BasePreprocessor(ABC):
         if image.size != (target_width, target_height):
             return image.resize((target_width, target_height), Image.LANCZOS)
         return image
-    
+
     def _ensure_target_size_tensor(self, tensor: torch.Tensor) -> torch.Tensor:
         """
         Centralized tensor resize logic
@@ -95,54 +95,54 @@ class BasePreprocessor(ABC):
         target_width, target_height = self.get_target_dimensions()
         current_size = tensor.shape[-2:]
         target_size = (target_height, target_width)
-        
+
         if current_size != target_size:
             if tensor.dim() == 3:
                 tensor = tensor.unsqueeze(0)
-            tensor = F.interpolate(tensor, size=target_size, mode='bilinear', align_corners=False)
+            tensor = F.interpolate(tensor, size=target_size, mode="bilinear", align_corners=False)
             if tensor.shape[0] == 1:
                 tensor = tensor.squeeze(0)
         return tensor
-    
+
     def validate_tensor_input(self, image_tensor: torch.Tensor) -> torch.Tensor:
         """
         Validate and normalize tensor input for processing
-        
+
         Args:
             image_tensor: Input tensor
-            
+
         Returns:
             Tensor in CHW format, on correct device
             Range: [0,1] if input was [0,255], otherwise preserves input range
-            
+
         Note: This preserves [-1,1] tensors (from pipeline) since max() <= 1.0
         """
         # Handle batch dimension
         if image_tensor.dim() == 4:
             image_tensor = image_tensor[0]  # Take first image from batch
-        
+
         # Convert to CHW format if needed
         if image_tensor.dim() == 3 and image_tensor.shape[0] not in [1, 3]:
             # Likely HWC format, convert to CHW
             image_tensor = image_tensor.permute(2, 0, 1)
-        
+
         # Ensure correct device and dtype
         image_tensor = image_tensor.to(device=self.device, dtype=self.dtype)
-        
+
         # Normalize to [0,1] range only if tensor is in [0,255] uint8 range
         # Preserves [-1,1] and [0,1] ranges (max <= 1.0)
         if image_tensor.max() > 1.0:
             image_tensor = image_tensor / 255.0
-        
+
         return image_tensor
-    
+
     def tensor_to_pil(self, tensor: torch.Tensor) -> Image.Image:
         """
         Convert tensor to PIL Image (minimize CPU transfers)
-        
+
         Args:
             tensor: Input tensor
-            
+
         Returns:
             PIL Image
         """
@@ -151,39 +151,39 @@ class BasePreprocessor(ABC):
             tensor = tensor[0]
         if tensor.dim() == 3 and tensor.shape[0] in [1, 3]:
             tensor = tensor.permute(1, 2, 0)
-        
+
         # Convert to numpy (unavoidable for PIL)
         if tensor.is_cuda:
             tensor = tensor.cpu()
-        
+
         # Convert to uint8
         if tensor.max() <= 1.0:
             tensor = (tensor * 255).clamp(0, 255).to(torch.uint8)
         else:
             tensor = tensor.clamp(0, 255).to(torch.uint8)
-        
+
         array = tensor.numpy()
-        
+
         if array.shape[-1] == 3:
-            return Image.fromarray(array, 'RGB')
+            return Image.fromarray(array, "RGB")
         elif array.shape[-1] == 1:
-            return Image.fromarray(array.squeeze(-1), 'L')
+            return Image.fromarray(array.squeeze(-1), "L")
         else:
             return Image.fromarray(array)
-    
+
     def pil_to_tensor(self, image: Image.Image) -> torch.Tensor:
         """
         Convert PIL Image to tensor on GPU
-        
+
         Args:
             image: PIL Image
-            
+
         Returns:
             Tensor on correct device
         """
         # Convert to numpy first
         array = np.array(image)
-        
+
         # Convert to tensor
         if len(array.shape) == 2:  # Grayscale
             tensor = torch.from_numpy(array).float() / 255.0
@@ -191,25 +191,25 @@ class BasePreprocessor(ABC):
         else:  # RGB
             tensor = torch.from_numpy(array).float() / 255.0
             tensor = tensor.permute(2, 0, 1)  # HWC to CHW
-        
+
         # Move to device
         tensor = tensor.to(device=self.device, dtype=self.dtype)
         return tensor.unsqueeze(0)  # Add batch dimension
-    
+
     def validate_input(self, image: Union[Image.Image, np.ndarray, torch.Tensor]) -> Image.Image:
         """
         Convert input to PIL Image for processing
-        
+
         Args:
             image: Input image in various formats
-            
+
         Returns:
             PIL Image
         """
         if isinstance(image, torch.Tensor):
             # Use tensor_to_pil method for better handling
             return self.tensor_to_pil(image)
-                
+
         if isinstance(image, np.ndarray):
             # Ensure uint8 format
             if image.dtype != np.uint8:
@@ -217,83 +217,83 @@ class BasePreprocessor(ABC):
                     image = (image * 255).astype(np.uint8)
                 else:
                     image = image.astype(np.uint8)
-            
+
             # Convert to PIL Image
             if len(image.shape) == 3:
-                image = Image.fromarray(image, 'RGB')
+                image = Image.fromarray(image, "RGB")
             else:
-                image = Image.fromarray(image, 'L')
-                
+                image = Image.fromarray(image, "L")
+
         if not isinstance(image, Image.Image):
             raise ValueError(f"Unsupported image type: {type(image)}")
-            
+
         return image
-    
+
     def get_target_dimensions(self) -> Tuple[int, int]:
         """
         Get target output dimensions (width, height)
         """
         # Check for explicit width/height parameters first
-        width = self.params.get('image_width')
-        height = self.params.get('image_height')
-        
+        width = self.params.get("image_width")
+        height = self.params.get("image_height")
+
         if width is not None and height is not None:
             return (width, height)
-        
+
         # Fallback to square resolution for backwards compatibility
-        resolution = self.params.get('image_resolution', 512)
+        resolution = self.params.get("image_resolution", 512)
         return (resolution, resolution)
-    
+
     def __call__(self, image: Union[Image.Image, np.ndarray, torch.Tensor], **kwargs) -> Image.Image:
         """
         Process an image (convenience method)
-        
+
         Args:
             image: Input image
             **kwargs: Additional parameters to override defaults
-            
+
         Returns:
             Processed PIL Image
         """
         # Update parameters for this call
         params = {**self.params, **kwargs}
-        
+
         # Store original params and update
         original_params = self.params
         self.params = params
-        
+
         try:
             result = self.process(image)
         finally:
             # Restore original params
             self.params = original_params
-            
+
         return result
 
 
 class PipelineAwareProcessor(BasePreprocessor):
     """
     Abstract base class for processors that need access to pipeline state (previous outputs).
-    
-    This base class marks processors as requiring synchronous processing to avoid 
+
+    This base class marks processors as requiring synchronous processing to avoid
     temporal artifacts and ensures they have access to pipeline references.
-    
+
     Usage:
         class MyProcessor(PipelineAwareProcessor):
             pass
-    
+
     Examples:
     - FeedbackPreprocessor: Needs previous diffusion output
     - TemporalNetPreprocessor: Needs previous frame for optical flow
     """
-    
+
     # Class attribute to mark processors as requiring sync processing
     requires_sync_processing = True
-    
-    def __init__(self, pipeline_ref: Any, normalization_context: str = 'controlnet', **kwargs):
+
+    def __init__(self, pipeline_ref: Any, normalization_context: str = "controlnet", **kwargs):
         """
         Initialize pipeline-aware functionality
-        
+
         Args:
             pipeline_ref: Reference to the StreamDiffusion pipeline instance (required)
             normalization_context: Context for normalization handling
@@ -302,4 +302,4 @@ class PipelineAwareProcessor(BasePreprocessor):
         if pipeline_ref is None:
             raise ValueError(f"{self.__class__.__name__} requires a pipeline_ref")
         super().__init__(normalization_context=normalization_context, **kwargs)
-        self.pipeline_ref = pipeline_ref 
+        self.pipeline_ref = pipeline_ref

--- a/src/streamdiffusion/preprocessing/processors/blur.py
+++ b/src/streamdiffusion/preprocessing/processors/blur.py
@@ -1,19 +1,18 @@
 import torch
 import torch.nn.functional as F
-import numpy as np
 from PIL import Image
-from typing import Union
+
 from .base import BasePreprocessor
 
 
 class BlurPreprocessor(BasePreprocessor):
     """
     Gaussian blur preprocessor for ControlNet
-    
+
     Applies Gaussian blur to the input image using GPU-accelerated operations.
     Useful for creating soft, dreamy effects or reducing image detail.
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
@@ -24,22 +23,22 @@ class BlurPreprocessor(BasePreprocessor):
                     "type": "float",
                     "default": 2.0,
                     "range": [0.1, 10.0],
-                    "description": "Intensity of the blur effect. Higher values create stronger blur."
+                    "description": "Intensity of the blur effect. Higher values create stronger blur.",
                 },
                 "kernel_size": {
                     "type": "int",
                     "default": 15,
                     "range": [3, 51],
-                    "description": "Size of the blur kernel. Must be odd. Larger values create smoother blur."
-                }
+                    "description": "Size of the blur kernel. Must be odd. Larger values create smoother blur.",
+                },
             },
-            "use_cases": ["Soft focus effects", "Background blur", "Artistic rendering", "Detail reduction"]
+            "use_cases": ["Soft focus effects", "Background blur", "Artistic rendering", "Detail reduction"],
         }
-    
+
     def __init__(self, blur_intensity: float = 2.0, kernel_size: int = 15, **kwargs):
         """
         Initialize Blur preprocessor
-        
+
         Args:
             blur_intensity: Standard deviation for Gaussian kernel (higher = more blur)
             kernel_size: Size of the blur kernel (must be odd)
@@ -48,58 +47,55 @@ class BlurPreprocessor(BasePreprocessor):
         # Ensure kernel_size is odd
         if kernel_size % 2 == 0:
             kernel_size += 1
-            
-        super().__init__(
-            blur_intensity=blur_intensity,
-            kernel_size=kernel_size,
-            **kwargs
-        )
-        
+
+        super().__init__(blur_intensity=blur_intensity, kernel_size=kernel_size, **kwargs)
+
         # Cache the Gaussian kernel for efficiency
         self._cached_kernel = None
         self._cached_kernel_size = None
         self._cached_intensity = None
-    
+
     def _create_gaussian_kernel(self, kernel_size: int, intensity: float) -> torch.Tensor:
         """
         Create a 2D Gaussian kernel for blurring
-        
+
         Args:
             kernel_size: Size of the kernel (must be odd)
             intensity: Standard deviation of the Gaussian
-            
+
         Returns:
             2D Gaussian kernel tensor
         """
         # Create coordinate grids
         coords = torch.arange(kernel_size, dtype=self.dtype, device=self.device)
         coords = coords - (kernel_size - 1) / 2
-        
+
         # Create 2D coordinate grids
-        y_grid, x_grid = torch.meshgrid(coords, coords, indexing='ij')
-        
+        y_grid, x_grid = torch.meshgrid(coords, coords, indexing="ij")
+
         # Calculate Gaussian values
         gaussian = torch.exp(-(x_grid**2 + y_grid**2) / (2 * intensity**2))
-        
+
         # Normalize to sum to 1
         gaussian = gaussian / gaussian.sum()
-        
+
         return gaussian
-    
+
     def _get_gaussian_kernel(self, kernel_size: int, intensity: float) -> torch.Tensor:
         """
         Get cached Gaussian kernel or create new one
         """
-        if (self._cached_kernel is None or 
-            self._cached_kernel_size != kernel_size or 
-            self._cached_intensity != intensity):
-            
+        if (
+            self._cached_kernel is None
+            or self._cached_kernel_size != kernel_size
+            or self._cached_intensity != intensity
+        ):
             self._cached_kernel = self._create_gaussian_kernel(kernel_size, intensity)
             self._cached_kernel_size = kernel_size
             self._cached_intensity = intensity
-            
+
         return self._cached_kernel
-    
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Apply Gaussian blur to the input image using PIL/numpy fallback
@@ -107,46 +103,46 @@ class BlurPreprocessor(BasePreprocessor):
         # Convert to tensor for processing
         tensor = self.pil_to_tensor(image)
         tensor = tensor.squeeze(0)  # Remove batch dimension
-        
+
         # Process on GPU
         blurred = self._process_tensor_core(tensor)
-        
+
         # Convert back to PIL
         return self.tensor_to_pil(blurred)
-    
+
     def _process_tensor_core(self, image_tensor: torch.Tensor) -> torch.Tensor:
         """
         Process tensor directly on GPU for Gaussian blur
         """
-        blur_intensity = self.params.get('blur_intensity', 2.0)
-        kernel_size = self.params.get('kernel_size', 15)
-        
+        blur_intensity = self.params.get("blur_intensity", 2.0)
+        kernel_size = self.params.get("kernel_size", 15)
+
         # Ensure kernel_size is odd
         if kernel_size % 2 == 0:
             kernel_size += 1
-        
+
         # Get the Gaussian kernel
         kernel = self._get_gaussian_kernel(kernel_size, blur_intensity)
-        
+
         # Ensure tensor has batch dimension
         if image_tensor.dim() == 3:
             image_tensor = image_tensor.unsqueeze(0)
-        
+
         # Ensure tensor is on the correct device and dtype
         image_tensor = image_tensor.to(device=self.device, dtype=self.dtype)
-        
+
         # Reshape kernel for conv2d: (out_channels, in_channels/groups, H, W)
         # We'll apply the same kernel to each channel separately
         num_channels = image_tensor.shape[1]
         kernel_conv = kernel.unsqueeze(0).unsqueeze(0).repeat(num_channels, 1, 1, 1)
-        
+
         # Apply Gaussian blur using conv2d with groups=num_channels for per-channel convolution
         padding = kernel_size // 2
         blurred = F.conv2d(
             image_tensor,
             kernel_conv,
             padding=padding,
-            groups=num_channels  # Apply kernel separately to each channel
+            groups=num_channels,  # Apply kernel separately to each channel
         )
-        
+
         return blurred

--- a/src/streamdiffusion/preprocessing/processors/canny.py
+++ b/src/streamdiffusion/preprocessing/processors/canny.py
@@ -1,18 +1,19 @@
 import cv2
 import numpy as np
-from PIL import Image
 import torch
-from typing import Union
+from PIL import Image
+
 from .base import BasePreprocessor
 
-#TODO provide gpu native edge detection
+
+# TODO provide gpu native edge detection
 class CannyPreprocessor(BasePreprocessor):
     """
     Canny edge detection preprocessor for ControlNet
-    
+
     Detects edges in the input image using the Canny edge detection algorithm.
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
@@ -23,52 +24,48 @@ class CannyPreprocessor(BasePreprocessor):
                     "type": "int",
                     "default": 100,
                     "range": [1, 255],
-                    "description": "Lower threshold for edge detection. Lower values detect more edges."
+                    "description": "Lower threshold for edge detection. Lower values detect more edges.",
                 },
                 "high_threshold": {
-                    "type": "int", 
+                    "type": "int",
                     "default": 200,
                     "range": [1, 255],
-                    "description": "Upper threshold for edge detection. Higher values are more selective."
-                }
+                    "description": "Upper threshold for edge detection. Higher values are more selective.",
+                },
             },
-            "use_cases": ["Line art", "Architecture", "Technical drawings", "Clean edge detection"]
+            "use_cases": ["Line art", "Architecture", "Technical drawings", "Clean edge detection"],
         }
-    
+
     def __init__(self, low_threshold: int = 100, high_threshold: int = 200, **kwargs):
         """
         Initialize Canny preprocessor
-        
+
         Args:
             low_threshold: Lower threshold for edge detection
             high_threshold: Upper threshold for edge detection
             **kwargs: Additional parameters
         """
-        super().__init__(
-            low_threshold=low_threshold,
-            high_threshold=high_threshold,
-            **kwargs
-        )
-    
+        super().__init__(low_threshold=low_threshold, high_threshold=high_threshold, **kwargs)
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Apply Canny edge detection to the input image
         """
         image_np = np.array(image)
-        
+
         if len(image_np.shape) == 3:
             gray = cv2.cvtColor(image_np, cv2.COLOR_RGB2GRAY)
         else:
             gray = image_np
-        
-        low_threshold = self.params.get('low_threshold', 100)
-        high_threshold = self.params.get('high_threshold', 200)
-        
+
+        low_threshold = self.params.get("low_threshold", 100)
+        high_threshold = self.params.get("high_threshold", 200)
+
         edges = cv2.Canny(gray, low_threshold, high_threshold)
         edges_rgb = cv2.cvtColor(edges, cv2.COLOR_GRAY2RGB)
-        
+
         return Image.fromarray(edges_rgb)
-    
+
     def _process_tensor_core(self, image_tensor: torch.Tensor) -> torch.Tensor:
         """
         Process tensor directly on GPU for Canny edge detection
@@ -77,18 +74,18 @@ class CannyPreprocessor(BasePreprocessor):
             gray_tensor = 0.299 * image_tensor[0] + 0.587 * image_tensor[1] + 0.114 * image_tensor[2]
         else:
             gray_tensor = image_tensor[0] if image_tensor.shape[0] == 1 else image_tensor
-        
+
         gray_cpu = gray_tensor.cpu()
         gray_np = (gray_cpu * 255).clamp(0, 255).to(torch.uint8).numpy()
-        
-        low_threshold = self.params.get('low_threshold', 100)
-        high_threshold = self.params.get('high_threshold', 200)
-        
+
+        low_threshold = self.params.get("low_threshold", 100)
+        high_threshold = self.params.get("high_threshold", 200)
+
         edges = cv2.Canny(gray_np, low_threshold, high_threshold)
-        
+
         edges_tensor = torch.from_numpy(edges).float() / 255.0
         edges_tensor = edges_tensor.to(device=self.device, dtype=self.dtype)
-        
+
         edges_rgb = edges_tensor.unsqueeze(0).repeat(3, 1, 1)
-        
-        return edges_rgb 
+
+        return edges_rgb

--- a/src/streamdiffusion/preprocessing/processors/depth.py
+++ b/src/streamdiffusion/preprocessing/processors/depth.py
@@ -1,12 +1,14 @@
 import numpy as np
-from PIL import Image
 import torch
-from typing import Union, Optional
+from PIL import Image
+
 from .base import BasePreprocessor
+
 
 try:
     import torch
     from transformers import pipeline
+
     TRANSFORMERS_AVAILABLE = True
 except ImportError:
     TRANSFORMERS_AVAILABLE = False
@@ -15,29 +17,25 @@ except ImportError:
 class DepthPreprocessor(BasePreprocessor):
     """
     Depth estimation preprocessor for ControlNet using MiDaS
-    
+
     Estimates depth maps from input images using the MiDaS depth estimation model.
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
             "display_name": "Depth Estimation",
             "description": "Estimates depth from the input image using MiDaS. Good for adding depth-based control to generation.",
-            "parameters": {
- 
-            },
-            "use_cases": ["3D-aware generation", "Depth preservation", "Scene understanding"]
+            "parameters": {},
+            "use_cases": ["3D-aware generation", "Depth preservation", "Scene understanding"],
         }
-    
-    def __init__(self, 
-                 model_name: str = "Intel/dpt-large",
-                 detect_resolution: int = 512,
-                 image_resolution: int = 512,
-                 **kwargs):
+
+    def __init__(
+        self, model_name: str = "Intel/dpt-large", detect_resolution: int = 512, image_resolution: int = 512, **kwargs
+    ):
         """
         Initialize depth preprocessor
-        
+
         Args:
             model_name: Name of the depth estimation model to use
             detect_resolution: Resolution for depth detection
@@ -46,102 +44,94 @@ class DepthPreprocessor(BasePreprocessor):
         """
         if not TRANSFORMERS_AVAILABLE:
             raise ImportError(
-                "transformers library is required for depth preprocessing. "
-                "Install it with: pip install transformers"
+                "transformers library is required for depth preprocessing. Install it with: pip install transformers"
             )
-        
+
         super().__init__(
-            model_name=model_name,
-            detect_resolution=detect_resolution,
-            image_resolution=image_resolution,
-            **kwargs
+            model_name=model_name, detect_resolution=detect_resolution, image_resolution=image_resolution, **kwargs
         )
-        
+
         self._depth_estimator = None
-    
+
     @property
     def depth_estimator(self):
         """Lazy loading of the depth estimation model"""
         if self._depth_estimator is None:
-            model_name = self.params.get('model_name', 'Intel/dpt-large')
+            model_name = self.params.get("model_name", "Intel/dpt-large")
             print(f"Loading depth estimation model: {model_name}")
             self._depth_estimator = pipeline(
-                'depth-estimation', 
-                model=model_name,
-                device=0 if torch.cuda.is_available() else -1
+                "depth-estimation", model=model_name, device=0 if torch.cuda.is_available() else -1
             )
         return self._depth_estimator
-    
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Apply depth estimation to the input image
         """
-        detect_resolution = self.params.get('detect_resolution', 512)
+        detect_resolution = self.params.get("detect_resolution", 512)
         image_resized = image.resize((detect_resolution, detect_resolution), Image.LANCZOS)
-        
+
         depth_result = self.depth_estimator(image_resized)
-        depth_map = depth_result['depth']
-        
-        if hasattr(depth_map, 'cpu'):
+        depth_map = depth_result["depth"]
+
+        if hasattr(depth_map, "cpu"):
             depth_np = depth_map.cpu().numpy()
         else:
             depth_np = np.array(depth_map)
-        
+
         depth_min = depth_np.min()
         depth_max = depth_np.max()
         if depth_max > depth_min:
             depth_normalized = ((depth_np - depth_min) / (depth_max - depth_min) * 255).astype(np.uint8)
         else:
             depth_normalized = np.zeros_like(depth_np, dtype=np.uint8)
-        
+
         depth_rgb = np.stack([depth_normalized] * 3, axis=-1)
         return Image.fromarray(depth_rgb)
-    
+
     def _process_tensor_core(self, image_tensor: torch.Tensor) -> torch.Tensor:
         """
         Process tensor directly on GPU for depth estimation
         """
-        detect_resolution = self.params.get('detect_resolution', 512)
+        detect_resolution = self.params.get("detect_resolution", 512)
         current_size = image_tensor.shape[-2:]
-        
+
         if current_size != (detect_resolution, detect_resolution):
             import torch.nn.functional as F
+
             if image_tensor.dim() == 3:
                 image_tensor = image_tensor.unsqueeze(0)
-            
+
             resized_tensor = F.interpolate(
-                image_tensor,
-                size=(detect_resolution, detect_resolution),
-                mode='bilinear',
-                align_corners=False
+                image_tensor, size=(detect_resolution, detect_resolution), mode="bilinear", align_corners=False
             )
-            
+
             if image_tensor.shape[0] == 1:
                 resized_tensor = resized_tensor.squeeze(0)
         else:
             resized_tensor = image_tensor
-        
+
         pil_image = self.tensor_to_pil(resized_tensor)
-        
+
         depth_result = self.depth_estimator(pil_image)
-        depth_map = depth_result['depth']
-        
-        if hasattr(depth_map, 'to'):
+        depth_map = depth_result["depth"]
+
+        if hasattr(depth_map, "to"):
             depth_tensor = depth_map.to(device=self.device, dtype=self.dtype)
         else:
             depth_np = np.array(depth_map)
             depth_tensor = torch.from_numpy(depth_np).to(device=self.device, dtype=self.dtype)
-        
+
         depth_min = depth_tensor.min()
         depth_max = depth_tensor.max()
         if depth_max > depth_min:
             depth_normalized = (depth_tensor - depth_min) / (depth_max - depth_min)
         else:
             depth_normalized = torch.zeros_like(depth_tensor)
-        
+
         if depth_normalized.dim() == 2:
             depth_rgb = depth_normalized.unsqueeze(0).repeat(3, 1, 1)
         else:
             depth_rgb = depth_normalized
-        
-        return depth_rgb 
+
+        return depth_rgb

--- a/src/streamdiffusion/preprocessing/processors/depth_tensorrt.py
+++ b/src/streamdiffusion/preprocessing/processors/depth_tensorrt.py
@@ -1,19 +1,23 @@
-#NOTE: ported from https://github.com/yuvraj108c/ComfyUI-Depth-Anything-Tensorrt
+# NOTE: ported from https://github.com/yuvraj108c/ComfyUI-Depth-Anything-Tensorrt
 
 import os
+
+import cv2
 import numpy as np
 import torch
 import torch.nn.functional as F
-import cv2
 from PIL import Image
-from typing import Union, Optional
+
 from .base import BasePreprocessor
 
+
 try:
+    from collections import OrderedDict
+
     import tensorrt as trt
     from polygraphy.backend.common import bytes_from_path
     from polygraphy.backend.trt import engine_from_bytes
-    from collections import OrderedDict
+
     TENSORRT_AVAILABLE = True
 except ImportError:
     TENSORRT_AVAILABLE = False
@@ -40,7 +44,7 @@ else:
 
 class TensorRTEngine:
     """Simplified TensorRT engine wrapper for depth estimation inference (optimized)"""
-    
+
     def __init__(self, engine_path):
         self.engine_path = engine_path
         self.engine = None
@@ -65,13 +69,11 @@ class TensorRTEngine:
             name = self.engine.get_tensor_name(idx)
             shape = self.context.get_tensor_shape(name)
             dtype = trt.nptype(self.engine.get_tensor_dtype(name))
-            
+
             if self.engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT:
                 self.context.set_input_shape(name, shape)
-            
-            tensor = torch.empty(
-                tuple(shape), dtype=numpy_to_torch_dtype_dict[dtype]
-            ).to(device=device)
+
+            tensor = torch.empty(tuple(shape), dtype=numpy_to_torch_dtype_dict[dtype]).to(device=device)
             self.tensors[name] = tensor
 
     def infer(self, feed_dict, stream=None):
@@ -79,7 +81,7 @@ class TensorRTEngine:
         # Use cached stream if none provided
         if stream is None:
             stream = self._cuda_stream
-            
+
         # Copy input data to tensors
         for name, buf in feed_dict.items():
             self.tensors[name].copy_(buf)
@@ -87,39 +89,35 @@ class TensorRTEngine:
         # Set tensor addresses
         for name, tensor in self.tensors.items():
             self.context.set_tensor_address(name, tensor.data_ptr())
-        
+
         # Execute inference
         success = self.context.execute_async_v3(stream)
         if not success:
             raise ValueError("ERROR: TensorRT inference failed.")
-        
+
         return self.tensors
 
 
 class DepthAnythingTensorrtPreprocessor(BasePreprocessor):
     """
     Depth Anything TensorRT preprocessor for ControlNet
-    
+
     Uses TensorRT-optimized Depth Anything model for fast depth estimation.
     """
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
             "display_name": "Depth Estimation (TensorRT)",
             "description": "Fast TensorRT-optimized depth estimation using Depth Anything model. Significantly faster than standard depth estimation.",
-            "parameters": {
-               
-            },
-            "use_cases": ["High-performance depth estimation", "Real-time applications", "3D-aware generation"]
+            "parameters": {},
+            "use_cases": ["High-performance depth estimation", "Real-time applications", "3D-aware generation"],
         }
-    def __init__(self, 
-                 engine_path: str = None,
-                 detect_resolution: int = 518,
-                 image_resolution: int = 512,
-                 **kwargs):
+
+    def __init__(self, engine_path: str = None, detect_resolution: int = 518, image_resolution: int = 512, **kwargs):
         """
         Initialize TensorRT depth preprocessor
-        
+
         Args:
             engine_path: Path to TensorRT engine file
             detect_resolution: Resolution for depth detection (should match engine input)
@@ -131,74 +129,68 @@ class DepthAnythingTensorrtPreprocessor(BasePreprocessor):
                 "TensorRT and polygraphy libraries are required for TensorRT depth preprocessing. "
                 "Install them with: pip install tensorrt polygraphy"
             )
-        
+
         super().__init__(
-            engine_path=engine_path,
-            detect_resolution=detect_resolution,
-            image_resolution=image_resolution,
-            **kwargs
+            engine_path=engine_path, detect_resolution=detect_resolution, image_resolution=image_resolution, **kwargs
         )
-        
+
         self._engine = None
-    
+
     @property
     def engine(self):
         """Lazy loading of the TensorRT engine"""
         if self._engine is None:
-            engine_path = self.params.get('engine_path')
+            engine_path = self.params.get("engine_path")
             if engine_path is None:
                 raise ValueError(
                     "engine_path is required for TensorRT depth preprocessing. "
                     "Please provide it in the preprocessor_params config."
                 )
-            
+
             if not os.path.exists(engine_path):
                 raise FileNotFoundError(f"TensorRT engine not found: {engine_path}")
-            
+
             print(f"Loading TensorRT depth estimation engine: {engine_path}")
-            
+
             self._engine = TensorRTEngine(engine_path)
             self._engine.load()
             self._engine.activate()
             self._engine.allocate_buffers()
-            
+
         return self._engine
-    
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Apply TensorRT depth estimation to the input image
         """
-        detect_resolution = self.params.get('detect_resolution', 518)
-        
+        detect_resolution = self.params.get("detect_resolution", 518)
+
         image_tensor = torch.from_numpy(np.array(image)).float() / 255.0
         image_tensor = image_tensor.permute(2, 0, 1).unsqueeze(0)
-        
+
         image_resized = F.interpolate(
-            image_tensor, 
-            size=(detect_resolution, detect_resolution), 
-            mode='bilinear', 
-            align_corners=False
+            image_tensor, size=(detect_resolution, detect_resolution), mode="bilinear", align_corners=False
         )
-        
+
         if torch.cuda.is_available():
             image_resized = image_resized.cuda()
-        
+
         cuda_stream = torch.cuda.current_stream().cuda_stream
         result = self.engine.infer({"input": image_resized}, cuda_stream)
-        depth = result['output']
-        
+        depth = result["output"]
+
         depth = np.reshape(depth.cpu().numpy(), (detect_resolution, detect_resolution))
         depth = (depth - depth.min()) / (depth.max() - depth.min()) * 255.0
         depth = depth.astype(np.uint8)
-        
+
         original_size = image.size
         depth = cv2.resize(depth, original_size)
-        
+
         depth_rgb = cv2.cvtColor(depth, cv2.COLOR_GRAY2RGB)
         result = Image.fromarray(depth_rgb)
-        
+
         return result
-    
+
     def _process_tensor_core(self, image_tensor: torch.Tensor) -> torch.Tensor:
         """
         Process tensor directly on GPU to avoid CPU transfers
@@ -207,20 +199,19 @@ class DepthAnythingTensorrtPreprocessor(BasePreprocessor):
             image_tensor = image_tensor.unsqueeze(0)
         if not image_tensor.is_cuda:
             image_tensor = image_tensor.cuda()
-        
-        detect_resolution = self.params.get('detect_resolution', 518)
-        
+
+        detect_resolution = self.params.get("detect_resolution", 518)
+
         image_resized = torch.nn.functional.interpolate(
-            image_tensor, size=(detect_resolution, detect_resolution), 
-            mode='bilinear', align_corners=False
+            image_tensor, size=(detect_resolution, detect_resolution), mode="bilinear", align_corners=False
         )
-        
+
         cuda_stream = torch.cuda.current_stream().cuda_stream
         result = self.engine.infer({"input": image_resized}, cuda_stream)
-        depth_tensor = result['output']
-        
+        depth_tensor = result["output"]
+
         depth_tensor = depth_tensor.squeeze() if depth_tensor.dim() > 2 else depth_tensor
         depth_min, depth_max = depth_tensor.min(), depth_tensor.max()
         depth_normalized = (depth_tensor - depth_min) / (depth_max - depth_min)
-        
-        return depth_normalized.repeat(3, 1, 1).unsqueeze(0) 
+
+        return depth_normalized.repeat(3, 1, 1).unsqueeze(0)

--- a/src/streamdiffusion/preprocessing/processors/external.py
+++ b/src/streamdiffusion/preprocessing/processors/external.py
@@ -1,95 +1,87 @@
+from typing import Union
+
 import numpy as np
 import torch
 from PIL import Image
-from typing import Union, Optional, Dict, Any
+
 from .base import BasePreprocessor
 
 
 class ExternalPreprocessor(BasePreprocessor):
     """
     External source preprocessor for client-processed control data
-    
+
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
             "display_name": "External",
             "description": "Allows using external preprocessing tools or custom processing pipelines.",
-            "parameters": {
-
-            },
-            "use_cases": ["Custom processing", "Third-party tools integration", "Pre-processed control images"]
+            "parameters": {},
+            "use_cases": ["Custom processing", "Third-party tools integration", "Pre-processed control images"],
         }
-    
-    def __init__(self,
-                 image_resolution: int = 512,
-                 validate_input: bool = True,
-                 **kwargs):
+
+    def __init__(self, image_resolution: int = 512, validate_input: bool = True, **kwargs):
         """
         Initialize external source preprocessor
-        
+
         Args:
             image_resolution: Target output resolution
             validate_input: Whether to validate the control image format
             **kwargs: Additional parameters
         """
-        super().__init__(
-            image_resolution=image_resolution,
-            validate_input=validate_input,
-            **kwargs
-        )
-    
+        super().__init__(image_resolution=image_resolution, validate_input=validate_input, **kwargs)
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Process client-preprocessed control image
-        
+
         Applies minimal server-side validation to control images
         that have already been processed by external sources.
         """
         # Optional validation of control image format
-        if self.params.get('validate_input', True):
+        if self.params.get("validate_input", True):
             image = self._validate_control_image(image)
-        
+
         return image
-    
+
     def _process_tensor_core(self, tensor: torch.Tensor) -> torch.Tensor:
         """
         Process tensor directly (optimized path for external sources)
-        
+
         For external sources, tensor input likely comes from client WebGL/Canvas
         processing, so minimal processing needed.
         """
         return tensor
-    
+
     def _validate_control_image(self, image: Image.Image) -> Image.Image:
         """
         Validate that the control image is in proper format
         """
         # Convert to RGB if needed
-        if image.mode != 'RGB':
-            image = image.convert('RGB')
-        
+        if image.mode != "RGB":
+            image = image.convert("RGB")
+
         # Basic validation - check if image has content
         # (not completely black, which might indicate processing failure)
         img_array = np.array(image)
         brightness = np.mean(img_array)
-        
+
         if brightness < 1.0:  # Very dark image, might be processing error
             print("ExternalPreprocessor._validate_control_image: Warning - control image appears very dark")
-        
+
         return image
-    
-    
+
     def __call__(self, image: Union[Image.Image, np.ndarray, torch.Tensor], **kwargs) -> Image.Image:
         """
         Process control image (convenience method)
         """
         # Store any client metadata if provided
-        client_metadata = kwargs.get('client_metadata', {})
+        client_metadata = kwargs.get("client_metadata", {})
         if client_metadata:
-            source = client_metadata.get('source', 'unknown')
-            control_type = client_metadata.get('type', 'unknown')
+            source = client_metadata.get("source", "unknown")
+            control_type = client_metadata.get("type", "unknown")
             print(f"ExternalPreprocessor: Received {control_type} control from {source}")
-        
-        return super().__call__(image, **kwargs) 
+
+        return super().__call__(image, **kwargs)

--- a/src/streamdiffusion/preprocessing/processors/faceid_embedding.py
+++ b/src/streamdiffusion/preprocessing/processors/faceid_embedding.py
@@ -1,8 +1,11 @@
-from typing import Tuple, Any
+from typing import Any, Tuple
+
 import torch
 from PIL import Image
-from .ipadapter_embedding import IPAdapterEmbeddingPreprocessor
+
 from streamdiffusion.utils.reporting import report_error
+
+from .ipadapter_embedding import IPAdapterEmbeddingPreprocessor
 
 
 class FaceIDEmbeddingPreprocessor(IPAdapterEmbeddingPreprocessor):
@@ -45,9 +48,7 @@ class FaceIDEmbeddingPreprocessor(IPAdapterEmbeddingPreprocessor):
         self.faceid_v2_weight = float(faceid_v2_weight)
 
         if not hasattr(ipadapter, "insightface_model") or ipadapter.insightface_model is None:
-            raise ValueError(
-                "FaceIDEmbeddingPreprocessor: ipadapter must have an initialized InsightFace model"
-            )
+            raise ValueError("FaceIDEmbeddingPreprocessor: ipadapter must have an initialized InsightFace model")
 
     def _process_core(self, image: Image.Image) -> Tuple[torch.Tensor, torch.Tensor]:
         """
@@ -78,8 +79,4 @@ class FaceIDEmbeddingPreprocessor(IPAdapterEmbeddingPreprocessor):
 
     def update_faceid_v2_weight(self, weight: float) -> None:
         self.faceid_v2_weight = float(weight)
-        print(
-            f"FaceIDEmbeddingPreprocessor.update_faceid_v2_weight: Updated weight to {self.faceid_v2_weight}"
-        )
-
-
+        print(f"FaceIDEmbeddingPreprocessor.update_faceid_v2_weight: Updated weight to {self.faceid_v2_weight}")

--- a/src/streamdiffusion/preprocessing/processors/feedback.py
+++ b/src/streamdiffusion/preprocessing/processors/feedback.py
@@ -1,28 +1,30 @@
+from typing import Any
+
 import torch
 from PIL import Image
-from typing import Union, Optional, Any
+
 from .base import PipelineAwareProcessor
 
 
 class FeedbackPreprocessor(PipelineAwareProcessor):
     """
     Feedback preprocessor for ControlNet
-    
+
     Creates a configurable blend between the current input image and the previous frame's diffusion output.
     This creates a feedback loop where each generated frame influences the next generation,
     while allowing control over the blend strength for stability and creative effects.
-    
+
     Formula: output = (1 - feedback_strength) * input_image + feedback_strength * previous_output
-    
+
     Examples:
     - feedback_strength = 0.0: Pure passthrough (input only)
     - feedback_strength = 0.5: 50/50 blend (default)
     - feedback_strength = 1.0: Pure feedback (previous output only)
-    
+
     The preprocessor accesses the pipeline's prev_image_result to get the previous output.
     For the first frame (when no previous output exists), it falls back to the input image.
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
@@ -34,21 +36,29 @@ class FeedbackPreprocessor(PipelineAwareProcessor):
                     "default": 0.5,
                     "range": [0.0, 1.0],
                     "step": 0.01,
-                    "description": "Strength of feedback blend (0.0 = pure input, 1.0 = pure feedback)"
+                    "description": "Strength of feedback blend (0.0 = pure input, 1.0 = pure feedback)",
                 }
             },
-            "use_cases": ["Temporal consistency", "Video-like generation", "Smooth transitions", "Deforum", "Blast off"]
+            "use_cases": [
+                "Temporal consistency",
+                "Video-like generation",
+                "Smooth transitions",
+                "Deforum",
+                "Blast off",
+            ],
         }
-    
-    def __init__(self, 
-                 pipeline_ref: Any,
-                 normalization_context: str = 'controlnet',
-                 image_resolution: int = 512,
-                 feedback_strength: float = 0.5,
-                 **kwargs):
+
+    def __init__(
+        self,
+        pipeline_ref: Any,
+        normalization_context: str = "controlnet",
+        image_resolution: int = 512,
+        feedback_strength: float = 0.5,
+        **kwargs,
+    ):
         """
         Initialize feedback preprocessor
-        
+
         Args:
             pipeline_ref: Reference to the StreamDiffusion pipeline instance (required)
             normalization_context: Context for normalization handling
@@ -61,41 +71,42 @@ class FeedbackPreprocessor(PipelineAwareProcessor):
             normalization_context=normalization_context,
             image_resolution=image_resolution,
             feedback_strength=feedback_strength,
-            **kwargs
+            **kwargs,
         )
         self.feedback_strength = max(0.0, min(1.0, feedback_strength))  # Clamp to [0, 1]
         self._first_frame = True
-    
+
     def reset(self):
         """Reset the processor state (useful for new sequences)"""
         self._first_frame = True
-    
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Process using configurable blend of input image + previous frame output
-        
+
         Args:
             image: Current input image
-            
+
         Returns:
             Blended PIL Image (blend strength controlled by feedback_strength), or input image for first frame
         """
         # Check if we have a pipeline reference and previous output
-        if (self.pipeline_ref is not None and 
-            hasattr(self.pipeline_ref, 'prev_image_result') and 
-            self.pipeline_ref.prev_image_result is not None and
-            not self._first_frame):
-            
+        if (
+            self.pipeline_ref is not None
+            and hasattr(self.pipeline_ref, "prev_image_result")
+            and self.pipeline_ref.prev_image_result is not None
+            and not self._first_frame
+        ):
             prev_output_tensor = self.pipeline_ref.prev_image_result
             # Convert previous output tensor to PIL Image
             if prev_output_tensor.dim() == 4:
                 prev_output_tensor = prev_output_tensor[0]  # Remove batch dimension
-            
+
             # Context-aware normalization handling
-            if self.normalization_context == 'controlnet':
+            if self.normalization_context == "controlnet":
                 # ControlNet context: Convert from [-1, 1] (VAE output) to [0, 1] (ControlNet input)
                 prev_output_tensor = (prev_output_tensor / 2.0 + 0.5).clamp(0, 1)
-            elif self.normalization_context == 'pipeline':
+            elif self.normalization_context == "pipeline":
                 # Pipeline context: prev_output is already [-1, 1], but pil_to_tensor produces [0, 1]
                 # So we need to convert input to [-1, 1] to match prev_output
                 # Convert prev_output to [0, 1] for blending in standard image space
@@ -103,15 +114,15 @@ class FeedbackPreprocessor(PipelineAwareProcessor):
             else:
                 # Unknown context - assume controlnet for backward compatibility
                 prev_output_tensor = (prev_output_tensor / 2.0 + 0.5).clamp(0, 1)
-            
+
             # Convert both to tensors for blending
             prev_output_pil = self.tensor_to_pil(prev_output_tensor)
             input_tensor = self.pil_to_tensor(image).squeeze(0)  # Remove batch dim for blending
             prev_tensor = self.pil_to_tensor(prev_output_pil).squeeze(0)
-            
+
             # Blend with configurable strength (both tensors now in [0, 1] range)
             blended_tensor = (1 - self.feedback_strength) * input_tensor + self.feedback_strength * prev_tensor
-            
+
             # Convert back to PIL
             blended_pil = self.tensor_to_pil(blended_tensor)
             return blended_pil
@@ -119,35 +130,36 @@ class FeedbackPreprocessor(PipelineAwareProcessor):
             # First frame, no pipeline ref, or no previous output available - use input image
             self._first_frame = False
             return image
-    
+
     def _process_tensor_core(self, tensor: torch.Tensor) -> torch.Tensor:
         """
         Process using configurable blend of input tensor + previous frame output (GPU-optimized path)
-        
+
         Args:
             tensor: Current input tensor
-            
+
         Returns:
             Blended tensor (blend strength controlled by feedback_strength), or input tensor for first frame
         """
         # Check if we have a pipeline reference and previous output
-        if (self.pipeline_ref is not None and 
-            hasattr(self.pipeline_ref, 'prev_image_result') and 
-            self.pipeline_ref.prev_image_result is not None and
-            not self._first_frame):
-            
+        if (
+            self.pipeline_ref is not None
+            and hasattr(self.pipeline_ref, "prev_image_result")
+            and self.pipeline_ref.prev_image_result is not None
+            and not self._first_frame
+        ):
             prev_output = self.pipeline_ref.prev_image_result
             input_tensor = tensor
-            
+
             # Context-aware normalization handling
-            if self.normalization_context == 'controlnet':
+            if self.normalization_context == "controlnet":
                 # ControlNet context: prev_output is [-1, 1] from VAE, input is [0, 1]
                 # Convert prev_output from [-1, 1] to [0, 1] to match input
                 prev_output = (prev_output / 2.0 + 0.5).clamp(0, 1)
                 # Normalize input tensor to [0, 1] if needed
                 if input_tensor.max() > 1.0:
                     input_tensor = input_tensor / 255.0
-            elif self.normalization_context == 'pipeline':
+            elif self.normalization_context == "pipeline":
                 # Pipeline context: both prev_output and input_tensor are in [-1, 1] range
                 # - prev_output comes from VAE decode (always [-1, 1])
                 # - input_tensor arrives as [-1, 1] from image_processor.preprocess()
@@ -157,17 +169,20 @@ class FeedbackPreprocessor(PipelineAwareProcessor):
             else:
                 # Unknown context - log warning and assume controlnet behavior for backward compatibility
                 import logging
-                logging.warning(f"FeedbackPreprocessor: Unknown normalization_context '{self.normalization_context}', using controlnet behavior")
+
+                logging.warning(
+                    f"FeedbackPreprocessor: Unknown normalization_context '{self.normalization_context}', using controlnet behavior"
+                )
                 prev_output = (prev_output / 2.0 + 0.5).clamp(0, 1)
                 if input_tensor.max() > 1.0:
                     input_tensor = input_tensor / 255.0
-            
+
             # Ensure both tensors have same format for blending
             if prev_output.dim() == 4 and prev_output.shape[0] == 1:
                 prev_output = prev_output[0]  # Remove batch dimension
             if input_tensor.dim() == 4 and input_tensor.shape[0] == 1:
                 input_tensor = input_tensor[0]  # Remove batch dimension
-                
+
             # Resize if dimensions don't match
             if prev_output.shape != input_tensor.shape:
                 # Use the input tensor's shape as target
@@ -176,18 +191,18 @@ class FeedbackPreprocessor(PipelineAwareProcessor):
                     if prev_output.dim() == 3:
                         prev_output = prev_output.unsqueeze(0)
                     prev_output = torch.nn.functional.interpolate(
-                        prev_output, size=target_size, mode='bilinear', align_corners=False
+                        prev_output, size=target_size, mode="bilinear", align_corners=False
                     )
                     if prev_output.shape[0] == 1:
                         prev_output = prev_output.squeeze(0)
-            
+
             # Blend with configurable strength
             blended_tensor = (1 - self.feedback_strength) * input_tensor + self.feedback_strength * prev_output
-            
+
             # Ensure correct output format
             if blended_tensor.dim() == 3:
                 blended_tensor = blended_tensor.unsqueeze(0)  # Add batch dimension back
-                
+
             # Ensure correct device and dtype
             blended_tensor = blended_tensor.to(device=self.device, dtype=self.dtype)
             return blended_tensor

--- a/src/streamdiffusion/preprocessing/processors/hed.py
+++ b/src/streamdiffusion/preprocessing/processors/hed.py
@@ -1,11 +1,13 @@
-import torch
 import numpy as np
+import torch
 from PIL import Image
-from typing import Union, Optional
+
 from .base import BasePreprocessor
+
 
 try:
     from controlnet_aux import HEDdetector
+
     CONTROLNET_AUX_AVAILABLE = True
 except ImportError:
     CONTROLNET_AUX_AVAILABLE = False
@@ -15,83 +17,81 @@ except ImportError:
 class HEDPreprocessor(BasePreprocessor):
     """
     HED (Holistically-Nested Edge Detection) preprocessor
-    
+
     Uses controlnet_aux HEDdetector for high-quality edge detection.
     """
-    
+
     _model_cache = {}
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
             "display_name": "HED Edge Detection",
             "description": "Holistically-Nested Edge Detection for clean, structured edge maps.",
             "parameters": {
-                "safe": {
-                    "type": "bool",
-                    "default": True,
-                    "description": "Whether to use safe mode for edge detection"
-                }
+                "safe": {"type": "bool", "default": True, "description": "Whether to use safe mode for edge detection"}
             },
-            "use_cases": ["Structured edge detection", "Clean architectural edges", "Line art generation"]
+            "use_cases": ["Structured edge detection", "Clean architectural edges", "Line art generation"],
         }
-    
+
     def __init__(self, safe: bool = True, **kwargs):
         if not CONTROLNET_AUX_AVAILABLE:
-            raise ImportError("controlnet_aux is required for HED preprocessor. Install with: pip install controlnet_aux")
-        
+            raise ImportError(
+                "controlnet_aux is required for HED preprocessor. Install with: pip install controlnet_aux"
+            )
+
         super().__init__(**kwargs)
         self.safe = safe
         self.model = None
         self._load_model()
-    
+
     def _load_model(self):
         """Load controlnet_aux HED model with caching"""
         cache_key = f"hed_{self.device}"
-        
+
         if cache_key in self._model_cache:
             self.model = self._model_cache[cache_key]
             return
-        
+
         print("HEDPreprocessor: Loading controlnet_aux HED model")
         try:
             # Initialize HED detector
             self.model = HEDdetector.from_pretrained("lllyasviel/Annotators")
-            if hasattr(self.model, 'to'):
+            if hasattr(self.model, "to"):
                 self.model = self.model.to(self.device)
-            
+
             # Cache the model
             self._model_cache[cache_key] = self.model
             print(f"HEDPreprocessor: Successfully loaded model on {self.device}")
-            
+
         except Exception as e:
             raise RuntimeError(f"Failed to load HED model: {e}")
-    
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """Apply HED edge detection to the input image"""
         # Get target dimensions
         target_width, target_height = self.get_target_dimensions()
-        
+
         # Process with controlnet_aux
         result = self.model(image, output_type="pil")
-        
+
         # Ensure result is PIL Image
         if not isinstance(result, Image.Image):
             if isinstance(result, np.ndarray):
                 result = Image.fromarray(result)
             else:
                 raise ValueError(f"Unexpected result type: {type(result)}")
-        
+
         # Resize to target size if needed
         if result.size != (target_width, target_height):
             result = result.resize((target_width, target_height), Image.LANCZOS)
-        
+
         return result
-    
+
     def _process_tensor_core(self, image_tensor: torch.Tensor) -> torch.Tensor:
         """
         GPU-optimized HED processing using tensors
-        
+
         Note: controlnet_aux doesn't support direct tensor input, so we convert to PIL and back.
         This is still reasonably fast due to optimized conversions in the base class.
         """
@@ -99,24 +99,18 @@ class HEDPreprocessor(BasePreprocessor):
         pil_image = self.tensor_to_pil(image_tensor)
         processed_pil = self._process_core(pil_image)
         return self.pil_to_tensor(processed_pil)
-    
-    
+
     @classmethod
-    def create_optimized(cls, device: str = 'cuda', dtype: torch.dtype = torch.float16, **kwargs):
+    def create_optimized(cls, device: str = "cuda", dtype: torch.dtype = torch.float16, **kwargs):
         """
         Create an optimized HED preprocessor
-        
+
         Args:
             device: Target device ('cuda' or 'cpu')
             dtype: Data type for inference
             **kwargs: Additional parameters
-            
+
         Returns:
             Optimized HEDPreprocessor instance
         """
-        return cls(
-            device=device,
-            dtype=dtype,
-            safe=True,
-            **kwargs
-        ) 
+        return cls(device=device, dtype=dtype, safe=True, **kwargs)

--- a/src/streamdiffusion/preprocessing/processors/ipadapter_embedding.py
+++ b/src/streamdiffusion/preprocessing/processors/ipadapter_embedding.py
@@ -1,6 +1,8 @@
-from typing import Union, Tuple, Optional, Any
+from typing import Any, Tuple, Union
+
 import torch
 from PIL import Image
+
 from .base import BasePreprocessor
 
 
@@ -9,53 +11,53 @@ class IPAdapterEmbeddingPreprocessor(BasePreprocessor):
     Preprocessor that generates IPAdapter embeddings instead of spatial conditioning.
     Leverages existing preprocessing infrastructure for parallel IPAdapter embedding generation.
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
             "display_name": "IPAdapter Embedding",
             "description": "Generates IPAdapter embeddings for style transfer and image conditioning instead of spatial control maps.",
             "parameters": {},
-            "use_cases": ["Style transfer", "Image conditioning", "Semantic control", "Content-aware generation"]
+            "use_cases": ["Style transfer", "Image conditioning", "Semantic control", "Content-aware generation"],
         }
-    
+
     def __init__(self, ipadapter: Any, **kwargs):
         super().__init__(**kwargs)
         self.ipadapter = ipadapter
         # Verify the ipadapter has the required method
-        if not hasattr(ipadapter, 'get_image_embeds'):
+        if not hasattr(ipadapter, "get_image_embeds"):
             raise ValueError("IPAdapterEmbeddingPreprocessor: ipadapter must have 'get_image_embeds' method")
-        
+
         # Create dedicated CUDA stream for IPAdapter processing to avoid TensorRT conflicts
         self._ipadapter_stream = torch.cuda.Stream() if torch.cuda.is_available() else None
-        
+
     def _process_core(self, image: Image.Image) -> Tuple[torch.Tensor, torch.Tensor]:
         """Returns (positive_embeds, negative_embeds) instead of processed image"""
         if self._ipadapter_stream is not None:
             # Use dedicated stream to avoid TensorRT stream capture conflicts
             with torch.cuda.stream(self._ipadapter_stream):
                 image_embeds, negative_embeds = self.ipadapter.get_image_embeds(images=[image])
-                
+
             # Wait for stream completion and move tensors to default stream
             self._ipadapter_stream.synchronize()
-            
+
             # Ensure tensors are accessible from default stream
-            if hasattr(image_embeds, 'record_stream'):
+            if hasattr(image_embeds, "record_stream"):
                 image_embeds.record_stream(torch.cuda.current_stream())
-            if hasattr(negative_embeds, 'record_stream'):
+            if hasattr(negative_embeds, "record_stream"):
                 negative_embeds.record_stream(torch.cuda.current_stream())
         else:
             # Fallback for non-CUDA environments
             image_embeds, negative_embeds = self.ipadapter.get_image_embeds(images=[image])
-            
+
         return image_embeds, negative_embeds
-        
+
     def _process_tensor_core(self, tensor: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         """GPU-optimized path for tensor inputs"""
         # Convert tensor to PIL for IPAdapter processing
         pil_image = self.tensor_to_pil(tensor)
         return self._process_core(pil_image)
-    
+
     def process(self, image: Union[Image.Image, torch.Tensor]) -> Tuple[torch.Tensor, torch.Tensor]:
         """Override base process to return embeddings tuple instead of PIL Image"""
         if isinstance(image, torch.Tensor):
@@ -63,9 +65,9 @@ class IPAdapterEmbeddingPreprocessor(BasePreprocessor):
         else:
             image = self.validate_input(image)
             result = self._process_core(image)
-        
+
         return result
-    
+
     def process_tensor(self, image_tensor: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         """Override base process_tensor to return embeddings tuple"""
         tensor = self.validate_tensor_input(image_tensor)

--- a/src/streamdiffusion/preprocessing/processors/latent_feedback.py
+++ b/src/streamdiffusion/preprocessing/processors/latent_feedback.py
@@ -1,27 +1,29 @@
+from typing import Any
+
 import torch
-from typing import Optional, Any
+
 from .base import PipelineAwareProcessor
 
 
 class LatentFeedbackPreprocessor(PipelineAwareProcessor):
     """
     Latent domain feedback preprocessor
-    
+
     Creates a configurable blend between the current input latent and the previous frame's latent output.
     This creates a feedback loop in latent space where each generated latent influences the next generation,
     providing temporal consistency without the overhead of VAE encoding/decoding.
-    
+
     Formula: output = (1 - feedback_strength) * input_latent + feedback_strength * previous_latent
-    
+
     Examples:
     - feedback_strength = 0.0: Pure passthrough (input only)
     - feedback_strength = 0.15: Default safe blend
     - feedback_strength = 0.40: Maximum safe feedback (values > 0.4 produce garbage)
-    
+
     The preprocessor accesses the pipeline's prev_latent_result to get the previous latent output.
     For the first frame (when no previous output exists), it falls back to the input latent.
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
@@ -33,20 +35,24 @@ class LatentFeedbackPreprocessor(PipelineAwareProcessor):
                     "default": 0.15,
                     "range": [0.0, 0.40],
                     "step": 0.01,
-                    "description": "Strength of latent feedback blend (0.0 = pure input, .40 = more feedback)"
+                    "description": "Strength of latent feedback blend (0.0 = pure input, .40 = more feedback)",
                 }
             },
-            "use_cases": ["Latent temporal consistency", "Latent space transitions", "Efficient feedback", "Latent preprocessing", "Temporal stability"]
+            "use_cases": [
+                "Latent temporal consistency",
+                "Latent space transitions",
+                "Efficient feedback",
+                "Latent preprocessing",
+                "Temporal stability",
+            ],
         }
-    
-    def __init__(self, 
-                 pipeline_ref: Any,
-                 normalization_context: str = 'latent',
-                 feedback_strength: float = 0.15,
-                 **kwargs):
+
+    def __init__(
+        self, pipeline_ref: Any, normalization_context: str = "latent", feedback_strength: float = 0.15, **kwargs
+    ):
         """
         Initialize latent feedback preprocessor
-        
+
         Args:
             pipeline_ref: Reference to the StreamDiffusion pipeline instance (required)
             normalization_context: Context for normalization handling (latent space doesn't need normalization)
@@ -57,29 +63,31 @@ class LatentFeedbackPreprocessor(PipelineAwareProcessor):
             pipeline_ref=pipeline_ref,
             normalization_context=normalization_context,
             feedback_strength=feedback_strength,
-            **kwargs
+            **kwargs,
         )
-        self.feedback_strength = max(0.0, min(0.40, feedback_strength))  # Clamp to [0, 0.40] - values > 0.4 produce garbage
+        self.feedback_strength = max(
+            0.0, min(0.40, feedback_strength)
+        )  # Clamp to [0, 0.40] - values > 0.4 produce garbage
         self._first_frame = True
-    
+
     def _get_previous_data(self):
         """Get previous frame latent data from pipeline"""
         if self.pipeline_ref is not None:
             # Get previous OUTPUT latent (after diffusion), not input latent
             # Check for prev_latent_result (the actual attribute name used by the pipeline)
-            if hasattr(self.pipeline_ref, 'prev_latent_result'):
+            if hasattr(self.pipeline_ref, "prev_latent_result"):
                 if self.pipeline_ref.prev_latent_result is not None and not self._first_frame:
                     return self.pipeline_ref.prev_latent_result
         return None
-    
-    #TODO: eventually, these processors should be divided by input and output domain rather than overriding image-first basec class
+
+    # TODO: eventually, these processors should be divided by input and output domain rather than overriding image-first basec class
     def validate_tensor_input(self, latent_tensor: torch.Tensor) -> torch.Tensor:
         """
         Validate latent tensor input - preserve batch dimensions for latent processing
-        
+
         Args:
             latent_tensor: Input latent tensor in format [B, C, H/8, W/8]
-            
+
         Returns:
             Validated latent tensor with preserved batch dimension
         """
@@ -87,18 +95,18 @@ class LatentFeedbackPreprocessor(PipelineAwareProcessor):
         # Only ensure correct device and dtype
         latent_tensor = latent_tensor.to(device=self.device, dtype=self.dtype)
         return latent_tensor
-        
-    #TODO: eventually, these processors should be divided by input and output domain rather than overriding image-first basec class
+
+    # TODO: eventually, these processors should be divided by input and output domain rather than overriding image-first basec class
     def _ensure_target_size_tensor(self, tensor: torch.Tensor) -> torch.Tensor:
         """
         Override base class resize logic - latent tensors should NOT be resized to image dimensions
-        
+
         For latent domain processing, we want to preserve the latent space dimensions,
         not resize to image target dimensions like image-domain processors.
         """
         # For latent feedback, just return the tensor as-is without any resizing
         return tensor
-    
+
     def _process_core(self, image):
         """
         For latent feedback, we don't process PIL images directly.
@@ -108,23 +116,23 @@ class LatentFeedbackPreprocessor(PipelineAwareProcessor):
             "LatentFeedbackPreprocessor is designed for latent domain processing. "
             "Use _process_tensor_core or process_tensor for latent tensors."
         )
-    
+
     def _process_tensor_core(self, tensor: torch.Tensor) -> torch.Tensor:
         """
         Process latent tensor with feedback blending
-        
+
         Args:
             tensor: Current input latent tensor in format [B, C, H/8, W/8]
-            
+
         Returns:
             Blended latent tensor (blend strength controlled by feedback_strength), or input tensor for first frame
         """
         # Get previous frame latent data using mixin method
         prev_latent = self._get_previous_data()
-        
+
         if prev_latent is not None:
             input_latent = tensor
-            
+
             # Ensure both tensors have the same batch size for element-wise blending
             # If batch sizes differ, expand the smaller one to match
             if prev_latent.shape[0] != input_latent.shape[0]:
@@ -139,22 +147,22 @@ class LatentFeedbackPreprocessor(PipelineAwareProcessor):
                     min_batch = min(prev_latent.shape[0], input_latent.shape[0])
                     prev_latent = prev_latent[:min_batch]
                     input_latent = input_latent[:min_batch]
-            
+
             # Resize spatial dimensions if they don't match (though this should be rare in latent space)
             if prev_latent.shape[2:] != input_latent.shape[2:]:
                 target_size = input_latent.shape[2:]  # Get H, W from input
                 prev_latent = torch.nn.functional.interpolate(
-                    prev_latent, size=target_size, mode='bilinear', align_corners=False
+                    prev_latent, size=target_size, mode="bilinear", align_corners=False
                 )
-            
+
             # Blend current latent with previous latent for temporal consistency
             # Higher feedback_strength = more influence from previous frame
             blended_latent = (1 - self.feedback_strength) * input_latent + self.feedback_strength * prev_latent
-            
+
             # Add safety measures for latent values to prevent extreme outputs
             # Clamp to reasonable range based on typical latent distributions
             blended_latent = torch.clamp(blended_latent, min=-10.0, max=10.0)
-            
+
             # Ensure correct device and dtype
             blended_latent = blended_latent.to(device=self.device, dtype=self.dtype)
             return blended_latent

--- a/src/streamdiffusion/preprocessing/processors/lineart.py
+++ b/src/streamdiffusion/preprocessing/processors/lineart.py
@@ -1,29 +1,34 @@
 import logging
-import numpy as np
-from PIL import Image
-from typing import Union, Optional
 import time
+
+from PIL import Image
+
 from .base import BasePreprocessor
+
 
 logger = logging.getLogger(__name__)
 
 try:
-    from controlnet_aux import LineartDetector, LineartAnimeDetector
+    from controlnet_aux import LineartAnimeDetector, LineartDetector
+
     CONTROLNET_AUX_AVAILABLE = True
 except ImportError:
     CONTROLNET_AUX_AVAILABLE = False
-    raise ImportError("LineartPreprocessor: controlnet_aux is required for real-time optimization. Install with: pip install controlnet_aux")
+    raise ImportError(
+        "LineartPreprocessor: controlnet_aux is required for real-time optimization. Install with: pip install controlnet_aux"
+    )
 
-#TODO provide gpu native lineart detection
+
+# TODO provide gpu native lineart detection
 class LineartPreprocessor(BasePreprocessor):
     """
     Real-time optimized Lineart detection preprocessor for ControlNet
-    
+
     Extracts line art from input images using controlnet_aux line art detection models.
     Supports both realistic and anime-style line art extraction.
     Optimized for real-time performance - no fallbacks.
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
@@ -33,26 +38,28 @@ class LineartPreprocessor(BasePreprocessor):
                 "coarse": {
                     "type": "bool",
                     "default": True,
-                    "description": "Whether to use coarse line art detection (faster but less detailed)"
+                    "description": "Whether to use coarse line art detection (faster but less detailed)",
                 },
                 "anime_style": {
                     "type": "bool",
                     "default": False,
-                    "description": "Whether to use anime-style line art detection"
-                }
+                    "description": "Whether to use anime-style line art detection",
+                },
             },
-            "use_cases": ["Sketch to image", "Line art generation", "Clean line extraction"]
+            "use_cases": ["Sketch to image", "Line art generation", "Clean line extraction"],
         }
-    
-    def __init__(self, 
-                 detect_resolution: int = 512,
-                 image_resolution: int = 512,
-                 coarse: bool = True,
-                 anime_style: bool = False,
-                 **kwargs):
+
+    def __init__(
+        self,
+        detect_resolution: int = 512,
+        image_resolution: int = 512,
+        coarse: bool = True,
+        anime_style: bool = False,
+        **kwargs,
+    ):
         """
         Initialize Lineart preprocessor
-        
+
         Args:
             detect_resolution: Resolution for line art detection
             image_resolution: Output image resolution
@@ -65,34 +72,34 @@ class LineartPreprocessor(BasePreprocessor):
             image_resolution=image_resolution,
             coarse=coarse,
             anime_style=anime_style,
-            **kwargs
+            **kwargs,
         )
 
         self._detector = None
-    
+
     @property
     def detector(self):
         """Lazy loading of the line art detector - controlnet_aux only"""
         if self._detector is None:
             start_time = time.time()
-            anime_style = self.params.get('anime_style', False)
-            
+            anime_style = self.params.get("anime_style", False)
+
             if anime_style:
-                self._detector = LineartAnimeDetector.from_pretrained('lllyasviel/Annotators')
+                self._detector = LineartAnimeDetector.from_pretrained("lllyasviel/Annotators")
             else:
-                self._detector = LineartDetector.from_pretrained('lllyasviel/Annotators')
+                self._detector = LineartDetector.from_pretrained("lllyasviel/Annotators")
 
             load_time = time.time() - start_time
             logger.info(f"Lineart detector loaded in {load_time:.3f}s")
-            
+
         return self._detector
-    
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Apply line art detection to the input image
         """
-        detect_resolution = self.params.get('detect_resolution', 512)
-        coarse = self.params.get('coarse', False)
+        detect_resolution = self.params.get("detect_resolution", 512)
+        coarse = self.params.get("coarse", False)
 
         if image.size != (detect_resolution, detect_resolution):
             image_resized = image.resize((detect_resolution, detect_resolution), Image.LANCZOS)
@@ -100,10 +107,7 @@ class LineartPreprocessor(BasePreprocessor):
             image_resized = image
 
         lineart_image = self.detector(
-            image_resized,
-            detect_resolution=detect_resolution,
-            image_resolution=detect_resolution,
-            coarse=coarse
+            image_resized, detect_resolution=detect_resolution, image_resolution=detect_resolution, coarse=coarse
         )
 
         return lineart_image

--- a/src/streamdiffusion/preprocessing/processors/mediapipe_pose.py
+++ b/src/streamdiffusion/preprocessing/processors/mediapipe_pose.py
@@ -1,12 +1,16 @@
+from typing import List
+
+import cv2
 import numpy as np
 import torch
-import cv2
-from PIL import Image, ImageDraw
-from typing import Union, Optional, List, Tuple, Dict
+from PIL import Image
+
 from .base import BasePreprocessor
+
 
 try:
     import mediapipe as mp
+
     MEDIAPIPE_AVAILABLE = True
 except ImportError:
     MEDIAPIPE_AVAILABLE = False
@@ -21,49 +25,87 @@ MEDIAPIPE_TO_OPENPOSE_MAP = {
     # 10: RKnee, 11: RAnkle, 12: LHip, 13: LKnee, 14: LAnkle,
     # 15: REye, 16: LEye, 17: REar, 18: LEar, 19: LBigToe,
     # 20: LSmallToe, 21: LHeel, 22: RBigToe, 23: RSmallToe, 24: RHeel
-    
-    0: 0,   # Nose -> Nose
-    1: None, # Neck (calculated from shoulders)
+    0: 0,  # Nose -> Nose
+    1: None,  # Neck (calculated from shoulders)
     2: 12,  # RShoulder -> RightShoulder
-    3: 14,  # RElbow -> RightElbow  
+    3: 14,  # RElbow -> RightElbow
     4: 16,  # RWrist -> RightWrist
     5: 11,  # LShoulder -> LeftShoulder
     6: 13,  # LElbow -> LeftElbow
     7: 15,  # LWrist -> LeftWrist
-    8: None, # MidHip (calculated from hips)
+    8: None,  # MidHip (calculated from hips)
     9: 24,  # RHip -> RightHip
-    10: 26, # RKnee -> RightKnee
-    11: 28, # RAnkle -> RightAnkle
-    12: 23, # LHip -> LeftHip
-    13: 25, # LKnee -> LeftKnee
-    14: 27, # LAnkle -> LeftAnkle
+    10: 26,  # RKnee -> RightKnee
+    11: 28,  # RAnkle -> RightAnkle
+    12: 23,  # LHip -> LeftHip
+    13: 25,  # LKnee -> LeftKnee
+    14: 27,  # LAnkle -> LeftAnkle
     15: 5,  # REye -> RightEye
     16: 2,  # LEye -> LeftEye
     17: 8,  # REar -> RightEar
     18: 7,  # LEar -> LeftEar
-    19: 31, # LBigToe -> LeftFootIndex
-    20: 31, # LSmallToe -> LeftFootIndex (approximation)
-    21: 29, # LHeel -> LeftHeel
-    22: 32, # RBigToe -> RightFootIndex
-    23: 32, # RSmallToe -> RightFootIndex (approximation)
-    24: 30  # RHeel -> RightHeel
+    19: 31,  # LBigToe -> LeftFootIndex
+    20: 31,  # LSmallToe -> LeftFootIndex (approximation)
+    21: 29,  # LHeel -> LeftHeel
+    22: 32,  # RBigToe -> RightFootIndex
+    23: 32,  # RSmallToe -> RightFootIndex (approximation)
+    24: 30,  # RHeel -> RightHeel
 }
 
 # OpenPose connections for proper skeleton rendering
 OPENPOSE_LIMB_SEQUENCE = [
-    [1, 2], [1, 5], [2, 3], [3, 4], [5, 6], [6, 7],
-    [1, 8], [8, 9], [9, 10], [10, 11], [8, 12], [12, 13], 
-    [13, 14], [1, 0], [0, 15], [15, 17], [0, 16], [16, 18],
-    [14, 19], [19, 20], [14, 21], [11, 22], [22, 23], [11, 24]
+    [1, 2],
+    [1, 5],
+    [2, 3],
+    [3, 4],
+    [5, 6],
+    [6, 7],
+    [1, 8],
+    [8, 9],
+    [9, 10],
+    [10, 11],
+    [8, 12],
+    [12, 13],
+    [13, 14],
+    [1, 0],
+    [0, 15],
+    [15, 17],
+    [0, 16],
+    [16, 18],
+    [14, 19],
+    [19, 20],
+    [14, 21],
+    [11, 22],
+    [22, 23],
+    [11, 24],
 ]
 
 # Standard OpenPose colors (BGR format) - matching actual OpenPose output
 OPENPOSE_COLORS = [
-    [255, 0, 0], [255, 85, 0], [255, 170, 0], [255, 255, 0], [170, 255, 0], 
-    [85, 255, 0], [0, 255, 0], [0, 255, 85], [0, 255, 170], [0, 255, 255], 
-    [0, 170, 255], [0, 85, 255], [0, 0, 255], [85, 0, 255], [170, 0, 255], 
-    [255, 0, 255], [255, 0, 170], [255, 0, 85], [255, 0, 0], [255, 85, 0],
-    [255, 170, 0], [255, 255, 0], [170, 255, 0], [85, 255, 0]
+    [255, 0, 0],
+    [255, 85, 0],
+    [255, 170, 0],
+    [255, 255, 0],
+    [170, 255, 0],
+    [85, 255, 0],
+    [0, 255, 0],
+    [0, 255, 85],
+    [0, 255, 170],
+    [0, 255, 255],
+    [0, 170, 255],
+    [0, 85, 255],
+    [0, 0, 255],
+    [85, 0, 255],
+    [170, 0, 255],
+    [255, 0, 255],
+    [255, 0, 170],
+    [255, 0, 85],
+    [255, 0, 0],
+    [255, 85, 0],
+    [255, 170, 0],
+    [255, 255, 0],
+    [170, 255, 0],
+    [85, 255, 0],
 ]
 
 # OPTIMIZATION: Vectorized mapping for MediaPipe to OpenPose conversion
@@ -76,19 +118,20 @@ MEDIAPIPE_INDICES = np.array([pair[1] for pair in VALID_MAPPINGS], dtype=np.int3
 OPENPOSE_COLORS_ARRAY = np.array(OPENPOSE_COLORS, dtype=np.uint8)
 LIMB_SEQUENCE_ARRAY = np.array(OPENPOSE_LIMB_SEQUENCE, dtype=np.int32)
 
+
 class MediaPipePosePreprocessor(BasePreprocessor):
     """
     MediaPipe-based pose preprocessor for ControlNet that outputs OpenPose-style annotations
-    
+
     Converts MediaPipe's 33 keypoints to OpenPose's 25 keypoints format and renders
     them in the standard OpenPose style for ControlNet compatibility.
-    
+
     Improvements inspired by TouchDesigner MediaPipe plugin:
     - Better confidence filtering
     - Temporal smoothing for jitter reduction
     - Improved multi-pose support preparation
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
@@ -100,89 +143,88 @@ class MediaPipePosePreprocessor(BasePreprocessor):
                     "default": 0.5,
                     "range": [0.0, 1.0],
                     "step": 0.01,
-                    "description": "Minimum confidence for pose detection"
+                    "description": "Minimum confidence for pose detection",
                 },
                 "min_tracking_confidence": {
                     "type": "float",
                     "default": 0.5,
                     "range": [0.0, 1.0],
                     "step": 0.01,
-                    "description": "Minimum confidence for pose tracking"
+                    "description": "Minimum confidence for pose tracking",
                 },
                 "model_complexity": {
                     "type": "int",
                     "default": 1,
                     "range": [0, 2],
-                    "description": "MediaPipe model complexity (0=fastest, 2=most accurate)"
+                    "description": "MediaPipe model complexity (0=fastest, 2=most accurate)",
                 },
                 "static_image_mode": {
                     "type": "bool",
                     "default": False,
-                    "description": "Use static image mode (slower but more accurate per frame)"
+                    "description": "Use static image mode (slower but more accurate per frame)",
                 },
-                "draw_hands": {
-                    "type": "bool",
-                    "default": True,
-                    "description": "Whether to draw hand poses"
-                },
-                "draw_face": {
-                    "type": "bool",
-                    "default": False,
-                    "description": "Whether to draw face landmarks"
-                },
+                "draw_hands": {"type": "bool", "default": True, "description": "Whether to draw hand poses"},
+                "draw_face": {"type": "bool", "default": False, "description": "Whether to draw face landmarks"},
                 "line_thickness": {
                     "type": "int",
                     "default": 2,
                     "range": [1, 10],
-                    "description": "Thickness of skeleton lines"
+                    "description": "Thickness of skeleton lines",
                 },
                 "circle_radius": {
                     "type": "int",
                     "default": 4,
                     "range": [1, 10],
-                    "description": "Radius of joint circles"
+                    "description": "Radius of joint circles",
                 },
                 "confidence_threshold": {
                     "type": "float",
                     "default": 0.3,
                     "range": [0.0, 1.0],
                     "step": 0.01,
-                    "description": "Minimum confidence for rendering keypoints"
+                    "description": "Minimum confidence for rendering keypoints",
                 },
                 "enable_smoothing": {
                     "type": "bool",
                     "default": True,
-                    "description": "Enable temporal smoothing to reduce jitter"
+                    "description": "Enable temporal smoothing to reduce jitter",
                 },
                 "smoothing_factor": {
                     "type": "float",
                     "default": 0.7,
                     "range": [0.0, 1.0],
                     "step": 0.01,
-                    "description": "Smoothing strength (higher = more smoothing)"
-                }
+                    "description": "Smoothing strength (higher = more smoothing)",
+                },
             },
-            "use_cases": ["Detailed pose control", "Hand and face detection", "Real-time pose tracking", "Custom confidence tuning"]
+            "use_cases": [
+                "Detailed pose control",
+                "Hand and face detection",
+                "Real-time pose tracking",
+                "Custom confidence tuning",
+            ],
         }
-    
-    def __init__(self,
-                 detect_resolution: int = 256,  # OPTIMIZATION: Reduced from 512 for 4x speedup
-                 image_resolution: int = 512,
-                 min_detection_confidence: float = 0.5,
-                 min_tracking_confidence: float = 0.5,
-                 model_complexity: int = 1,
-                 static_image_mode: bool = False,  # OPTIMIZATION: Video mode for tracking (3-5x faster)
-                 draw_hands: bool = True,
-                 draw_face: bool = False,  # Simplified - disable face by default
-                 line_thickness: int = 2,
-                 circle_radius: int = 4,
-                 confidence_threshold: float = 0.3,  # TouchDesigner-style confidence filtering
-                 enable_smoothing: bool = True,  # TouchDesigner-inspired smoothing
-                 smoothing_factor: float = 0.7,  # Smoothing strength
-                 **kwargs):
+
+    def __init__(
+        self,
+        detect_resolution: int = 256,  # OPTIMIZATION: Reduced from 512 for 4x speedup
+        image_resolution: int = 512,
+        min_detection_confidence: float = 0.5,
+        min_tracking_confidence: float = 0.5,
+        model_complexity: int = 1,
+        static_image_mode: bool = False,  # OPTIMIZATION: Video mode for tracking (3-5x faster)
+        draw_hands: bool = True,
+        draw_face: bool = False,  # Simplified - disable face by default
+        line_thickness: int = 2,
+        circle_radius: int = 4,
+        confidence_threshold: float = 0.3,  # TouchDesigner-style confidence filtering
+        enable_smoothing: bool = True,  # TouchDesigner-inspired smoothing
+        smoothing_factor: float = 0.7,  # Smoothing strength
+        **kwargs,
+    ):
         """
         Initialize MediaPipe pose preprocessor with TouchDesigner-inspired improvements
-        
+
         Args:
             detect_resolution: Resolution for pose detection
             image_resolution: Output image resolution
@@ -201,10 +243,9 @@ class MediaPipePosePreprocessor(BasePreprocessor):
         """
         if not MEDIAPIPE_AVAILABLE:
             raise ImportError(
-                "MediaPipe is required for MediaPipe pose preprocessing. "
-                "Install it with: pip install mediapipe"
+                "MediaPipe is required for MediaPipe pose preprocessing. Install it with: pip install mediapipe"
             )
-        
+
         super().__init__(
             detect_resolution=detect_resolution,
             image_resolution=image_resolution,
@@ -219,312 +260,335 @@ class MediaPipePosePreprocessor(BasePreprocessor):
             confidence_threshold=confidence_threshold,
             enable_smoothing=enable_smoothing,
             smoothing_factor=smoothing_factor,
-            **kwargs
+            **kwargs,
         )
-        
+
         self._detector = None
         self._current_options = None
         # TouchDesigner-style smoothing buffers
         self._smoothing_buffers = {}
-    
+
     @property
     def detector(self):
         """Lazy loading of the MediaPipe Holistic detector with GPU optimization"""
         new_options = {
-            'min_detection_confidence': self.params.get('min_detection_confidence', 0.5),
-            'min_tracking_confidence': self.params.get('min_tracking_confidence', 0.5),
-            'model_complexity': self.params.get('model_complexity', 1),
-            'static_image_mode': self.params.get('static_image_mode', False),  # Video mode default
+            "min_detection_confidence": self.params.get("min_detection_confidence", 0.5),
+            "min_tracking_confidence": self.params.get("min_tracking_confidence", 0.5),
+            "model_complexity": self.params.get("model_complexity", 1),
+            "static_image_mode": self.params.get("static_image_mode", False),  # Video mode default
         }
-        
+
         # Initialize or update detector if needed
         if self._detector is None or self._current_options != new_options:
             if self._detector is not None:
                 self._detector.close()
-            
+
             # OPTIMIZATION: Try GPU delegate first, fallback to CPU
             try:
                 print("MediaPipePosePreprocessor.detector: Attempting GPU delegate initialization")
-                
+
                 # Try to create base options with GPU delegate
                 try:
-                    base_options = mp.tasks.BaseOptions(
-                        delegate=mp.tasks.BaseOptions.Delegate.GPU
-                    )
+                    base_options = mp.tasks.BaseOptions(delegate=mp.tasks.BaseOptions.Delegate.GPU)
                     print("MediaPipePosePreprocessor.detector: GPU delegate available")
                 except Exception as gpu_error:
                     print(f"MediaPipePosePreprocessor.detector: GPU delegate failed ({gpu_error}), using CPU")
-                    base_options = mp.tasks.BaseOptions(
-                        delegate=mp.tasks.BaseOptions.Delegate.CPU
-                    )
-                
+                    base_options = mp.tasks.BaseOptions(delegate=mp.tasks.BaseOptions.Delegate.CPU)
+
                 # Create detector with optimized settings
-                print(f"MediaPipePosePreprocessor.detector: Initializing MediaPipe Holistic (video_mode={not new_options['static_image_mode']})")
+                print(
+                    f"MediaPipePosePreprocessor.detector: Initializing MediaPipe Holistic (video_mode={not new_options['static_image_mode']})"
+                )
                 self._detector = mp.solutions.holistic.Holistic(
-                    static_image_mode=new_options['static_image_mode'],
-                    model_complexity=new_options['model_complexity'],
+                    static_image_mode=new_options["static_image_mode"],
+                    model_complexity=new_options["model_complexity"],
                     enable_segmentation=False,
                     refine_face_landmarks=False,  # Keep simple for speed
-                    min_detection_confidence=new_options['min_detection_confidence'],
-                    min_tracking_confidence=new_options['min_tracking_confidence'],
+                    min_detection_confidence=new_options["min_detection_confidence"],
+                    min_tracking_confidence=new_options["min_tracking_confidence"],
                 )
-                
+
             except Exception as e:
                 print(f"MediaPipePosePreprocessor.detector: Advanced options failed ({e}), using basic setup")
                 # Fallback to basic setup
                 self._detector = mp.solutions.holistic.Holistic(
-                    static_image_mode=new_options['static_image_mode'],
-                    model_complexity=new_options['model_complexity'],
+                    static_image_mode=new_options["static_image_mode"],
+                    model_complexity=new_options["model_complexity"],
                     enable_segmentation=False,
                     refine_face_landmarks=False,
-                    min_detection_confidence=new_options['min_detection_confidence'],
-                    min_tracking_confidence=new_options['min_tracking_confidence'],
+                    min_detection_confidence=new_options["min_detection_confidence"],
+                    min_tracking_confidence=new_options["min_tracking_confidence"],
                 )
-            
+
             self._current_options = new_options
-            
+
         return self._detector
-    
+
     def _apply_smoothing(self, keypoints: List[List[float]], pose_id: str = "default") -> List[List[float]]:
         """
         Apply TouchDesigner-inspired temporal smoothing - VECTORIZED
-        
+
         Args:
             keypoints: Current frame keypoints
             pose_id: Unique identifier for this pose
-            
+
         Returns:
             Smoothed keypoints
         """
-        if not self.params.get('enable_smoothing', True) or not keypoints:
+        if not self.params.get("enable_smoothing", True) or not keypoints:
             return keypoints
-            
-        smoothing_factor = self.params.get('smoothing_factor', 0.7)
-        
+
+        smoothing_factor = self.params.get("smoothing_factor", 0.7)
+
         # Initialize buffer for this pose if needed
         if pose_id not in self._smoothing_buffers:
             self._smoothing_buffers[pose_id] = keypoints.copy()
             return keypoints
-            
+
         # OPTIMIZATION: Vectorized exponential smoothing
         current_array = np.array(keypoints, dtype=np.float32)
         previous_array = np.array(self._smoothing_buffers[pose_id], dtype=np.float32)
-        
+
         # Create confidence mask for selective smoothing
         confidence_mask = current_array[:, 2] > 0.1
-        
+
         # Vectorized smoothing calculation
         smoothed_array = previous_array.copy()
         # Apply smoothing only where confidence is good
-        smoothed_array[confidence_mask, :2] = (
-            previous_array[confidence_mask, :2] * smoothing_factor + 
-            current_array[confidence_mask, :2] * (1 - smoothing_factor)
-        )
+        smoothed_array[confidence_mask, :2] = previous_array[confidence_mask, :2] * smoothing_factor + current_array[
+            confidence_mask, :2
+        ] * (1 - smoothing_factor)
         # Always use current confidence values
         smoothed_array[:, 2] = current_array[:, 2]
-        
+
         # Update buffer and return
         smoothed_list = smoothed_array.tolist()
         self._smoothing_buffers[pose_id] = smoothed_list
         return smoothed_list
-    
-    def _mediapipe_to_openpose(self, mediapipe_landmarks: List, image_width: int, image_height: int) -> List[List[float]]:
+
+    def _mediapipe_to_openpose(
+        self, mediapipe_landmarks: List, image_width: int, image_height: int
+    ) -> List[List[float]]:
         """
         Convert MediaPipe landmarks to OpenPose format - VECTORIZED
-        
+
         Args:
             mediapipe_landmarks: MediaPipe pose landmarks
             image_width: Image width
             image_height: Image height
-            
+
         Returns:
             OpenPose keypoints in [x, y, confidence] format
         """
         if not mediapipe_landmarks:
             return []
-        
+
         # OPTIMIZATION: Vectorized landmark conversion
         # Extract all coordinates and confidences in one go
-        landmarks_data = np.array([
-            [lm.x * image_width, lm.y * image_height, 
-             lm.visibility if hasattr(lm, 'visibility') else 1.0]
-            for lm in mediapipe_landmarks
-        ], dtype=np.float32)
-        
+        landmarks_data = np.array(
+            [
+                [lm.x * image_width, lm.y * image_height, lm.visibility if hasattr(lm, "visibility") else 1.0]
+                for lm in mediapipe_landmarks
+            ],
+            dtype=np.float32,
+        )
+
         # Initialize OpenPose keypoints array (25 points x 3 values)
         openpose_keypoints = np.zeros((25, 3), dtype=np.float32)
-        
+
         # OPTIMIZATION: Vectorized mapping using advanced indexing
         # Only map valid indices that exist in landmarks_data
         valid_mask = MEDIAPIPE_INDICES < len(landmarks_data)
         valid_mp_indices = MEDIAPIPE_INDICES[valid_mask]
         valid_op_indices = OPENPOSE_INDICES[valid_mask]
-        
+
         # Vectorized assignment
         openpose_keypoints[valid_op_indices] = landmarks_data[valid_mp_indices]
-        
+
         # OPTIMIZATION: Vectorized derived point calculations
-        confidence_threshold = self.params.get('confidence_threshold', 0.3)
-        
+        confidence_threshold = self.params.get("confidence_threshold", 0.3)
+
         # Neck (1): midpoint between shoulders (indices 11, 12)
-        if (len(landmarks_data) > 12 and 
-            landmarks_data[11, 2] > confidence_threshold and 
-            landmarks_data[12, 2] > confidence_threshold):
+        if (
+            len(landmarks_data) > 12
+            and landmarks_data[11, 2] > confidence_threshold
+            and landmarks_data[12, 2] > confidence_threshold
+        ):
             # Vectorized midpoint calculation
             neck_point = np.mean(landmarks_data[[11, 12]], axis=0)
             neck_point[2] = np.min(landmarks_data[[11, 12], 2])  # Min confidence
             openpose_keypoints[1] = neck_point
-        
+
         # MidHip (8): midpoint between hips (indices 23, 24)
-        if (len(landmarks_data) > 24 and 
-            landmarks_data[23, 2] > confidence_threshold and 
-            landmarks_data[24, 2] > confidence_threshold):
+        if (
+            len(landmarks_data) > 24
+            and landmarks_data[23, 2] > confidence_threshold
+            and landmarks_data[24, 2] > confidence_threshold
+        ):
             # Vectorized midpoint calculation
             midhip_point = np.mean(landmarks_data[[23, 24]], axis=0)
             midhip_point[2] = np.min(landmarks_data[[23, 24], 2])  # Min confidence
             openpose_keypoints[8] = midhip_point
-        
+
         # Convert back to list format for compatibility
         return openpose_keypoints.tolist()
-    
+
     def _draw_openpose_skeleton(self, image: np.ndarray, keypoints: List[List[float]]) -> np.ndarray:
         """
         Draw OpenPose-style skeleton on image
-        
+
         Args:
             image: Input image
             keypoints: OpenPose keypoints
-            
+
         Returns:
             Image with skeleton drawn
         """
         if not keypoints or len(keypoints) != 25:
             return image
-        
+
         h, w = image.shape[:2]
-        line_thickness = self.params.get('line_thickness', 2)
-        circle_radius = self.params.get('circle_radius', 4)
-        confidence_threshold = self.params.get('confidence_threshold', 0.3)
-        
+        line_thickness = self.params.get("line_thickness", 2)
+        circle_radius = self.params.get("circle_radius", 4)
+        confidence_threshold = self.params.get("confidence_threshold", 0.3)
+
         # OPTIMIZATION: Vectorized limb drawing with confidence filtering
         keypoints_array = np.array(keypoints, dtype=np.float32)
-        
+
         # Draw limbs
         for i, (start_idx, end_idx) in enumerate(LIMB_SEQUENCE_ARRAY):
-            if (start_idx < len(keypoints_array) and end_idx < len(keypoints_array) and
-                keypoints_array[start_idx, 2] > confidence_threshold and keypoints_array[end_idx, 2] > confidence_threshold):
-                
+            if (
+                start_idx < len(keypoints_array)
+                and end_idx < len(keypoints_array)
+                and keypoints_array[start_idx, 2] > confidence_threshold
+                and keypoints_array[end_idx, 2] > confidence_threshold
+            ):
                 start_point = (int(keypoints_array[start_idx, 0]), int(keypoints_array[start_idx, 1]))
                 end_point = (int(keypoints_array[end_idx, 0]), int(keypoints_array[end_idx, 1]))
-                
+
                 # Use vectorized color array
                 color = OPENPOSE_COLORS_ARRAY[i % len(OPENPOSE_COLORS_ARRAY)].tolist()
-                
+
                 cv2.line(image, start_point, end_point, color, line_thickness)
-        
+
         # OPTIMIZATION: Vectorized keypoint drawing with confidence filtering
         confidence_mask = keypoints_array[:, 2] > confidence_threshold
         valid_indices = np.where(confidence_mask)[0]
-        
+
         for i in valid_indices:
             center = (int(keypoints_array[i, 0]), int(keypoints_array[i, 1]))
             color = OPENPOSE_COLORS_ARRAY[i % len(OPENPOSE_COLORS_ARRAY)].tolist()
             cv2.circle(image, center, circle_radius, color, -1)
-        
+
         return image
-    
+
     def _draw_hand_keypoints(self, image: np.ndarray, hand_landmarks: List, is_left_hand: bool = True) -> np.ndarray:
         """
         Draw hand keypoints in OpenPose style - FIXED coordinate mapping
-        
+
         Args:
             image: Input image
             hand_landmarks: MediaPipe hand landmarks
             is_left_hand: Whether this is the left hand
-            
+
         Returns:
             Image with hand keypoints drawn
         """
         if not hand_landmarks:
             return image
-        
+
         h, w = image.shape[:2]
-        confidence_threshold = self.params.get('confidence_threshold', 0.3)
-        
+        confidence_threshold = self.params.get("confidence_threshold", 0.3)
+
         # Standard hand connections (21 landmarks per hand)
         hand_connections = [
             # Thumb
-            (0, 1), (1, 2), (2, 3), (3, 4),
-            # Index finger  
-            (0, 5), (5, 6), (6, 7), (7, 8),
+            (0, 1),
+            (1, 2),
+            (2, 3),
+            (3, 4),
+            # Index finger
+            (0, 5),
+            (5, 6),
+            (6, 7),
+            (7, 8),
             # Middle finger
-            (0, 9), (9, 10), (10, 11), (11, 12),
+            (0, 9),
+            (9, 10),
+            (10, 11),
+            (11, 12),
             # Ring finger
-            (0, 13), (13, 14), (14, 15), (15, 16),
+            (0, 13),
+            (13, 14),
+            (14, 15),
+            (15, 16),
             # Pinky
-            (0, 17), (17, 18), (18, 19), (19, 20),
+            (0, 17),
+            (17, 18),
+            (18, 19),
+            (19, 20),
             # Palm connections
-            (5, 9), (9, 13), (13, 17),
+            (5, 9),
+            (9, 13),
+            (13, 17),
         ]
-        
+
         # OPTIMIZATION: Vectorized hand coordinate conversion
         landmarks_array = np.array([[lm.x * w, lm.y * h] for lm in hand_landmarks], dtype=np.int32)
         hand_points = [(int(pt[0]), int(pt[1])) for pt in landmarks_array]
-        
+
         # Standard hand colors
         hand_color = [255, 128, 0] if is_left_hand else [0, 255, 255]  # Orange for left, cyan for right
-        
+
         # Draw connections
         for start_idx, end_idx in hand_connections:
             if start_idx < len(hand_points) and end_idx < len(hand_points):
                 cv2.line(image, hand_points[start_idx], hand_points[end_idx], hand_color, 2)
-        
+
         # Draw keypoints
         for point in hand_points:
             cv2.circle(image, point, 3, hand_color, -1)
-        
+
         return image
-    
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Apply MediaPipe pose detection and create OpenPose-style annotation
         """
-        detect_resolution = self.params.get('detect_resolution', 512)
+        detect_resolution = self.params.get("detect_resolution", 512)
         image_resized = image.resize((detect_resolution, detect_resolution), Image.LANCZOS)
-        
+
         rgb_image = cv2.cvtColor(np.array(image_resized), cv2.COLOR_BGR2RGB)
-        
+
         results = self.detector.process(rgb_image)
-        
+
         pose_image = np.zeros((detect_resolution, detect_resolution, 3), dtype=np.uint8)
-        
+
         if results.pose_landmarks:
             openpose_keypoints = self._mediapipe_to_openpose(
-                results.pose_landmarks.landmark, 
-                detect_resolution, 
-                detect_resolution
+                results.pose_landmarks.landmark, detect_resolution, detect_resolution
             )
-            
+
             openpose_keypoints = self._apply_smoothing(openpose_keypoints, "main_pose")
-            
+
             pose_image = self._draw_openpose_skeleton(pose_image, openpose_keypoints)
-        
-        draw_hands = self.params.get('draw_hands', True)
+
+        draw_hands = self.params.get("draw_hands", True)
         if draw_hands:
             if results.left_hand_landmarks:
                 pose_image = self._draw_hand_keypoints(
                     pose_image, results.left_hand_landmarks.landmark, is_left_hand=True
                 )
-            
+
             if results.right_hand_landmarks:
                 pose_image = self._draw_hand_keypoints(
                     pose_image, results.right_hand_landmarks.landmark, is_left_hand=False
                 )
-        
+
         pose_pil = Image.fromarray(cv2.cvtColor(pose_image, cv2.COLOR_BGR2RGB))
-        
+
         return pose_pil
-    
+
     def _process_tensor_core(self, image_tensor: torch.Tensor) -> torch.Tensor:
         """
         Process tensor directly on GPU to avoid unnecessary CPU transfers
@@ -532,23 +596,23 @@ class MediaPipePosePreprocessor(BasePreprocessor):
         pil_image = self.tensor_to_pil(image_tensor)
         processed_pil = self._process_core(pil_image)
         return self.pil_to_tensor(processed_pil)
-    
+
     def reset_smoothing_buffers(self):
         """Reset smoothing buffers (useful for new sequences)"""
         print("MediaPipePosePreprocessor.reset_smoothing_buffers: Clearing smoothing buffers")
         self._smoothing_buffers.clear()
-    
+
     def reset_tracking(self):
         """Reset MediaPipe tracking for new video sequences (when using video mode)"""
         print("MediaPipePosePreprocessor.reset_tracking: Resetting MediaPipe tracking state")
-        if hasattr(self, '_detector') and self._detector is not None:
+        if hasattr(self, "_detector") and self._detector is not None:
             # Force detector recreation to reset tracking state
             self._detector.close()
             self._detector = None
             self._current_options = None
         self.reset_smoothing_buffers()
-    
+
     def __del__(self):
         """Cleanup MediaPipe detector"""
-        if hasattr(self, '_detector') and self._detector is not None:
-            self._detector.close() 
+        if hasattr(self, "_detector") and self._detector is not None:
+            self._detector.close()

--- a/src/streamdiffusion/preprocessing/processors/mediapipe_segmentation.py
+++ b/src/streamdiffusion/preprocessing/processors/mediapipe_segmentation.py
@@ -1,12 +1,16 @@
+from typing import Tuple
+
+import cv2
 import numpy as np
 import torch
-import cv2
 from PIL import Image
-from typing import Union, Optional, List, Tuple
+
 from .base import BasePreprocessor
+
 
 try:
     import mediapipe as mp
+
     MEDIAPIPE_AVAILABLE = True
 except ImportError:
     MEDIAPIPE_AVAILABLE = False
@@ -15,11 +19,11 @@ except ImportError:
 class MediaPipeSegmentationPreprocessor(BasePreprocessor):
     """
     MediaPipe-based segmentation preprocessor for ControlNet
-    
+
     Uses MediaPipe's Selfie Segmentation model to create accurate person segmentation masks.
     Outputs binary masks suitable for ControlNet conditioning.
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
@@ -30,43 +34,50 @@ class MediaPipeSegmentationPreprocessor(BasePreprocessor):
                     "type": "int",
                     "default": 1,
                     "range": [0, 1],
-                    "description": "Model type (0=general/faster, 1=landscape/better quality)"
+                    "description": "Model type (0=general/faster, 1=landscape/better quality)",
                 },
                 "threshold": {
                     "type": "float",
                     "default": 0.5,
                     "range": [0.0, 1.0],
                     "step": 0.01,
-                    "description": "Confidence threshold for segmentation"
+                    "description": "Confidence threshold for segmentation",
                 },
                 "blur_radius": {
                     "type": "int",
                     "default": 0,
                     "range": [0, 20],
-                    "description": "Blur radius for mask smoothing (0=no blur)"
+                    "description": "Blur radius for mask smoothing (0=no blur)",
                 },
                 "invert_mask": {
                     "type": "bool",
                     "default": False,
-                    "description": "Whether to invert the segmentation mask"
-                }
+                    "description": "Whether to invert the segmentation mask",
+                },
             },
-            "use_cases": ["Precise object control", "Background replacement", "Person segmentation", "Mask generation"]
+            "use_cases": [
+                "Precise object control",
+                "Background replacement",
+                "Person segmentation",
+                "Mask generation",
+            ],
         }
-    
-    def __init__(self,
-                 detect_resolution: int = 512,
-                 image_resolution: int = 512,
-                 model_selection: int = 1,  # 0 for general model, 1 for landscape model
-                 threshold: float = 0.5,
-                 blur_radius: int = 0,
-                 invert_mask: bool = False,
-                 output_mode: str = "binary",  # "binary", "alpha", "background"
-                 background_color: Tuple[int, int, int] = (0, 0, 0),
-                 **kwargs):
+
+    def __init__(
+        self,
+        detect_resolution: int = 512,
+        image_resolution: int = 512,
+        model_selection: int = 1,  # 0 for general model, 1 for landscape model
+        threshold: float = 0.5,
+        blur_radius: int = 0,
+        invert_mask: bool = False,
+        output_mode: str = "binary",  # "binary", "alpha", "background"
+        background_color: Tuple[int, int, int] = (0, 0, 0),
+        **kwargs,
+    ):
         """
         Initialize MediaPipe segmentation preprocessor
-        
+
         Args:
             detect_resolution: Resolution for segmentation processing
             image_resolution: Output image resolution
@@ -83,7 +94,7 @@ class MediaPipeSegmentationPreprocessor(BasePreprocessor):
                 "MediaPipe is required for MediaPipe segmentation preprocessing. "
                 "Install it with: pip install mediapipe"
             )
-        
+
         super().__init__(
             detect_resolution=detect_resolution,
             image_resolution=image_resolution,
@@ -93,145 +104,145 @@ class MediaPipeSegmentationPreprocessor(BasePreprocessor):
             invert_mask=invert_mask,
             output_mode=output_mode,
             background_color=background_color,
-            **kwargs
+            **kwargs,
         )
-        
+
         self._segmentor = None
         self._current_options = None
-    
+
     @property
     def segmentor(self):
         """Lazy loading of the MediaPipe Selfie Segmentation model"""
         new_options = {
-            'model_selection': self.params.get('model_selection', 1),
+            "model_selection": self.params.get("model_selection", 1),
         }
-        
+
         # Initialize or update segmentor if needed
         if self._segmentor is None or self._current_options != new_options:
             if self._segmentor is not None:
                 self._segmentor.close()
-                
-            print(f"MediaPipeSegmentationPreprocessor.segmentor: Initializing MediaPipe Selfie Segmentation model")
+
+            print("MediaPipeSegmentationPreprocessor.segmentor: Initializing MediaPipe Selfie Segmentation model")
             self._segmentor = mp.solutions.selfie_segmentation.SelfieSegmentation(
-                model_selection=new_options['model_selection']
+                model_selection=new_options["model_selection"]
             )
             self._current_options = new_options
-            
+
         return self._segmentor
-    
+
     def _apply_mask_smoothing(self, mask: np.ndarray) -> np.ndarray:
         """
         Apply smoothing to the segmentation mask
-        
+
         Args:
             mask: Input segmentation mask
-            
+
         Returns:
             Smoothed mask
         """
-        blur_radius = self.params.get('blur_radius', 0)
-        
+        blur_radius = self.params.get("blur_radius", 0)
+
         if blur_radius > 0:
             # Apply Gaussian blur for smoother edges
             kernel_size = blur_radius * 2 + 1
             mask = cv2.GaussianBlur(mask, (kernel_size, kernel_size), 0)
-        
+
         return mask
-    
+
     def _threshold_mask(self, mask: np.ndarray) -> np.ndarray:
         """
         Apply threshold to segmentation mask
-        
+
         Args:
             mask: Input segmentation mask (0.0-1.0)
-            
+
         Returns:
             Binary mask
         """
-        threshold = self.params.get('threshold', 0.5)
-        invert_mask = self.params.get('invert_mask', False)
-        
+        threshold = self.params.get("threshold", 0.5)
+        invert_mask = self.params.get("invert_mask", False)
+
         # Apply threshold
         binary_mask = (mask > threshold).astype(np.uint8)
-        
+
         # Invert if requested
         if invert_mask:
             binary_mask = 1 - binary_mask
-        
+
         return binary_mask
-    
+
     def _create_output_image(self, original_image: np.ndarray, mask: np.ndarray) -> np.ndarray:
         """
         Create final output image based on output mode
-        
+
         Args:
             original_image: Original input image
             mask: Segmentation mask
-            
+
         Returns:
             Output image
         """
-        output_mode = self.params.get('output_mode', 'binary')
-        
-        if output_mode == 'binary':
+        output_mode = self.params.get("output_mode", "binary")
+
+        if output_mode == "binary":
             # Create binary black/white mask
             binary_mask = self._threshold_mask(mask)
             output = np.stack([binary_mask * 255] * 3, axis=-1)
-            
-        elif output_mode == 'alpha':
+
+        elif output_mode == "alpha":
             # Create RGBA output with alpha channel
             if len(original_image.shape) == 3:
                 alpha = (mask * 255).astype(np.uint8)
                 output = np.concatenate([original_image, alpha[..., np.newaxis]], axis=-1)
             else:
                 output = original_image
-                
-        elif output_mode == 'background':
+
+        elif output_mode == "background":
             # Replace background with solid color
-            background_color = self.params.get('background_color', (0, 0, 0))
+            background_color = self.params.get("background_color", (0, 0, 0))
             binary_mask = self._threshold_mask(mask)
-            
+
             output = original_image.copy()
             # Apply background where mask is 0
             for i in range(3):
                 output[..., i] = np.where(binary_mask, output[..., i], background_color[i])
-                
+
         else:
             raise ValueError(f"Unknown output_mode: {output_mode}")
-        
+
         return output
-    
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Apply MediaPipe segmentation to the input image
         """
-        detect_resolution = self.params.get('detect_resolution', 512)
+        detect_resolution = self.params.get("detect_resolution", 512)
         image_resized = image.resize((detect_resolution, detect_resolution), Image.LANCZOS)
-        
+
         rgb_image = cv2.cvtColor(np.array(image_resized), cv2.COLOR_BGR2RGB)
-        
+
         results = self.segmentor.process(rgb_image)
-        
+
         if results.segmentation_mask is not None:
             mask = results.segmentation_mask
-            
+
             mask = self._apply_mask_smoothing(mask)
-            
+
             output_image = self._create_output_image(rgb_image, mask)
         else:
-            output_mode = self.params.get('output_mode', 'binary')
-            if output_mode == 'binary':
+            output_mode = self.params.get("output_mode", "binary")
+            if output_mode == "binary":
                 output_image = np.zeros((detect_resolution, detect_resolution, 3), dtype=np.uint8)
             else:
                 output_image = rgb_image
-        
+
         if output_image.shape[-1] == 4:
-            result_pil = Image.fromarray(output_image, 'RGBA')
+            result_pil = Image.fromarray(output_image, "RGBA")
         else:
-            result_pil = Image.fromarray(output_image, 'RGB')
-        
+            result_pil = Image.fromarray(output_image, "RGB")
+
         return result_pil
-    
+
     def _process_tensor_core(self, image_tensor: torch.Tensor) -> torch.Tensor:
         """
         Process tensor directly on GPU to avoid unnecessary CPU transfers
@@ -239,8 +250,8 @@ class MediaPipeSegmentationPreprocessor(BasePreprocessor):
         pil_image = self.tensor_to_pil(image_tensor)
         processed_pil = self._process_core(pil_image)
         return self.pil_to_tensor(processed_pil)
-    
+
     def __del__(self):
         """Cleanup MediaPipe segmentor"""
-        if hasattr(self, '_segmentor') and self._segmentor is not None:
-            self._segmentor.close() 
+        if hasattr(self, "_segmentor") and self._segmentor is not None:
+            self._segmentor.close()

--- a/src/streamdiffusion/preprocessing/processors/openpose.py
+++ b/src/streamdiffusion/preprocessing/processors/openpose.py
@@ -1,16 +1,18 @@
-import numpy as np
 from PIL import Image, ImageDraw
-from typing import Union, Optional, List, Tuple
+
 from .base import BasePreprocessor
+
 
 try:
     import cv2
+
     OPENCV_AVAILABLE = True
 except ImportError:
     OPENCV_AVAILABLE = False
 
 try:
     from controlnet_aux import OpenposeDetector
+
     CONTROLNET_AUX_AVAILABLE = True
 except ImportError:
     CONTROLNET_AUX_AVAILABLE = False
@@ -19,10 +21,10 @@ except ImportError:
 class OpenPosePreprocessor(BasePreprocessor):
     """
     OpenPose human pose detection preprocessor for ControlNet
-    
+
     Detects human poses and creates stick figure representations.
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
@@ -32,26 +34,28 @@ class OpenPosePreprocessor(BasePreprocessor):
                 "include_hands": {
                     "type": "bool",
                     "default": False,
-                    "description": "Whether to include hand keypoints in detection"
+                    "description": "Whether to include hand keypoints in detection",
                 },
                 "include_face": {
                     "type": "bool",
                     "default": False,
-                    "description": "Whether to include face keypoints in detection"
-                }
+                    "description": "Whether to include face keypoints in detection",
+                },
             },
-            "use_cases": ["Human pose control", "Dance movements", "Character poses"]
+            "use_cases": ["Human pose control", "Dance movements", "Character poses"],
         }
-    
-    def __init__(self, 
-                 detect_resolution: int = 512,
-                 image_resolution: int = 512,
-                 include_hands: bool = False,
-                 include_face: bool = False,
-                 **kwargs):
+
+    def __init__(
+        self,
+        detect_resolution: int = 512,
+        image_resolution: int = 512,
+        include_hands: bool = False,
+        include_face: bool = False,
+        **kwargs,
+    ):
         """
         Initialize OpenPose preprocessor
-        
+
         Args:
             detect_resolution: Resolution for pose detection
             image_resolution: Output image resolution
@@ -64,81 +68,93 @@ class OpenPosePreprocessor(BasePreprocessor):
             image_resolution=image_resolution,
             include_hands=include_hands,
             include_face=include_face,
-            **kwargs
+            **kwargs,
         )
-        
+
         self._detector = None
-    
+
     @property
     def detector(self):
         """Lazy loading of the OpenPose detector"""
         if self._detector is None:
             if CONTROLNET_AUX_AVAILABLE:
                 print("Loading OpenPose detector from controlnet_aux")
-                self._detector = OpenposeDetector.from_pretrained('lllyasviel/Annotators')
+                self._detector = OpenposeDetector.from_pretrained("lllyasviel/Annotators")
             else:
                 print("Warning: controlnet_aux not available, using fallback OpenPose implementation")
                 self._detector = self._create_fallback_detector()
         return self._detector
-    
+
     def _create_fallback_detector(self):
         """Create a simple fallback detector if controlnet_aux is not available"""
+
         class FallbackDetector:
             def __call__(self, image, include_hands=False, include_face=False):
                 # Simple fallback: return a blank image with some basic pose lines
                 width, height = image.size
-                pose_image = Image.new('RGB', (width, height), (0, 0, 0))
+                pose_image = Image.new("RGB", (width, height), (0, 0, 0))
                 draw = ImageDraw.Draw(pose_image)
-                
+
                 # Draw a basic stick figure in the center
                 center_x, center_y = width // 2, height // 2
-                
+
                 # Head
                 head_radius = min(width, height) // 20
-                draw.ellipse([
-                    center_x - head_radius, center_y - height // 4 - head_radius,
-                    center_x + head_radius, center_y - height // 4 + head_radius
-                ], outline=(255, 255, 255), width=2)
-                
+                draw.ellipse(
+                    [
+                        center_x - head_radius,
+                        center_y - height // 4 - head_radius,
+                        center_x + head_radius,
+                        center_y - height // 4 + head_radius,
+                    ],
+                    outline=(255, 255, 255),
+                    width=2,
+                )
+
                 # Body
                 body_top = center_y - height // 4 + head_radius
                 body_bottom = center_y + height // 6
                 draw.line([center_x, body_top, center_x, body_bottom], fill=(255, 255, 255), width=2)
-                
+
                 # Arms
                 arm_length = width // 6
                 arm_y = body_top + (body_bottom - body_top) // 3
                 draw.line([center_x - arm_length, arm_y, center_x + arm_length, arm_y], fill=(255, 255, 255), width=2)
-                
+
                 # Legs
                 leg_length = height // 8
-                draw.line([center_x, body_bottom, center_x - leg_length//2, body_bottom + leg_length], fill=(255, 255, 255), width=2)
-                draw.line([center_x, body_bottom, center_x + leg_length//2, body_bottom + leg_length], fill=(255, 255, 255), width=2)
-                
+                draw.line(
+                    [center_x, body_bottom, center_x - leg_length // 2, body_bottom + leg_length],
+                    fill=(255, 255, 255),
+                    width=2,
+                )
+                draw.line(
+                    [center_x, body_bottom, center_x + leg_length // 2, body_bottom + leg_length],
+                    fill=(255, 255, 255),
+                    width=2,
+                )
+
                 return pose_image
-        
+
         return FallbackDetector()
-    
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Apply OpenPose detection to the input image
         """
-        detect_resolution = self.params.get('detect_resolution', 512)
+        detect_resolution = self.params.get("detect_resolution", 512)
         image_resized = image.resize((detect_resolution, detect_resolution), Image.LANCZOS)
-        
-        include_hands = self.params.get('include_hands', False)
-        include_face = self.params.get('include_face', False)
-        
-        if CONTROLNET_AUX_AVAILABLE and hasattr(self.detector, '__call__'):
+
+        include_hands = self.params.get("include_hands", False)
+        include_face = self.params.get("include_face", False)
+
+        if CONTROLNET_AUX_AVAILABLE and hasattr(self.detector, "__call__"):
             try:
-                pose_image = self.detector(
-                    image_resized,
-                    hand_and_face=include_hands or include_face
-                )
+                pose_image = self.detector(image_resized, hand_and_face=include_hands or include_face)
             except Exception as e:
                 print(f"Warning: OpenPose detection failed, using fallback: {e}")
                 pose_image = self._create_fallback_detector()(image_resized, include_hands, include_face)
         else:
             pose_image = self.detector(image_resized, include_hands, include_face)
-        
-        return pose_image 
+
+        return pose_image

--- a/src/streamdiffusion/preprocessing/processors/passthrough.py
+++ b/src/streamdiffusion/preprocessing/processors/passthrough.py
@@ -1,55 +1,47 @@
-import numpy as np
-from PIL import Image
 import torch
-from typing import Union, Optional
+from PIL import Image
+
 from .base import BasePreprocessor
 
 
 class PassthroughPreprocessor(BasePreprocessor):
     """
     Passthrough preprocessor for ControlNet
-    
+
     Simply passes the input image through without any processing.
     Useful for ControlNets that expect the raw input image, such as:
     - Tile ControlNet
     - Reference ControlNet
     - Custom ControlNets that don't need preprocessing
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
             "display_name": "Passthrough",
             "description": "Passes the input image through with minimal processing. Used for tile ControlNet or when you want to use the input image directly.",
-            "parameters": {
-
-            },
-            "use_cases": ["Tile ControlNet", "Image-to-image with structure preservation", "Upscaling with control"]
+            "parameters": {},
+            "use_cases": ["Tile ControlNet", "Image-to-image with structure preservation", "Upscaling with control"],
         }
-    
-    def __init__(self, 
-                 image_resolution: int = 512,
-                 **kwargs):
+
+    def __init__(self, image_resolution: int = 512, **kwargs):
         """
         Initialize passthrough preprocessor
-        
+
         Args:
             image_resolution: Output image resolution
             **kwargs: Additional parameters (ignored for passthrough)
         """
-        super().__init__(
-            image_resolution=image_resolution,
-            **kwargs
-        )
-    
+        super().__init__(image_resolution=image_resolution, **kwargs)
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Pass through the input image with no processing
         """
         return image
-    
+
     def _process_tensor_core(self, tensor: torch.Tensor) -> torch.Tensor:
         """
         Pass through tensor with no processing
         """
-        return tensor 
+        return tensor

--- a/src/streamdiffusion/preprocessing/processors/pose_tensorrt.py
+++ b/src/streamdiffusion/preprocessing/processors/pose_tensorrt.py
@@ -1,19 +1,23 @@
-#NOTE: ported from https://github.com/yuvraj108c/ComfyUI-YoloNasPose-Tensorrt
+# NOTE: ported from https://github.com/yuvraj108c/ComfyUI-YoloNasPose-Tensorrt
 
 import os
+
+import cv2
 import numpy as np
 import torch
 import torch.nn.functional as F
-import cv2
 from PIL import Image
-from typing import Union, Optional, List, Tuple
+
 from .base import BasePreprocessor
 
+
 try:
+    from collections import OrderedDict
+
     import tensorrt as trt
     from polygraphy.backend.common import bytes_from_path
     from polygraphy.backend.trt import engine_from_bytes
-    from collections import OrderedDict
+
     TENSORRT_AVAILABLE = True
 except ImportError:
     TENSORRT_AVAILABLE = False
@@ -40,7 +44,7 @@ else:
 
 class TensorRTEngine:
     """Simplified TensorRT engine wrapper for pose estimation inference (optimized)"""
-    
+
     def __init__(self, engine_path):
         self.engine_path = engine_path
         self.engine = None
@@ -64,13 +68,11 @@ class TensorRTEngine:
             name = self.engine.get_tensor_name(idx)
             shape = self.context.get_tensor_shape(name)
             dtype = trt.nptype(self.engine.get_tensor_dtype(name))
-            
+
             if self.engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT:
                 self.context.set_input_shape(name, shape)
-            
-            tensor = torch.empty(
-                tuple(shape), dtype=numpy_to_torch_dtype_dict[dtype]
-            ).to(device=device)
+
+            tensor = torch.empty(tuple(shape), dtype=numpy_to_torch_dtype_dict[dtype]).to(device=device)
             self.tensors[name] = tensor
 
     def infer(self, feed_dict, stream=None):
@@ -78,7 +80,7 @@ class TensorRTEngine:
         # Use cached stream if none provided
         if stream is None:
             stream = self._cuda_stream
-            
+
         # Copy input data to tensors
         for name, buf in feed_dict.items():
             self.tensors[name].copy_(buf)
@@ -86,23 +88,23 @@ class TensorRTEngine:
         # Set tensor addresses
         for name, tensor in self.tensors.items():
             self.context.set_tensor_address(name, tensor.data_ptr())
-        
+
         # Execute inference
         success = self.context.execute_async_v3(stream)
         if not success:
             raise ValueError("TensorRT inference failed.")
-        
+
         return self.tensors
 
 
 class PoseVisualization:
     """Pose drawing utilities ported from ComfyUI YoloNasPose node"""
-    
+
     @staticmethod
     def draw_skeleton(image, keypoints, edge_links, edge_colors, joint_thickness=10, keypoint_radius=10):
         """Draw pose skeleton on image"""
         overlay = image.copy()
-        
+
         # Draw edges/links between keypoints
         for (kp1, kp2), color in zip(edge_links, edge_colors):
             if kp1 < len(keypoints) and kp2 < len(keypoints):
@@ -113,32 +115,32 @@ class PoseVisualization:
                         p1 = (int(keypoints[kp1][0]), int(keypoints[kp1][1]))
                         p2 = (int(keypoints[kp2][0]), int(keypoints[kp2][1]))
                         cv2.line(overlay, p1, p2, color=color, thickness=joint_thickness, lineType=cv2.LINE_AA)
-        
+
         # Draw keypoints
         for keypoint in keypoints:
             if len(keypoint) >= 3 and keypoint[2] > 0.5:  # confidence threshold
                 x, y = int(keypoint[0]), int(keypoint[1])
                 cv2.circle(overlay, (x, y), keypoint_radius, (0, 255, 0), -1, cv2.LINE_AA)
-        
+
         return cv2.addWeighted(overlay, 0.75, image, 0.25, 0)
 
     @staticmethod
     def draw_poses(image, poses, edge_links, edge_colors, joint_thickness=10, keypoint_radius=10):
         """Draw multiple poses on image"""
         result = image.copy()
-        
+
         for pose in poses:
             result = PoseVisualization.draw_skeleton(
                 result, pose, edge_links, edge_colors, joint_thickness, keypoint_radius
             )
-        
+
         return result
 
 
 def iterate_over_batch_predictions(predictions, batch_size):
     """Process batch predictions from TensorRT output"""
     num_detections, batch_boxes, batch_scores, batch_joints = predictions
-    
+
     for image_index in range(batch_size):
         num_detection_in_image = int(num_detections[image_index, 0])
 
@@ -150,35 +152,62 @@ def iterate_over_batch_predictions(predictions, batch_size):
         else:
             pred_scores = batch_scores[image_index, :num_detection_in_image]
             pred_boxes = batch_boxes[image_index, :num_detection_in_image]
-            pred_joints = batch_joints[image_index, :num_detection_in_image].reshape(
-                (num_detection_in_image, -1, 3))
+            pred_joints = batch_joints[image_index, :num_detection_in_image].reshape((num_detection_in_image, -1, 3))
 
         yield image_index, pred_boxes, pred_scores, pred_joints
 
+
 # precompute edge links define skeleton connections (COCO format)
-edge_links = [[0, 17], [13, 15], [14, 16], [12, 14], [12, 17], [5, 6], 
-                [11, 13], [7, 9], [5, 7], [17, 11], [6, 8], [8, 10], 
-                [1, 3], [0, 1], [0, 2], [2, 4]]
+edge_links = [
+    [0, 17],
+    [13, 15],
+    [14, 16],
+    [12, 14],
+    [12, 17],
+    [5, 6],
+    [11, 13],
+    [7, 9],
+    [5, 7],
+    [17, 11],
+    [6, 8],
+    [8, 10],
+    [1, 3],
+    [0, 1],
+    [0, 2],
+    [2, 4],
+]
 
 edge_colors = [
-    [255, 0, 0], [255, 85, 0], [170, 255, 0], [85, 255, 0], [85, 255, 0], 
-    [85, 0, 255], [255, 170, 0], [0, 177, 58], [0, 179, 119], [179, 179, 0], 
-    [0, 119, 179], [0, 179, 179], [119, 0, 179], [179, 0, 179], [178, 0, 118], [178, 0, 118]
+    [255, 0, 0],
+    [255, 85, 0],
+    [170, 255, 0],
+    [85, 255, 0],
+    [85, 255, 0],
+    [85, 0, 255],
+    [255, 170, 0],
+    [0, 177, 58],
+    [0, 179, 119],
+    [179, 179, 0],
+    [0, 119, 179],
+    [0, 179, 179],
+    [119, 0, 179],
+    [179, 0, 179],
+    [178, 0, 118],
+    [178, 0, 118],
 ]
+
+
 def show_predictions_from_batch_format(predictions):
     """Convert predictions to pose visualization format"""
     try:
-        image_index, pred_boxes, pred_scores, pred_joints = next(
-            iter(iterate_over_batch_predictions(predictions, 1)))
+        image_index, pred_boxes, pred_scores, pred_joints = next(iter(iterate_over_batch_predictions(predictions, 1)))
     except Exception as e:
         raise RuntimeError(f"show_predictions_from_batch_format: Error in iterate_over_batch_predictions: {e}")
 
-
-    
     # Handle case where no poses are detected
     if pred_joints.shape[0] == 0:
         return np.zeros((640, 640, 3))
-    
+
     # Add middle joint between shoulders (keypoints 5 and 6)
     try:
         # Calculate middle joints for all poses at once
@@ -187,49 +216,50 @@ def show_predictions_from_batch_format(predictions):
         new_pred_joints = np.concatenate([pred_joints, middle_joints[:, np.newaxis]], axis=1)
     except Exception as e:
         raise RuntimeError(f"show_predictions_from_batch_format: Error processing poses: {e}")
-    
+
     # Create black background for pose visualization
     black_image = np.zeros((640, 640, 3))
-    
+
     try:
         image = PoseVisualization.draw_poses(
-            image=black_image, 
-            poses=new_pred_joints, 
-            edge_links=edge_links, 
-            edge_colors=edge_colors, 
+            image=black_image,
+            poses=new_pred_joints,
+            edge_links=edge_links,
+            edge_colors=edge_colors,
             joint_thickness=10,
-            keypoint_radius=10
+            keypoint_radius=10,
         )
     except Exception as e:
         raise RuntimeError(f"show_predictions_from_batch_format: Error in pose drawing: {e}")
-    
+
     return image
 
 
 class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
     """
     YoloNas Pose TensorRT preprocessor for ControlNet
-    
+
     Uses TensorRT-optimized YoloNas Pose model for fast pose estimation.
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
             "display_name": "Pose Detection (TensorRT)",
             "description": "Fast TensorRT-optimized pose detection using YOLO-NAS Pose model. Detects human pose keypoints with high performance.",
             "parameters": {},
-            "use_cases": ["Human pose control", "Character animation", "Pose-guided generation", "Real-time pose detection"]
+            "use_cases": [
+                "Human pose control",
+                "Character animation",
+                "Pose-guided generation",
+                "Real-time pose detection",
+            ],
         }
-    
-    def __init__(self, 
-                 engine_path: str = None,
-                 detect_resolution: int = 640,
-                 image_resolution: int = 512,
-                 **kwargs):
+
+    def __init__(self, engine_path: str = None, detect_resolution: int = 640, image_resolution: int = 512, **kwargs):
         """
         Initialize TensorRT pose preprocessor
-        
+
         Args:
             engine_path: Path to TensorRT engine file
             detect_resolution: Resolution for pose detection (should match engine input)
@@ -241,78 +271,72 @@ class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
                 "TensorRT and polygraphy libraries are required for TensorRT pose preprocessing. "
                 "Install them with: pip install tensorrt polygraphy"
             )
-        
+
         super().__init__(
-            engine_path=engine_path,
-            detect_resolution=detect_resolution,
-            image_resolution=image_resolution,
-            **kwargs
+            engine_path=engine_path, detect_resolution=detect_resolution, image_resolution=image_resolution, **kwargs
         )
-        
+
         self._engine = None
         self._device = "cuda" if torch.cuda.is_available() else "cpu"
         self._is_cuda_available = torch.cuda.is_available()
-    
+
     @property
     def engine(self):
         """Lazy loading of the TensorRT engine"""
         if self._engine is None:
-            engine_path = self.params.get('engine_path')
+            engine_path = self.params.get("engine_path")
             if engine_path is None:
                 raise ValueError(
                     "engine_path is required for TensorRT pose preprocessing. "
                     "Please provide it in the preprocessor_params config."
                 )
-            
+
             if not os.path.exists(engine_path):
                 raise FileNotFoundError(f"TensorRT engine not found: {engine_path}")
-            
+
             self._engine = TensorRTEngine(engine_path)
             self._engine.load()
             self._engine.activate()
             self._engine.allocate_buffers()
-            
+
         return self._engine
-    
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Apply TensorRT pose estimation to the input image
         """
-        detect_resolution = self.params.get('detect_resolution', 640)
-        
+        detect_resolution = self.params.get("detect_resolution", 640)
+
         image_tensor = torch.from_numpy(np.array(image)).float() / 255.0
         image_tensor = image_tensor.permute(2, 0, 1).unsqueeze(0)
-        
+
         image_resized = F.interpolate(
-            image_tensor, 
-            size=(detect_resolution, detect_resolution), 
-            mode='bilinear', 
-            align_corners=False
+            image_tensor, size=(detect_resolution, detect_resolution), mode="bilinear", align_corners=False
         )
-        
+
         image_resized_uint8 = (image_resized * 255.0).type(torch.uint8)
-        
+
         if self._is_cuda_available:
             image_resized_uint8 = image_resized_uint8.cuda()
-        
+
         cuda_stream = torch.cuda.current_stream().cuda_stream
         result = self.engine.infer({"input": image_resized_uint8}, cuda_stream)
-        
-        predictions = [result[key].cpu().numpy() for key in result.keys() if key != 'input']
-        
+
+        predictions = [result[key].cpu().numpy() for key in result.keys() if key != "input"]
+
         try:
             pose_image = show_predictions_from_batch_format(predictions)
         except Exception:
             # Fallback to black image on error
             pose_image = np.zeros((detect_resolution, detect_resolution, 3))
-        
+
         pose_image = pose_image.clip(0, 255).astype(np.uint8)
         pose_image = cv2.cvtColor(pose_image, cv2.COLOR_BGR2RGB)
-        
+
         result = Image.fromarray(pose_image)
-        
+
         return result
-    
+
     def _process_tensor_core(self, image_tensor: torch.Tensor) -> torch.Tensor:
         """
         Process tensor directly on GPU to avoid CPU transfers
@@ -321,31 +345,30 @@ class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
             image_tensor = image_tensor.unsqueeze(0)
         if not image_tensor.is_cuda:
             image_tensor = image_tensor.cuda()
-        
-        detect_resolution = self.params.get('detect_resolution', 640)
-        
+
+        detect_resolution = self.params.get("detect_resolution", 640)
+
         image_resized = torch.nn.functional.interpolate(
-            image_tensor, size=(detect_resolution, detect_resolution), 
-            mode='bilinear', align_corners=False
+            image_tensor, size=(detect_resolution, detect_resolution), mode="bilinear", align_corners=False
         )
-        
+
         image_resized_uint8 = (image_resized * 255.0).type(torch.uint8)
-        
+
         cuda_stream = torch.cuda.current_stream().cuda_stream
         result = self.engine.infer({"input": image_resized_uint8}, cuda_stream)
-        
-        predictions = [result[key].cpu().numpy() for key in result.keys() if key != 'input']
-        
+
+        predictions = [result[key].cpu().numpy() for key in result.keys() if key != "input"]
+
         try:
             pose_image = show_predictions_from_batch_format(predictions)
             pose_image = pose_image.clip(0, 255).astype(np.uint8)
             pose_image = cv2.cvtColor(pose_image, cv2.COLOR_BGR2RGB)
-            
+
             pose_tensor = torch.from_numpy(pose_image).float() / 255.0
             pose_tensor = pose_tensor.permute(2, 0, 1).unsqueeze(0).cuda()
-            
+
         except Exception:
             # Fallback to black tensor on error
             pose_tensor = torch.zeros(1, 3, detect_resolution, detect_resolution).cuda()
-        
-        return pose_tensor 
+
+        return pose_tensor

--- a/src/streamdiffusion/preprocessing/processors/realesrgan_trt.py
+++ b/src/streamdiffusion/preprocessing/processors/realesrgan_trt.py
@@ -317,7 +317,7 @@ class RealESRGANProcessor(BasePreprocessor):
         try:
             # Create builder and network
             builder = trt.Builder(trt.Logger(trt.Logger.WARNING))
-            network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
+            network = builder.create_network()  # EXPLICIT_BATCH deprecated/ignored in TRT 10.x
             parser = trt.OnnxParser(network, trt.Logger(trt.Logger.WARNING))
 
             # Parse ONNX model

--- a/src/streamdiffusion/preprocessing/processors/realesrgan_trt.py
+++ b/src/streamdiffusion/preprocessing/processors/realesrgan_trt.py
@@ -1,22 +1,23 @@
 # NOTE: ported from https://github.com/yuvraj108c/ComfyUI-Upscaler-Tensorrt
 
-import os
-import torch
-import numpy as np
-from PIL import Image
-from typing import Optional, Tuple
-import requests
-from tqdm import tqdm
-import hashlib
 import logging
-from pathlib import Path
 from collections import OrderedDict
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+import requests
+import torch
+from PIL import Image
+from tqdm import tqdm
 
 from .base import BasePreprocessor
+
 
 # Try to import spandrel for model loading
 try:
     from spandrel import ModelLoader
+
     SPANDREL_AVAILABLE = True
 except ImportError:
     SPANDREL_AVAILABLE = False
@@ -24,9 +25,11 @@ except ImportError:
 # Try to import TensorRT dependencies
 try:
     import tensorrt as trt
-    from streamdiffusion.acceleration.tensorrt.utilities import engine_from_bytes, bytes_from_path
+
+    from streamdiffusion.acceleration.tensorrt.utilities import bytes_from_path, engine_from_bytes
+
     TRT_AVAILABLE = True
-    
+
     # Numpy to PyTorch dtype mapping (same as depth_tensorrt.py)
     numpy_to_torch_dtype_dict = {
         np.uint8: torch.uint8,
@@ -40,27 +43,28 @@ try:
         np.complex64: torch.complex64,
         np.complex128: torch.complex128,
     }
-    
+
     # Handle bool type for numpy compatibility (same as depth_tensorrt.py)
     if np.version.full_version >= "1.24.0":
         numpy_to_torch_dtype_dict[np.bool_] = torch.bool
     else:
         numpy_to_torch_dtype_dict[np.bool] = torch.bool
-        
+
 except ImportError:
     TRT_AVAILABLE = False
 
 
 class RealESRGANEngine:
     """TensorRT engine wrapper for RealESRGAN inference (following depth_tensorrt pattern)"""
-    
+
     def __init__(self, engine_path):
         self.engine_path = engine_path
         self.engine = None
         self.context = None
         self.tensors = OrderedDict()
-        
+
         import threading
+
         self._inference_lock = threading.Lock()
 
     def load(self):
@@ -79,13 +83,13 @@ class RealESRGANEngine:
         # Set input shape for dynamic sizing
         input_name = "input"
         self.context.set_input_shape(input_name, input_shape)
-        
+
         # Allocate tensors for all bindings
         for idx in range(self.engine.num_io_tensors):
             name = self.engine.get_tensor_name(idx)
             shape = self.context.get_tensor_shape(name)
             dtype = trt.nptype(self.engine.get_tensor_dtype(name))
-            
+
             # Convert numpy dtype to torch dtype
             if dtype == np.float32:
                 torch_dtype = torch.float32
@@ -93,7 +97,7 @@ class RealESRGANEngine:
                 torch_dtype = torch.float16
             else:
                 torch_dtype = torch.float32
-            
+
             tensor = torch.empty(tuple(shape), dtype=torch_dtype, device=device)
             self.tensors[name] = tensor
 
@@ -102,7 +106,7 @@ class RealESRGANEngine:
         # Use provided stream or current stream context
         if stream is None:
             stream = torch.cuda.current_stream().cuda_stream
-        
+
         # Copy input data to tensors
         for name, buf in feed_dict.items():
             self.tensors[name].copy_(buf)
@@ -111,27 +115,29 @@ class RealESRGANEngine:
         for name, tensor in self.tensors.items():
             addr = tensor.data_ptr()
             self.context.set_tensor_address(name, addr)
-        
+
         with self._inference_lock:
             success = self.context.execute_async_v3(stream)
-            
+
             if not success:
                 raise RuntimeError("RealESRGANEngine: TensorRT inference failed")
-            
+
             torch.cuda.synchronize()
-        
+
         return self.tensors
 
+
 logger = logging.getLogger(__name__)
+
 
 class RealESRGANProcessor(BasePreprocessor):
     """
     RealESRGAN 2x upscaling processor with automatic model download, ONNX export, and TensorRT acceleration.
     """
-    
+
     MODEL_URL = "https://huggingface.co/ai-forever/Real-ESRGAN/resolve/main/RealESRGAN_x2.pth?download=true"
-    
-    @classmethod 
+
+    @classmethod
     def get_preprocessor_metadata(cls):
         return {
             "display_name": "RealESRGAN 2x",
@@ -140,94 +146,98 @@ class RealESRGANProcessor(BasePreprocessor):
                 "enable_tensorrt": {
                     "type": "bool",
                     "default": True,
-                    "description": "Use TensorRT acceleration for faster inference"
+                    "description": "Use TensorRT acceleration for faster inference",
                 },
                 "force_rebuild": {
-                    "type": "bool", 
+                    "type": "bool",
                     "default": False,
-                    "description": "Force rebuild TensorRT engine even if it exists"
-                }
+                    "description": "Force rebuild TensorRT engine even if it exists",
+                },
             },
-            "use_cases": ["High-quality upscaling", "Real-time 2x enlargement", "Image enhancement"]
+            "use_cases": ["High-quality upscaling", "Real-time 2x enlargement", "Image enhancement"],
         }
-    
+
     def __init__(self, enable_tensorrt: bool = True, force_rebuild: bool = False, **kwargs):
         super().__init__(enable_tensorrt=enable_tensorrt, force_rebuild=force_rebuild, **kwargs)
         self.enable_tensorrt = enable_tensorrt and TRT_AVAILABLE
         self.force_rebuild = force_rebuild
         self.scale_factor = 2  # RealESRGAN 2x model
-        
+
         # Model paths
         self.models_dir = Path("models") / "realesrgan"
         self.models_dir.mkdir(parents=True, exist_ok=True)
         self.model_path = self.models_dir / "RealESRGAN_x2.pth"
         self.onnx_path = self.models_dir / "RealESRGAN_x2.onnx"
         self.engine_path = self.models_dir / f"RealESRGAN_x2_{trt.__version__ if TRT_AVAILABLE else 'notrt'}.trt"
-        
+
         # Model state
         self.pytorch_model = None
         self._engine = None  # Lazy loading like depth processor
-        
+
         # Thread safety for engine initialization
         import threading
+
         self._engine_lock = threading.Lock()
-        
+
         # Initialize
         self._ensure_model_ready()
-    
+
     @property
     def engine(self):
         """Lazy loading of the TensorRT engine"""
         if self._engine is None:
             if not self.engine_path.exists():
                 raise FileNotFoundError(f"TensorRT engine not found: {self.engine_path}")
-            
+
             self._engine = RealESRGANEngine(str(self.engine_path))
             self._engine.load()
             self._engine.activate()
-            
+
             # Allocate buffers for standard input size (will be reallocated as needed)
             standard_shape = (1, 3, 512, 512)
             self._engine.allocate_buffers(standard_shape, device=self.device)
-        
+
         return self._engine
-    
+
     def _download_file(self, url: str, save_path: Path):
         """Download file with progress bar"""
         if save_path.exists():
             return
-        
+
         response = requests.get(url, stream=True)
         response.raise_for_status()
-        
-        total_size = int(response.headers.get('content-length', 0))
-        
-        with open(save_path, 'wb') as file, tqdm(
-            desc=f"Downloading {save_path.name}",
-            total=total_size,
-            unit='iB',
-            unit_scale=True,
-            unit_divisor=1024,
-            colour='green'
-        ) as progress_bar:
+
+        total_size = int(response.headers.get("content-length", 0))
+
+        with (
+            open(save_path, "wb") as file,
+            tqdm(
+                desc=f"Downloading {save_path.name}",
+                total=total_size,
+                unit="iB",
+                unit_scale=True,
+                unit_divisor=1024,
+                colour="green",
+            ) as progress_bar,
+        ):
             for data in response.iter_content(chunk_size=1024):
                 size = file.write(data)
                 progress_bar.update(size)
-    
+
     def _ensure_model_ready(self):
         """Ensure PyTorch model is downloaded and loaded"""
         # Download model if needed
         if not self.model_path.exists():
             self._download_file(self.MODEL_URL, self.model_path)
-        
+
         # Load PyTorch model
         if self.pytorch_model is None:
             self._load_pytorch_model()
-        
+
         # Setup TensorRT if enabled
         if self.enable_tensorrt:
             self._setup_tensorrt()
-    
+
     def _load_pytorch_model(self):
         """Load PyTorch model from file"""
         if not SPANDREL_AVAILABLE:
@@ -235,92 +245,92 @@ class RealESRGANProcessor(BasePreprocessor):
             state_dict = torch.load(self.model_path, map_location=self.device)
             # This is a simplified approach - real implementation would need model architecture
             return
-        
+
         model_descriptor = ModelLoader().load_from_file(str(self.model_path))
         # Don't force dtype conversion as it can cause type mismatches
         # Let the model keep its native dtype and convert inputs as needed
         self.pytorch_model = model_descriptor.model.eval().to(device=self.device)
         model_dtype = next(self.pytorch_model.parameters()).dtype
-    
+
     def _export_to_onnx(self):
         """Export PyTorch model to ONNX format"""
         if self.onnx_path.exists() and not self.force_rebuild:
             return
-        
+
         if self.pytorch_model is None:
             self._load_pytorch_model()
-        
+
         if self.pytorch_model is None:
             return
-        
+
         # Test with small input for export
         test_input = torch.randn(1, 3, 256, 256).to(self.device)
-        
+
         dynamic_axes = {
             "input": {0: "batch_size", 2: "height", 3: "width"},
             "output": {0: "batch_size", 2: "height", 3: "width"},
         }
-        
+
         with torch.no_grad():
             torch.onnx.export(
                 self.pytorch_model,
                 test_input,
                 str(self.onnx_path),
                 verbose=False,
-                input_names=['input'],
-                output_names=['output'],
+                input_names=["input"],
+                output_names=["output"],
                 opset_version=17,
                 export_params=True,
                 dynamic_axes=dynamic_axes,
             )
-    
+
     def _setup_tensorrt(self):
         """Setup TensorRT engine"""
         if not TRT_AVAILABLE:
             return
-        
+
         # Export to ONNX first if needed
         if not self.onnx_path.exists():
             self._export_to_onnx()
-        
+
         # Build/load TensorRT engine
         self._load_tensorrt_engine()
-    
+
     def _load_tensorrt_engine(self):
         """Load or build TensorRT engine"""
         if self.engine_path.exists() and not self.force_rebuild:
             self._load_existing_engine()
         else:
             self._build_tensorrt_engine()
-    
+
     def _load_existing_engine(self):
         """Load existing TensorRT engine (now handled by lazy loading property)"""
         # Engine loading is now handled by the lazy loading 'engine' property
         # This method is kept for compatibility but does nothing
         pass
-    
+
     def _build_tensorrt_engine(self):
         """Build TensorRT engine from ONNX model"""
         if not self.onnx_path.exists():
             return
-        
+
         try:
             # Create builder and network
             builder = trt.Builder(trt.Logger(trt.Logger.WARNING))
             network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
             parser = trt.OnnxParser(network, trt.Logger(trt.Logger.WARNING))
-            
+
             # Parse ONNX model
-            with open(self.onnx_path, 'rb') as model:
+            with open(self.onnx_path, "rb") as model:
                 if not parser.parse(model.read()):
                     for error in range(parser.num_errors):
                         pass
                     return
-            
+
             # Configure builder
             config = builder.create_builder_config()
             config.set_flag(trt.BuilderFlag.FP16)  # Enable FP16 for better performance
-            
+
             # Set optimization profile for dynamic shapes
             profile = builder.create_optimization_profile()
             min_shape = (1, 3, 256, 256)
@@ -328,87 +338,87 @@ class RealESRGANProcessor(BasePreprocessor):
             max_shape = (1, 3, 1024, 1024)
             profile.set_shape("input", min_shape, opt_shape, max_shape)
             config.add_optimization_profile(profile)
-            
+
             # Build engine
             engine = builder.build_serialized_network(network, config)
-            
+
             if engine is None:
                 return
-            
+
             # Save engine
-            with open(self.engine_path, 'wb') as f:
+            with open(self.engine_path, "wb") as f:
                 f.write(engine)
-            
+
             # Load the built engine
             self._load_existing_engine()
-        
-        except Exception as e:
+
+        except Exception:
             pass
-    
+
     def _process_with_tensorrt(self, tensor: torch.Tensor) -> torch.Tensor:
         """Process tensor using TensorRT engine (following depth_tensorrt pattern)"""
         batch_size, channels, height, width = tensor.shape
         input_shape = (batch_size, channels, height, width)
-        
+
         # Ensure buffers are allocated for this input shape
-        if not hasattr(self.engine, 'tensors') or len(self.engine.tensors) == 0:
+        if not hasattr(self.engine, "tensors") or len(self.engine.tensors) == 0:
             self.engine.allocate_buffers(input_shape, device=self.device)
         else:
             # Check if we need to reallocate for different input shape
             input_tensor_shape = self.engine.tensors.get("input", torch.empty(0)).shape
             if input_tensor_shape != input_shape:
                 self.engine.allocate_buffers(input_shape, device=self.device)
-        
+
         # Prepare input tensor
         input_tensor = tensor.contiguous()
         if input_tensor.dtype != self.engine.tensors["input"].dtype:
             input_tensor = input_tensor.to(dtype=self.engine.tensors["input"].dtype)
-        
+
         # Use engine inference with current stream context for proper synchronization
         cuda_stream = torch.cuda.current_stream().cuda_stream
         result = self.engine.infer({"input": input_tensor}, cuda_stream)
-        output_tensor = result['output']
-        
+        output_tensor = result["output"]
+
         # Ensure output is properly clamped to [0, 1] range for RealESRGAN
         output_tensor = torch.clamp(output_tensor, 0.0, 1.0)
-        
+
         return output_tensor.clone()
-    
+
     def _process_with_pytorch(self, tensor: torch.Tensor) -> torch.Tensor:
         """Process tensor using PyTorch model"""
         if self.pytorch_model is None:
             raise RuntimeError("_process_with_pytorch: PyTorch model not loaded")
-        
+
         # Ensure model and input tensor have compatible dtypes
         model_dtype = next(self.pytorch_model.parameters()).dtype
         original_dtype = tensor.dtype
         if tensor.dtype != model_dtype:
             tensor = tensor.to(dtype=model_dtype)
-        
+
         with torch.no_grad():
             result = self.pytorch_model(tensor)
-            
+
             # Ensure output is properly clamped to [0, 1] range for RealESRGAN
             result = torch.clamp(result, 0.0, 1.0)
-            
+
             # Convert result to the desired output dtype (self.dtype)
             if result.dtype != self.dtype:
                 result = result.to(dtype=self.dtype)
-                
+
             return result
-    
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """Core processing using PIL Image"""
         # Convert to tensor for processing
         tensor = self.pil_to_tensor(image)
         if tensor.dim() == 3:
             tensor = tensor.unsqueeze(0)
-        
+
         # Process with available backend
         if self.enable_tensorrt and TRT_AVAILABLE and self.engine_path.exists():
             try:
                 output_tensor = self._process_with_tensorrt(tensor)
-            except Exception as e:
+            except Exception:
                 output_tensor = self._process_with_pytorch(tensor)
         elif self.pytorch_model is not None:
             output_tensor = self._process_with_pytorch(tensor)
@@ -416,29 +426,29 @@ class RealESRGANProcessor(BasePreprocessor):
             # Fallback to simple upscaling if no model is available
             target_width, target_height = self.get_target_dimensions()
             return image.resize((target_width, target_height), Image.LANCZOS)
-        
+
         # Convert back to PIL
         if output_tensor.dim() == 4:
             output_tensor = output_tensor.squeeze(0)
-        
+
         result_image = self.tensor_to_pil(output_tensor)
-        
+
         return result_image
-    
+
     def _ensure_target_size(self, image: Image.Image) -> Image.Image:
         """
         Override base class method - for upscaling, we want to keep the upscaled size
         Don't resize back to original dimensions
         """
         return image
-    
+
     def _ensure_target_size_tensor(self, tensor: torch.Tensor) -> torch.Tensor:
         """
         Override base class method - for upscaling, we want to keep the upscaled size
         Don't resize back to original dimensions
         """
         return tensor
-    
+
     def _process_tensor_core(self, tensor: torch.Tensor) -> torch.Tensor:
         """Core tensor processing"""
         if tensor.dim() == 3:
@@ -446,49 +456,46 @@ class RealESRGANProcessor(BasePreprocessor):
             squeeze_output = True
         else:
             squeeze_output = False
-        
+
         # Process with available backend
         if self.enable_tensorrt and TRT_AVAILABLE and self.engine_path.exists():
             try:
                 output_tensor = self._process_with_tensorrt(tensor)
-            except Exception as e:
+            except Exception:
                 output_tensor = self._process_with_pytorch(tensor)
         elif self.pytorch_model is not None:
             output_tensor = self._process_with_pytorch(tensor)
         else:
             # Fallback using interpolation
             output_tensor = torch.nn.functional.interpolate(
-                tensor, 
-                scale_factor=self.scale_factor,
-                mode='bicubic',
-                align_corners=False
+                tensor, scale_factor=self.scale_factor, mode="bicubic", align_corners=False
             )
-        
+
         if squeeze_output:
             output_tensor = output_tensor.squeeze(0)
-        
+
         return output_tensor
-    
+
     def get_target_dimensions(self) -> Tuple[int, int]:
         """Get target output dimensions (width, height) - 2x upscaled"""
-        width = self.params.get('image_width')
-        height = self.params.get('image_height')
-        
+        width = self.params.get("image_width")
+        height = self.params.get("image_height")
+
         if width is not None and height is not None:
             target_dims = (width * self.scale_factor, height * self.scale_factor)
             return target_dims
-        
+
         # Fallback to square resolution
-        resolution = self.params.get('image_resolution', 512)
+        resolution = self.params.get("image_resolution", 512)
         target_resolution = resolution * self.scale_factor
         target_dims = (target_resolution, target_resolution)
         return target_dims
-    
+
     def __del__(self):
         """Cleanup resources"""
-        if hasattr(self, '_engine') and self._engine is not None:
+        if hasattr(self, "_engine") and self._engine is not None:
             # Cleanup dedicated stream if it exists
-            if hasattr(self._engine, '_dedicated_stream'):
+            if hasattr(self._engine, "_dedicated_stream"):
                 torch.cuda.synchronize()
                 del self._engine._dedicated_stream
             del self._engine

--- a/src/streamdiffusion/preprocessing/processors/sharpen.py
+++ b/src/streamdiffusion/preprocessing/processors/sharpen.py
@@ -1,22 +1,21 @@
 import torch
 import torch.nn.functional as F
-import numpy as np
 from PIL import Image
-from typing import Union
+
 from .base import BasePreprocessor
 
 
 class SharpenPreprocessor(BasePreprocessor):
     """
     GPU-heavy image sharpening preprocessor using unsharp masking and edge enhancement
-    
+
     Applies sophisticated sharpening using multiple Gaussian operations:
     - Multi-scale unsharp masking
     - Edge-preserving enhancement
     - Laplacian-based detail enhancement
     - All operations performed on GPU for maximum performance
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
@@ -27,52 +26,54 @@ class SharpenPreprocessor(BasePreprocessor):
                     "type": "float",
                     "default": 1.5,
                     "range": [0.1, 5.0],
-                    "description": "Overall sharpening intensity. Higher values create stronger effects."
+                    "description": "Overall sharpening intensity. Higher values create stronger effects.",
                 },
                 "unsharp_radius": {
                     "type": "float",
                     "default": 1.0,
                     "range": [0.1, 5.0],
-                    "description": "Radius for unsharp masking blur. Affects detail scale."
+                    "description": "Radius for unsharp masking blur. Affects detail scale.",
                 },
                 "edge_enhancement": {
                     "type": "float",
                     "default": 0.5,
                     "range": [0.0, 2.0],
-                    "description": "Edge enhancement factor. Emphasizes image boundaries."
+                    "description": "Edge enhancement factor. Emphasizes image boundaries.",
                 },
                 "detail_boost": {
                     "type": "float",
                     "default": 0.3,
                     "range": [0.0, 1.0],
-                    "description": "Fine detail enhancement using Laplacian filtering."
+                    "description": "Fine detail enhancement using Laplacian filtering.",
                 },
                 "noise_reduction": {
                     "type": "float",
                     "default": 0.1,
                     "range": [0.0, 0.5],
-                    "description": "Mild noise reduction to prevent amplification."
+                    "description": "Mild noise reduction to prevent amplification.",
                 },
                 "multi_scale": {
                     "type": "bool",
                     "default": True,
-                    "description": "Use multi-scale processing for better quality (more GPU intensive)."
-                }
+                    "description": "Use multi-scale processing for better quality (more GPU intensive).",
+                },
             },
-            "use_cases": ["Detail enhancement", "Photo sharpening", "Edge definition", "Clarity improvement"]
+            "use_cases": ["Detail enhancement", "Photo sharpening", "Edge definition", "Clarity improvement"],
         }
-    
-    def __init__(self, 
-                 sharpen_intensity: float = 1.5,
-                 unsharp_radius: float = 1.0,
-                 edge_enhancement: float = 0.5,
-                 detail_boost: float = 0.3,
-                 noise_reduction: float = 0.1,
-                 multi_scale: bool = True,
-                 **kwargs):
+
+    def __init__(
+        self,
+        sharpen_intensity: float = 1.5,
+        unsharp_radius: float = 1.0,
+        edge_enhancement: float = 0.5,
+        detail_boost: float = 0.3,
+        noise_reduction: float = 0.1,
+        multi_scale: bool = True,
+        **kwargs,
+    ):
         """
         Initialize Sharpen preprocessor
-        
+
         Args:
             sharpen_intensity: Overall sharpening strength
             unsharp_radius: Blur radius for unsharp masking
@@ -89,194 +90,182 @@ class SharpenPreprocessor(BasePreprocessor):
             detail_boost=detail_boost,
             noise_reduction=noise_reduction,
             multi_scale=multi_scale,
-            **kwargs
+            **kwargs,
         )
-        
+
         # Cache kernels for efficiency
         self._cached_gaussian_kernels = {}
         self._cached_laplacian_kernel = None
         self._cached_edge_kernels = None
-    
+
     def _create_gaussian_kernel(self, size: int, sigma: float) -> torch.Tensor:
         """Create 2D Gaussian kernel"""
         coords = torch.arange(size, dtype=self.dtype, device=self.device)
         coords = coords - (size - 1) / 2
-        y_grid, x_grid = torch.meshgrid(coords, coords, indexing='ij')
+        y_grid, x_grid = torch.meshgrid(coords, coords, indexing="ij")
         gaussian = torch.exp(-(x_grid**2 + y_grid**2) / (2 * sigma**2))
         return gaussian / gaussian.sum()
-    
+
     def _get_gaussian_kernel(self, sigma: float) -> torch.Tensor:
         """Get cached Gaussian kernel"""
         # Calculate appropriate kernel size (6 sigma rule)
         size = max(3, int(6 * sigma + 1))
         if size % 2 == 0:
             size += 1
-        
+
         key = (size, sigma)
         if key not in self._cached_gaussian_kernels:
             self._cached_gaussian_kernels[key] = self._create_gaussian_kernel(size, sigma)
-        
+
         return self._cached_gaussian_kernels[key]
-    
+
     def _create_laplacian_kernel(self) -> torch.Tensor:
         """Create Laplacian kernel for edge detection"""
-        kernel = torch.tensor([
-            [0, -1, 0],
-            [-1, 4, -1],
-            [0, -1, 0]
-        ], dtype=self.dtype, device=self.device)
+        kernel = torch.tensor([[0, -1, 0], [-1, 4, -1], [0, -1, 0]], dtype=self.dtype, device=self.device)
         return kernel
-    
+
     def _get_laplacian_kernel(self) -> torch.Tensor:
         """Get cached Laplacian kernel"""
         if self._cached_laplacian_kernel is None:
             self._cached_laplacian_kernel = self._create_laplacian_kernel()
         return self._cached_laplacian_kernel
-    
+
     def _create_edge_kernels(self) -> tuple:
         """Create Sobel edge detection kernels"""
-        sobel_x = torch.tensor([
-            [-1, 0, 1],
-            [-2, 0, 2],
-            [-1, 0, 1]
-        ], dtype=self.dtype, device=self.device)
-        
-        sobel_y = torch.tensor([
-            [-1, -2, -1],
-            [0, 0, 0],
-            [1, 2, 1]
-        ], dtype=self.dtype, device=self.device)
-        
+        sobel_x = torch.tensor([[-1, 0, 1], [-2, 0, 2], [-1, 0, 1]], dtype=self.dtype, device=self.device)
+
+        sobel_y = torch.tensor([[-1, -2, -1], [0, 0, 0], [1, 2, 1]], dtype=self.dtype, device=self.device)
+
         return sobel_x, sobel_y
-    
+
     def _get_edge_kernels(self) -> tuple:
         """Get cached edge kernels"""
         if self._cached_edge_kernels is None:
             self._cached_edge_kernels = self._create_edge_kernels()
         return self._cached_edge_kernels
-    
+
     def _apply_kernel(self, image: torch.Tensor, kernel: torch.Tensor) -> torch.Tensor:
         """Apply convolution kernel to image"""
         num_channels = image.shape[1]
         padding = kernel.shape[-1] // 2
-        
+
         # Expand kernel for all channels
         kernel_conv = kernel.unsqueeze(0).unsqueeze(0).repeat(num_channels, 1, 1, 1)
-        
+
         return F.conv2d(image, kernel_conv, padding=padding, groups=num_channels)
-    
+
     def _gaussian_blur(self, image: torch.Tensor, sigma: float) -> torch.Tensor:
         """Apply Gaussian blur"""
         kernel = self._get_gaussian_kernel(sigma)
         return self._apply_kernel(image, kernel)
-    
+
     def _unsharp_mask(self, image: torch.Tensor, radius: float, intensity: float) -> torch.Tensor:
         """Apply unsharp masking"""
         # Create blurred version
         blurred = self._gaussian_blur(image, radius)
-        
+
         # Create mask (original - blurred)
         mask = image - blurred
-        
+
         # Apply sharpening
         sharpened = image + intensity * mask
-        
+
         return torch.clamp(sharpened, 0, 1)
-    
+
     def _edge_enhancement(self, image: torch.Tensor, strength: float) -> torch.Tensor:
         """Enhance edges using Sobel operators"""
         sobel_x, sobel_y = self._get_edge_kernels()
-        
+
         # Calculate gradients
         grad_x = self._apply_kernel(image, sobel_x)
         grad_y = self._apply_kernel(image, sobel_y)
-        
+
         # Calculate edge magnitude
         edge_magnitude = torch.sqrt(grad_x**2 + grad_y**2)
-        
+
         # Enhance edges
         enhanced = image + strength * edge_magnitude
-        
+
         return torch.clamp(enhanced, 0, 1)
-    
+
     def _detail_enhancement(self, image: torch.Tensor, strength: float) -> torch.Tensor:
         """Enhance fine details using Laplacian"""
         laplacian = self._get_laplacian_kernel()
-        
+
         # Apply Laplacian filter
         details = self._apply_kernel(image, laplacian)
-        
+
         # Add details back to image
         enhanced = image + strength * details
-        
+
         return torch.clamp(enhanced, 0, 1)
-    
+
     def _noise_reduction_light(self, image: torch.Tensor, strength: float) -> torch.Tensor:
         """Light noise reduction using small Gaussian blur"""
         if strength <= 0:
             return image
-        
+
         # Very light blur to reduce noise
         noise_reduced = self._gaussian_blur(image, 0.3)
-        
+
         # Blend with original
         return (1 - strength) * image + strength * noise_reduced
-    
+
     def _multi_scale_sharpen(self, image: torch.Tensor) -> torch.Tensor:
         """Apply multi-scale sharpening for better quality"""
-        sharpen_intensity = self.params.get('sharpen_intensity', 1.5)
-        unsharp_radius = self.params.get('unsharp_radius', 1.0)
-        
+        sharpen_intensity = self.params.get("sharpen_intensity", 1.5)
+        unsharp_radius = self.params.get("unsharp_radius", 1.0)
+
         # Multiple scales for better quality
         scales = [unsharp_radius * 0.5, unsharp_radius, unsharp_radius * 2.0]
         weights = [0.3, 0.5, 0.2]
-        
+
         result = image.clone()
-        
+
         for scale, weight in zip(scales, weights):
             # Apply unsharp mask at this scale
             sharpened_scale = self._unsharp_mask(image, scale, sharpen_intensity * weight)
-            
+
             # Blend with result
             result = result + weight * (sharpened_scale - image)
-        
+
         return torch.clamp(result, 0, 1)
-    
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """Apply sharpening using PIL/numpy fallback"""
         # Convert to tensor for GPU processing
         tensor = self.pil_to_tensor(image)
         tensor = tensor.squeeze(0)  # Remove batch dimension
-        
+
         # Process on GPU
         sharpened = self._process_tensor_core(tensor)
-        
+
         # Convert back to PIL
         return self.tensor_to_pil(sharpened)
-    
+
     def _process_tensor_core(self, image_tensor: torch.Tensor) -> torch.Tensor:
         """GPU-intensive sharpening processing"""
         # Ensure batch dimension
         if image_tensor.dim() == 3:
             image_tensor = image_tensor.unsqueeze(0)
-        
+
         # Ensure correct device and dtype
         image_tensor = image_tensor.to(device=self.device, dtype=self.dtype)
-        
+
         # Get parameters
-        sharpen_intensity = self.params.get('sharpen_intensity', 1.5)
-        unsharp_radius = self.params.get('unsharp_radius', 1.0)
-        edge_enhancement = self.params.get('edge_enhancement', 0.5)
-        detail_boost = self.params.get('detail_boost', 0.3)
-        noise_reduction = self.params.get('noise_reduction', 0.1)
-        multi_scale = self.params.get('multi_scale', True)
-        
+        sharpen_intensity = self.params.get("sharpen_intensity", 1.5)
+        unsharp_radius = self.params.get("unsharp_radius", 1.0)
+        edge_enhancement = self.params.get("edge_enhancement", 0.5)
+        detail_boost = self.params.get("detail_boost", 0.3)
+        noise_reduction = self.params.get("noise_reduction", 0.1)
+        multi_scale = self.params.get("multi_scale", True)
+
         result = image_tensor.clone()
-        
+
         # Step 1: Light noise reduction (prevent amplification)
         if noise_reduction > 0:
             result = self._noise_reduction_light(result, noise_reduction)
-        
+
         # Step 2: Main sharpening
         if multi_scale:
             # Multi-scale processing (more GPU intensive)
@@ -284,16 +273,16 @@ class SharpenPreprocessor(BasePreprocessor):
         else:
             # Single-scale unsharp masking
             result = self._unsharp_mask(result, unsharp_radius, sharpen_intensity)
-        
+
         # Step 3: Edge enhancement
         if edge_enhancement > 0:
             result = self._edge_enhancement(result, edge_enhancement)
-        
+
         # Step 4: Fine detail enhancement
         if detail_boost > 0:
             result = self._detail_enhancement(result, detail_boost)
-        
+
         # Final clamp to ensure valid range
         result = torch.clamp(result, 0, 1)
-        
+
         return result

--- a/src/streamdiffusion/preprocessing/processors/soft_edge.py
+++ b/src/streamdiffusion/preprocessing/processors/soft_edge.py
@@ -1,9 +1,7 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
-import numpy as np
 from PIL import Image
-from typing import Union, Optional
+
 from .base import BasePreprocessor
 
 
@@ -12,95 +10,100 @@ class MultiScaleSobelOperator(nn.Module):
     Real-time multi-scale Sobel edge detector optimized for soft HED-like edges
     Based on the existing SobelOperator but enhanced for soft edge detection
     """
-    
+
     def __init__(self, device="cuda", dtype=torch.float16):
         super(MultiScaleSobelOperator, self).__init__()
         self.device = device
         self.dtype = dtype
-        
+
         # Multi-scale edge detection (3 scales)
         self.edge_conv_x_1 = nn.Conv2d(1, 1, kernel_size=3, padding=1, bias=False).to(device)
         self.edge_conv_y_1 = nn.Conv2d(1, 1, kernel_size=3, padding=1, bias=False).to(device)
-        
+
         self.edge_conv_x_2 = nn.Conv2d(1, 1, kernel_size=5, padding=2, bias=False).to(device)
         self.edge_conv_y_2 = nn.Conv2d(1, 1, kernel_size=5, padding=2, bias=False).to(device)
-        
+
         self.edge_conv_x_3 = nn.Conv2d(1, 1, kernel_size=7, padding=3, bias=False).to(device)
         self.edge_conv_y_3 = nn.Conv2d(1, 1, kernel_size=7, padding=3, bias=False).to(device)
-        
+
         # Gaussian blur for soft edges
         self.blur = nn.Conv2d(1, 1, kernel_size=5, padding=2, bias=False).to(device)
-        
+
         self._setup_kernels()
-    
+
     def _setup_kernels(self):
         """Setup Sobel kernels for different scales"""
         # Scale 1: Standard 3x3 Sobel
-        sobel_x_3 = torch.tensor([
-            [-1.0, 0.0, 1.0],
-            [-2.0, 0.0, 2.0], 
-            [-1.0, 0.0, 1.0]
-        ], device=self.device, dtype=self.dtype)
-        
-        sobel_y_3 = torch.tensor([
-            [-1.0, -2.0, -1.0],
-            [0.0, 0.0, 0.0],
-            [1.0, 2.0, 1.0]
-        ], device=self.device, dtype=self.dtype)
-        
+        sobel_x_3 = torch.tensor(
+            [[-1.0, 0.0, 1.0], [-2.0, 0.0, 2.0], [-1.0, 0.0, 1.0]], device=self.device, dtype=self.dtype
+        )
+
+        sobel_y_3 = torch.tensor(
+            [[-1.0, -2.0, -1.0], [0.0, 0.0, 0.0], [1.0, 2.0, 1.0]], device=self.device, dtype=self.dtype
+        )
+
         # Scale 2: 5x5 Sobel
-        sobel_x_5 = torch.tensor([
-            [-1, -2, 0, 2, 1],
-            [-2, -3, 0, 3, 2],
-            [-3, -5, 0, 5, 3],
-            [-2, -3, 0, 3, 2],
-            [-1, -2, 0, 2, 1]
-        ], device=self.device, dtype=self.dtype) / 16.0
-        
+        sobel_x_5 = (
+            torch.tensor(
+                [[-1, -2, 0, 2, 1], [-2, -3, 0, 3, 2], [-3, -5, 0, 5, 3], [-2, -3, 0, 3, 2], [-1, -2, 0, 2, 1]],
+                device=self.device,
+                dtype=self.dtype,
+            )
+            / 16.0
+        )
+
         sobel_y_5 = sobel_x_5.T
-        
+
         # Scale 3: 7x7 Sobel (smoothed)
-        sobel_x_7 = torch.tensor([
-            [-1, -2, -3, 0, 3, 2, 1],
-            [-2, -3, -4, 0, 4, 3, 2],
-            [-3, -4, -5, 0, 5, 4, 3],
-            [-4, -5, -6, 0, 6, 5, 4],
-            [-3, -4, -5, 0, 5, 4, 3],
-            [-2, -3, -4, 0, 4, 3, 2],
-            [-1, -2, -3, 0, 3, 2, 1]
-        ], device=self.device, dtype=self.dtype) / 32.0
-        
+        sobel_x_7 = (
+            torch.tensor(
+                [
+                    [-1, -2, -3, 0, 3, 2, 1],
+                    [-2, -3, -4, 0, 4, 3, 2],
+                    [-3, -4, -5, 0, 5, 4, 3],
+                    [-4, -5, -6, 0, 6, 5, 4],
+                    [-3, -4, -5, 0, 5, 4, 3],
+                    [-2, -3, -4, 0, 4, 3, 2],
+                    [-1, -2, -3, 0, 3, 2, 1],
+                ],
+                device=self.device,
+                dtype=self.dtype,
+            )
+            / 32.0
+        )
+
         sobel_y_7 = sobel_x_7.T
-        
+
         # Gaussian kernel for smoothing
-        gaussian_5 = torch.tensor([
-            [1, 4, 6, 4, 1],
-            [4, 16, 24, 16, 4],
-            [6, 24, 36, 24, 6],
-            [4, 16, 24, 16, 4],
-            [1, 4, 6, 4, 1]
-        ], device=self.device, dtype=self.dtype) / 256.0
-        
+        gaussian_5 = (
+            torch.tensor(
+                [[1, 4, 6, 4, 1], [4, 16, 24, 16, 4], [6, 24, 36, 24, 6], [4, 16, 24, 16, 4], [1, 4, 6, 4, 1]],
+                device=self.device,
+                dtype=self.dtype,
+            )
+            / 256.0
+        )
+
         # Set kernel weights
         self.edge_conv_x_1.weight = nn.Parameter(sobel_x_3.view(1, 1, 3, 3))
         self.edge_conv_y_1.weight = nn.Parameter(sobel_y_3.view(1, 1, 3, 3))
-        
+
         self.edge_conv_x_2.weight = nn.Parameter(sobel_x_5.view(1, 1, 5, 5))
         self.edge_conv_y_2.weight = nn.Parameter(sobel_y_5.view(1, 1, 5, 5))
-        
+
         self.edge_conv_x_3.weight = nn.Parameter(sobel_x_7.view(1, 1, 7, 7))
         self.edge_conv_y_3.weight = nn.Parameter(sobel_y_7.view(1, 1, 7, 7))
-        
+
         self.blur.weight = nn.Parameter(gaussian_5.view(1, 1, 5, 5))
 
     @torch.no_grad()
     def forward(self, image_tensor: torch.Tensor) -> torch.Tensor:
         """
         Fast multi-scale soft edge detection
-        
+
         Args:
             image_tensor: Input tensor [B, C, H, W] or [C, H, W]
-            
+
         Returns:
             Soft edge map tensor [B, 1, H, W] or [1, H, W]
         """
@@ -109,108 +112,108 @@ class MultiScaleSobelOperator(nn.Module):
         if image_tensor.dim() == 3:
             image_tensor = image_tensor.unsqueeze(0)
             squeeze_output = True
-        
+
         # Convert to grayscale if needed
         if image_tensor.shape[1] == 3:
             # RGB to grayscale
             gray = 0.299 * image_tensor[:, 0:1] + 0.587 * image_tensor[:, 1:2] + 0.114 * image_tensor[:, 2:3]
         else:
             gray = image_tensor[:, 0:1]
-        
+
         # Multi-scale edge detection
         # Scale 1 (fine details)
         edge_x1 = self.edge_conv_x_1(gray)
         edge_y1 = self.edge_conv_y_1(gray)
         edge1 = torch.sqrt(edge_x1**2 + edge_y1**2)
-        
+
         # Scale 2 (medium details)
         edge_x2 = self.edge_conv_x_2(gray)
         edge_y2 = self.edge_conv_y_2(gray)
         edge2 = torch.sqrt(edge_x2**2 + edge_y2**2)
-        
+
         # Scale 3 (coarse details)
         edge_x3 = self.edge_conv_x_3(gray)
         edge_y3 = self.edge_conv_y_3(gray)
         edge3 = torch.sqrt(edge_x3**2 + edge_y3**2)
-        
+
         # Combine scales with weights (like HED side outputs)
         combined_edge = 0.5 * edge1 + 0.3 * edge2 + 0.2 * edge3
-        
+
         # Apply Gaussian smoothing for soft edges
         soft_edge = self.blur(combined_edge)
-        
+
         # Normalize to [0, 1] range
         soft_edge = soft_edge / (soft_edge.max() + 1e-8)
-        
+
         # Apply soft sigmoid activation for smooth transitions
         soft_edge = torch.sigmoid(soft_edge * 6.0 - 3.0)  # Soft S-curve
-        
+
         if squeeze_output:
             soft_edge = soft_edge.squeeze(0)
-            
+
         return soft_edge
 
 
 class SoftEdgePreprocessor(BasePreprocessor):
     """
     Real-time soft edge detection preprocessor - HED alternative
-    
+
     Uses multi-scale Sobel operations for extremely fast soft edge detection
     that mimics HED output quality at 50x+ the speed.
     """
-    
+
     _model_cache = {}
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
             "display_name": "Soft Edge Detection",
             "description": "Real-time soft edge detection optimized for smooth, artistic edge maps using multi-scale Sobel operations.",
             "parameters": {},
-            "use_cases": ["Artistic edge maps", "Soft stylistic control", "Real-time edge detection"]
+            "use_cases": ["Artistic edge maps", "Soft stylistic control", "Real-time edge detection"],
         }
-    
+
     def __init__(self, **kwargs):
         """
         Initialize soft edge preprocessor
-        
+
         Args:
             **kwargs: Additional parameters
         """
         super().__init__(**kwargs)
         self.model = None
         self._load_model()
-    
+
     def _load_model(self):
         """
         Load multi-scale Sobel operator with caching
         """
         cache_key = f"soft_edge_{self.device}_{self.dtype}"
-        
+
         if cache_key in self._model_cache:
             self.model = self._model_cache[cache_key]
             return
-        
+
         print("SoftEdgePreprocessor: Loading real-time multi-scale edge detector")
         self.model = MultiScaleSobelOperator(device=self.device, dtype=self.dtype)
         self.model.eval()
-        
+
         # Cache the model
         self._model_cache[cache_key] = self.model
-    
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Apply soft edge detection to the input image
         """
         # Convert PIL to tensor for GPU processing
         image_tensor = self.pil_to_tensor(image).squeeze(0)  # Remove batch dim
-        
+
         # Process with GPU-accelerated tensor method
         processed_tensor = self._process_tensor_core(image_tensor)
-        
+
         # Convert back to PIL
         return self.tensor_to_pil(processed_tensor)
-    
+
     def _process_tensor_core(self, image_tensor: torch.Tensor) -> torch.Tensor:
         """
         GPU-optimized soft edge processing using tensors
@@ -218,25 +221,25 @@ class SoftEdgePreprocessor(BasePreprocessor):
         with torch.no_grad():
             # Ensure correct input format and device
             image_tensor = image_tensor.to(device=self.device, dtype=self.dtype)
-            
+
             # Normalize to [0, 1] if needed
             if image_tensor.max() > 1.0:
                 image_tensor = image_tensor / 255.0
-            
+
             # Multi-scale edge detection
             edge_map = self.model(image_tensor)
-            
+
             # Convert to 3-channel RGB format
             if edge_map.dim() == 3:
                 edge_map = edge_map.repeat(3, 1, 1)
             else:
                 edge_map = edge_map.repeat(1, 3, 1, 1).squeeze(0)
-            
+
             # Ensure output is in [0, 1] range
             edge_map = torch.clamp(edge_map, 0.0, 1.0)
-            
+
         return edge_map
-    
+
     def get_model_info(self) -> dict:
         """
         Get information about the loaded model
@@ -248,24 +251,20 @@ class SoftEdgePreprocessor(BasePreprocessor):
             "device": str(self.device),
             "dtype": str(self.dtype),
             "description": "Real-time multi-scale soft edge detection, HED quality at 50x+ speed",
-            "expected_fps": "100+ FPS at 512x512"
+            "expected_fps": "100+ FPS at 512x512",
         }
-    
+
     @classmethod
-    def create_optimized(cls, device: str = 'cuda', dtype: torch.dtype = torch.float16, **kwargs):
+    def create_optimized(cls, device: str = "cuda", dtype: torch.dtype = torch.float16, **kwargs):
         """
         Create an optimized soft edge preprocessor for real-time use
-        
+
         Args:
             device: Target device ('cuda' or 'cpu')
             dtype: Data type for inference
             **kwargs: Additional parameters
-            
+
         Returns:
             Optimized SoftEdgePreprocessor instance
         """
-        return cls(
-            device=device,
-            dtype=dtype,
-            **kwargs
-        ) 
+        return cls(device=device, dtype=dtype, **kwargs)

--- a/src/streamdiffusion/preprocessing/processors/standard_lineart.py
+++ b/src/streamdiffusion/preprocessing/processors/standard_lineart.py
@@ -1,22 +1,22 @@
-import numpy as np
-import cv2
-from PIL import Image
-from typing import Union, Optional
 import time
-from .base import BasePreprocessor
+
+import numpy as np
 import torch
 import torch.nn.functional as F
+from PIL import Image
+
+from .base import BasePreprocessor
 
 
 class StandardLineartPreprocessor(BasePreprocessor):
     """
     Real-time optimized Standard Lineart detection preprocessor for ControlNet
-    
+
     Extracts line art from input images using traditional computer vision techniques.
     Uses Gaussian blur and intensity calculations to detect lines without requiring
     pre-trained models. GPU-accelerated with PyTorch for optimal real-time performance.
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
@@ -28,27 +28,29 @@ class StandardLineartPreprocessor(BasePreprocessor):
                     "default": 6.0,
                     "range": [1.0, 20.0],
                     "step": 0.1,
-                    "description": "Standard deviation for Gaussian blur (higher = smoother lines)"
+                    "description": "Standard deviation for Gaussian blur (higher = smoother lines)",
                 },
                 "intensity_threshold": {
                     "type": "int",
                     "default": 8,
                     "range": [1, 50],
-                    "description": "Threshold for intensity calculation (lower = more sensitive)"
-                }
+                    "description": "Threshold for intensity calculation (lower = more sensitive)",
+                },
             },
-            "use_cases": ["Traditional line art", "Simple edge detection", "No AI model required"]
+            "use_cases": ["Traditional line art", "Simple edge detection", "No AI model required"],
         }
-    
-    def __init__(self, 
-                 detect_resolution: int = 512,
-                 image_resolution: int = 512,
-                 gaussian_sigma: float = 6.0,
-                 intensity_threshold: int = 8,
-                 **kwargs):
+
+    def __init__(
+        self,
+        detect_resolution: int = 512,
+        image_resolution: int = 512,
+        gaussian_sigma: float = 6.0,
+        intensity_threshold: int = 8,
+        **kwargs,
+    ):
         """
         Initialize Standard Lineart preprocessor
-        
+
         Args:
             detect_resolution: Resolution for line art detection
             image_resolution: Output image resolution
@@ -56,39 +58,39 @@ class StandardLineartPreprocessor(BasePreprocessor):
             intensity_threshold: Threshold for intensity calculation
             **kwargs: Additional parameters
         """
-        
+
         super().__init__(
             detect_resolution=detect_resolution,
             image_resolution=image_resolution,
             gaussian_sigma=gaussian_sigma,
             intensity_threshold=intensity_threshold,
-            **kwargs
+            **kwargs,
         )
-        
+
         # Initialize GPU device
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    
+
     def _gaussian_kernel(self, kernel_size: int, sigma: float, device=None) -> torch.Tensor:
         """Create 2D Gaussian kernel - based on existing codebase pattern"""
         x, y = torch.meshgrid(
-            torch.linspace(-1, 1, kernel_size, device=device), 
-            torch.linspace(-1, 1, kernel_size, device=device), 
-            indexing="ij"
+            torch.linspace(-1, 1, kernel_size, device=device),
+            torch.linspace(-1, 1, kernel_size, device=device),
+            indexing="ij",
         )
         d = torch.sqrt(x * x + y * y)
         g = torch.exp(-(d * d) / (2.0 * sigma * sigma))
         return g / g.sum()
-    
+
     def _gaussian_blur_torch(self, image: torch.Tensor, sigma: float) -> torch.Tensor:
         """Apply Gaussian blur using PyTorch - GPU accelerated"""
         # Calculate kernel size from sigma (odd number)
         kernel_size = int(2 * torch.ceil(torch.tensor(3 * sigma)) + 1)
         if kernel_size % 2 == 0:
             kernel_size += 1
-        
+
         # Create Gaussian kernel
         kernel = self._gaussian_kernel(kernel_size, sigma, device=image.device)
-        
+
         # Handle different input shapes
         if image.dim() == 3:  # HWC format
             H, W, C = image.shape
@@ -100,31 +102,31 @@ class StandardLineartPreprocessor(BasePreprocessor):
             needs_reshape = False
         else:
             raise ValueError(f"standardlineart_gaussian_blur_torch: Unsupported image shape: {image.shape}")
-        
+
         # Expand kernel for all channels
         kernel = kernel.repeat(image.shape[1], 1, 1).unsqueeze(1)
-        
+
         # Apply blur with reflection padding
         padding = kernel_size // 2
-        padded_image = F.pad(image, (padding, padding, padding, padding), 'reflect')
+        padded_image = F.pad(image, (padding, padding, padding, padding), "reflect")
         blurred = F.conv2d(padded_image, kernel, padding=0, groups=image.shape[1])
-        
+
         # Convert back to original format if needed
         if needs_reshape:
             blurred = blurred.squeeze(0).permute(1, 2, 0)  # BCHW -> HWC
-        
+
         return blurred
-    
+
     def _ensure_hwc3_torch(self, x: torch.Tensor) -> torch.Tensor:
         """Ensure image has 3 channels (HWC3 format) - PyTorch version"""
         if x.dim() == 2:
             x = x.unsqueeze(-1)  # Add channel dimension
-        
+
         if x.dim() != 3:
             raise ValueError(f"standardlineart_ensure_hwc3_torch: Expected 2D or 3D tensor, got {x.dim()}D")
-        
+
         H, W, C = x.shape
-        
+
         if C == 3:
             return x
         elif C == 1:
@@ -136,90 +138,87 @@ class StandardLineartPreprocessor(BasePreprocessor):
             return torch.clamp(y, 0, 255)
         else:
             raise ValueError(f"standardlineart_ensure_hwc3_torch: Unsupported channel count: {C}")
-    
+
     def _pad64(self, x: int) -> int:
         """Pad to nearest multiple of 64"""
         return int(torch.ceil(torch.tensor(float(x) / 64.0)) * 64 - x)
-    
+
     def _resize_image_with_pad_torch(self, input_image: torch.Tensor, resolution: int) -> tuple:
         """Resize image with padding to target resolution - PyTorch GPU accelerated"""
         img = self._ensure_hwc3_torch(input_image)
         H_raw, W_raw, _ = img.shape
-        
+
         if resolution == 0:
             return img, lambda x: x
-            
+
         k = float(resolution) / float(min(H_raw, W_raw))
         H_target = int(torch.round(torch.tensor(float(H_raw) * k)))
         W_target = int(torch.round(torch.tensor(float(W_raw) * k)))
-        
+
         # Convert to BCHW for interpolation
         img_bchw = img.permute(2, 0, 1).unsqueeze(0)  # HWC -> BCHW
-        
+
         # Use PyTorch's interpolate for GPU-accelerated resize
-        mode = 'bicubic' if k > 1 else 'area'
+        mode = "bicubic" if k > 1 else "area"
         img_resized_bchw = F.interpolate(
-            img_bchw, 
-            size=(H_target, W_target), 
-            mode=mode, 
-            align_corners=False if mode == 'bicubic' else None
+            img_bchw, size=(H_target, W_target), mode=mode, align_corners=False if mode == "bicubic" else None
         )
-        
+
         # Convert back to HWC
         img_resized = img_resized_bchw.squeeze(0).permute(1, 2, 0)
-        
+
         # Apply padding
         H_pad, W_pad = self._pad64(H_target), self._pad64(W_target)
-        img_padded = F.pad(img_resized.permute(2, 0, 1), (0, W_pad, 0, H_pad), mode='replicate').permute(1, 2, 0)
+        img_padded = F.pad(img_resized.permute(2, 0, 1), (0, W_pad, 0, H_pad), mode="replicate").permute(1, 2, 0)
 
         def remove_pad(x):
             return x[:H_target, :W_target, ...]
 
         return img_padded, remove_pad
-    
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Apply standard line art detection to the input image
         """
         start_time = time.time()
-        
+
         if isinstance(image, Image.Image):
             input_image_cpu = np.array(image, dtype=np.uint8)
         else:
             input_image_cpu = image.astype(np.uint8)
-            
+
         input_image = torch.from_numpy(input_image_cpu).float().to(self.device)
-            
-        detect_resolution = self.params.get('detect_resolution', 512)
-        gaussian_sigma = self.params.get('gaussian_sigma', 6.0)
-        intensity_threshold = self.params.get('intensity_threshold', 8)
-        
+
+        detect_resolution = self.params.get("detect_resolution", 512)
+        gaussian_sigma = self.params.get("gaussian_sigma", 6.0)
+        intensity_threshold = self.params.get("intensity_threshold", 8)
+
         input_image, remove_pad = self._resize_image_with_pad_torch(input_image, detect_resolution)
-        
+
         x = input_image
-        
+
         g = self._gaussian_blur_torch(x, gaussian_sigma)
-        
+
         intensity = torch.min(g - x, dim=2)[0]
         intensity = torch.clamp(intensity, 0, 255)
-        
+
         threshold_mask = intensity > intensity_threshold
         if torch.any(threshold_mask):
             median_val = torch.median(intensity[threshold_mask])
             normalization_factor = max(16, float(median_val))
         else:
             normalization_factor = 16
-            
+
         intensity = intensity / normalization_factor
         intensity = intensity * 127
-        
+
         detected_map = torch.clamp(intensity, 0, 255).byte()
         detected_map = detected_map.unsqueeze(-1)
         detected_map = self._ensure_hwc3_torch(detected_map.float())
-        
+
         detected_map = remove_pad(detected_map)
-        
+
         detected_map_cpu = detected_map.byte().cpu().numpy()
         lineart_image = Image.fromarray(detected_map_cpu)
-        
-        return lineart_image 
+
+        return lineart_image

--- a/src/streamdiffusion/preprocessing/processors/temporal_net_tensorrt.py
+++ b/src/streamdiffusion/preprocessing/processors/temporal_net_tensorrt.py
@@ -83,7 +83,16 @@ class TensorRTEngine:
         for idx in range(self.engine.num_io_tensors):
             name = self.engine.get_tensor_name(idx)
             shape = self.context.get_tensor_shape(name)
-            dtype = trt.nptype(self.engine.get_tensor_dtype(name))
+            trt_dtype = self.engine.get_tensor_dtype(name)
+            try:
+                dtype_np = trt.nptype(trt_dtype)
+                torch_dtype = numpy_to_torch_dtype_dict[dtype_np]
+            except TypeError:
+                # FP8 (FLOAT8E4M3FN) has no numpy equivalent — map directly to torch
+                if trt_dtype == trt.DataType.FP8:
+                    torch_dtype = torch.float8_e4m3fn
+                else:
+                    raise
 
             if self.engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT:
                 # For dynamic shapes, use provided input_shape
@@ -103,7 +112,7 @@ class TensorRTEngine:
                     f"Please provide input_shape parameter to allocate_buffers()."
                 )
 
-            tensor = torch.empty(tuple(shape), dtype=numpy_to_torch_dtype_dict[dtype]).to(device=device)
+            tensor = torch.empty(tuple(shape), dtype=torch_dtype).to(device=device)
             self.tensors[name] = tensor
 
     def infer(self, feed_dict, stream=None):

--- a/src/streamdiffusion/preprocessing/processors/temporal_net_tensorrt.py
+++ b/src/streamdiffusion/preprocessing/processors/temporal_net_tensorrt.py
@@ -1,26 +1,32 @@
-import torch
-import torch.nn.functional as F
-import numpy as np
-from PIL import Image
 import logging
 from pathlib import Path
 from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from PIL import Image
+
 from .base import PipelineAwareProcessor
+
 
 # Try to import TensorRT dependencies
 try:
+    from collections import OrderedDict
+
     import tensorrt as trt
     from polygraphy.backend.common import bytes_from_path
     from polygraphy.backend.trt import engine_from_bytes
-    from collections import OrderedDict
+
     TENSORRT_AVAILABLE = True
 except ImportError:
     TENSORRT_AVAILABLE = False
 
 # Try to import torchvision for RAFT model
 try:
-    from torchvision.models.optical_flow import raft_small, Raft_Small_Weights
+    from torchvision.models.optical_flow import Raft_Small_Weights, raft_small
     from torchvision.utils import flow_to_image
+
     TORCHVISION_AVAILABLE = True
 except ImportError:
     TORCHVISION_AVAILABLE = False
@@ -48,7 +54,7 @@ else:
 
 class TensorRTEngine:
     """TensorRT engine wrapper for RAFT optical flow inference"""
-    
+
     def __init__(self, engine_path):
         self.engine_path = engine_path
         self.engine = None
@@ -69,7 +75,7 @@ class TensorRTEngine:
     def allocate_buffers(self, device="cuda", input_shape=None):
         """
         Allocate input/output buffers
-        
+
         Args:
             device: Device to allocate tensors on
             input_shape: Shape for input tensors (B, C, H, W). Required for engines with dynamic shapes.
@@ -78,7 +84,7 @@ class TensorRTEngine:
             name = self.engine.get_tensor_name(idx)
             shape = self.context.get_tensor_shape(name)
             dtype = trt.nptype(self.engine.get_tensor_dtype(name))
-            
+
             if self.engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT:
                 # For dynamic shapes, use provided input_shape
                 if input_shape is not None and any(dim == -1 for dim in shape):
@@ -89,24 +95,22 @@ class TensorRTEngine:
             else:
                 # For output tensors, get shape after input shapes are set
                 shape = self.context.get_tensor_shape(name)
-            
+
             # Verify shape has no dynamic dimensions
             if any(dim == -1 for dim in shape):
                 raise RuntimeError(
                     f"Tensor '{name}' still has dynamic dimensions {shape} after setting input shapes. "
                     f"Please provide input_shape parameter to allocate_buffers()."
                 )
-            
-            tensor = torch.empty(
-                tuple(shape), dtype=numpy_to_torch_dtype_dict[dtype]
-            ).to(device=device)
+
+            tensor = torch.empty(tuple(shape), dtype=numpy_to_torch_dtype_dict[dtype]).to(device=device)
             self.tensors[name] = tensor
 
     def infer(self, feed_dict, stream=None):
         """Run inference with optional stream parameter"""
         if stream is None:
             stream = self._cuda_stream
-        
+
         # Check if we need to update tensor shapes for dynamic dimensions
         need_realloc = False
         for name, buf in feed_dict.items():
@@ -114,7 +118,7 @@ class TensorRTEngine:
                 if self.tensors[name].shape != buf.shape:
                     need_realloc = True
                     break
-        
+
         # Reallocate buffers if input shape changed
         if need_realloc:
             # Update input shapes
@@ -126,18 +130,18 @@ class TensorRTEngine:
                 except:
                     # Tensor name might not be in engine, skip
                     pass
-            
+
             # Reallocate all tensors with new shapes
             for idx in range(self.engine.num_io_tensors):
                 name = self.engine.get_tensor_name(idx)
                 shape = self.context.get_tensor_shape(name)
                 dtype = trt.nptype(self.engine.get_tensor_dtype(name))
-                
-                tensor = torch.empty(
-                    tuple(shape), dtype=numpy_to_torch_dtype_dict[dtype]
-                ).to(device=self.tensors[name].device)
+
+                tensor = torch.empty(tuple(shape), dtype=numpy_to_torch_dtype_dict[dtype]).to(
+                    device=self.tensors[name].device
+                )
                 self.tensors[name] = tensor
-            
+
         # Copy input data to tensors
         for name, buf in feed_dict.items():
             self.tensors[name].copy_(buf)
@@ -145,26 +149,26 @@ class TensorRTEngine:
         # Set tensor addresses
         for name, tensor in self.tensors.items():
             self.context.set_tensor_address(name, tensor.data_ptr())
-        
+
         # Execute inference
         success = self.context.execute_async_v3(stream)
         if not success:
             raise ValueError("TensorRT inference failed.")
-        
+
         return self.tensors
 
 
 class TemporalNetTensorRTPreprocessor(PipelineAwareProcessor):
     """
     TensorRT-accelerated TemporalNet preprocessor for temporal consistency using optical flow visualization.
-    
+
     This preprocessor uses TensorRT to accelerate RAFT optical flow computation and creates a 6-channel
     control tensor by concatenating the previous input frame (RGB) with a colorized optical flow
     visualization (RGB) computed between the previous and current input frames.
-    
+
     Output: [prev_input_RGB, flow_RGB(prev_input → current_input)]
     """
-    
+
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
@@ -174,53 +178,59 @@ class TemporalNetTensorRTPreprocessor(PipelineAwareProcessor):
                 "engine_path": {
                     "type": "str",
                     "default": None,
-                    "description": "Path to pre-built TensorRT engine file. Use compile_raft_tensorrt.py to build one."
+                    "description": "Path to pre-built TensorRT engine file. Use compile_raft_tensorrt.py to build one.",
                 },
                 "flow_strength": {
                     "type": "float",
                     "default": 1.0,
                     "range": [0.0, 2.0],
                     "step": 0.1,
-                    "description": "Strength multiplier for optical flow visualization (1.0 = normal, higher = more pronounced flow)"
+                    "description": "Strength multiplier for optical flow visualization (1.0 = normal, higher = more pronounced flow)",
                 },
                 "height": {
                     "type": "int",
                     "default": 512,
                     "range": [256, 1024],
                     "step": 64,
-                    "description": "Height for optical flow computation (must be within engine's height range)"
+                    "description": "Height for optical flow computation (must be within engine's height range)",
                 },
                 "width": {
                     "type": "int",
                     "default": 512,
                     "range": [256, 1024],
                     "step": 64,
-                    "description": "Width for optical flow computation (must be within engine's width range)"
+                    "description": "Width for optical flow computation (must be within engine's width range)",
                 },
                 "output_format": {
-                    "type": "str", 
+                    "type": "str",
                     "default": "concat",
                     "options": ["concat", "warped_only"],
-                    "description": "Output format: 'concat' for 6-channel (prev_input+flow_RGB), 'warped_only' for 3-channel flow RGB only"
-                }
+                    "description": "Output format: 'concat' for 6-channel (prev_input+flow_RGB), 'warped_only' for 3-channel flow RGB only",
+                },
             },
-            "use_cases": ["High-performance video generation", "Real-time temporal consistency", "GPU-optimized motion control"]
+            "use_cases": [
+                "High-performance video generation",
+                "Real-time temporal consistency",
+                "GPU-optimized motion control",
+            ],
         }
-    
-    def __init__(self, 
-                 pipeline_ref: Any,
-                 engine_path: str = None,
-                 height: int = 512,
-                 width: int = 512,
-                 flow_strength: float = 1.0,
-                 output_format: str = "concat",
-                 **kwargs):
+
+    def __init__(
+        self,
+        pipeline_ref: Any,
+        engine_path: str = None,
+        height: int = 512,
+        width: int = 512,
+        flow_strength: float = 1.0,
+        output_format: str = "concat",
+        **kwargs,
+    ):
         """
         Initialize TensorRT TemporalNet preprocessor
-        
+
         Args:
             pipeline_ref: Reference to the StreamDiffusion pipeline instance (required)
-            engine_path: Path to pre-built TensorRT engine file (required). 
+            engine_path: Path to pre-built TensorRT engine file (required).
                         Build one using: python -m streamdiffusion.tools.compile_raft_tensorrt
             height: Height for optical flow computation (must be within engine's height range)
             width: Width for optical flow computation (must be within engine's width range)
@@ -228,13 +238,12 @@ class TemporalNetTensorRTPreprocessor(PipelineAwareProcessor):
             output_format: "concat" for 6-channel [prev_input+flow_RGB], "warped_only" for 3-channel flow RGB only
             **kwargs: Additional parameters passed to BasePreprocessor
         """
-        
+
         if not TORCHVISION_AVAILABLE:
             raise ImportError(
-                "torchvision is required for TemporalNet preprocessing. "
-                "Install it with: pip install torchvision"
+                "torchvision is required for TemporalNet preprocessing. Install it with: pip install torchvision"
             )
-        
+
         if not TENSORRT_AVAILABLE:
             raise ImportError(
                 "TensorRT and polygraphy are required for TensorRT acceleration. "
@@ -247,7 +256,7 @@ class TemporalNetTensorRTPreprocessor(PipelineAwareProcessor):
                 "  python -m streamdiffusion.tools.compile_raft_tensorrt --min_resolution 512x512 --max_resolution 1024x1024 --output_dir ./models/temporal_net\n"
                 "Then pass the engine path to this preprocessor."
             )
-        
+
         super().__init__(
             pipeline_ref=pipeline_ref,
             height=height,
@@ -255,17 +264,17 @@ class TemporalNetTensorRTPreprocessor(PipelineAwareProcessor):
             engine_path=engine_path,
             flow_strength=flow_strength,
             output_format=output_format,
-            **kwargs
+            **kwargs,
         )
-        
+
         self.flow_strength = max(0.0, min(2.0, flow_strength))
         self.height = height
         self.width = width
         self._first_frame = True
-        
+
         # Store previous input frame for flow computation
         self.prev_input = None
-        
+
         # Engine path
         self.engine_path = Path(engine_path)
         if not self.engine_path.exists():
@@ -274,17 +283,17 @@ class TemporalNetTensorRTPreprocessor(PipelineAwareProcessor):
                 f"Build one using:\n"
                 f"  python -m streamdiffusion.tools.compile_raft_tensorrt --min_resolution {height}x{width} --max_resolution {height}x{width} --output_dir {self.engine_path.parent}"
             )
-        
+
         # Model state
         self.trt_engine = None
-        
+
         # Cached tensors for performance
         self._grid_cache = {}
         self._tensor_cache = {}
-        
+
         # Load TensorRT engine
         self._load_tensorrt_engine()
-    
+
     def _load_tensorrt_engine(self):
         """Load pre-built TensorRT engine"""
         logger.info(f"_load_tensorrt_engine: Loading TensorRT engine: {self.engine_path}")
@@ -292,11 +301,11 @@ class TemporalNetTensorRTPreprocessor(PipelineAwareProcessor):
             self.trt_engine = TensorRTEngine(str(self.engine_path))
             self.trt_engine.load()
             self.trt_engine.activate()
-            
+
             # For dynamic shapes, provide the input shape based on image dimensions
             input_shape = (1, 3, self.height, self.width)
             self.trt_engine.allocate_buffers(device=self.device, input_shape=input_shape)
-            
+
             logger.info(f"_load_tensorrt_engine: TensorRT engine loaded successfully from {self.engine_path}")
             logger.info(f"_load_tensorrt_engine: Using resolution: {self.height}x{self.width}")
         except Exception as e:
@@ -307,16 +316,14 @@ class TemporalNetTensorRTPreprocessor(PipelineAwareProcessor):
                 f"Make sure the engine was built with a resolution range that includes {self.height}x{self.width}.\n"
                 f"For example: python -m streamdiffusion.tools.compile_raft_tensorrt --min_resolution 512x512 --max_resolution 1024x1024"
             )
-    
 
-    
     def _process_core(self, image: Image.Image) -> Image.Image:
         """
         Process using TensorRT-accelerated optical flow warping
-        
+
         Args:
             image: Current input image
-            
+
         Returns:
             Warped previous frame for temporal guidance, or fallback for first frame
         """
@@ -324,50 +331,50 @@ class TemporalNetTensorRTPreprocessor(PipelineAwareProcessor):
         tensor = self.pil_to_tensor(image)
         result_tensor = self._process_tensor_core(tensor)
         return self.tensor_to_pil(result_tensor)
-    
+
     def _process_tensor_core(self, tensor: torch.Tensor) -> torch.Tensor:
         """
         Process using TensorRT-accelerated optical flow computation (GPU-optimized path)
-        
+
         Args:
             tensor: Current input tensor
-            
+
         Returns:
             Concatenated tensor: [prev_input_RGB, flow_RGB] for temporal guidance
         """
-        
+
         # Normalize input tensor
         input_tensor = tensor
         if input_tensor.max() > 1.0:
             input_tensor = input_tensor / 255.0
-        
+
         # Ensure consistent format
         if input_tensor.dim() == 4 and input_tensor.shape[0] == 1:
             input_tensor = input_tensor[0]
-        
+
         # Check if we have a previous input frame
         if self.prev_input is not None and not self._first_frame:
             try:
                 # Compute optical flow between prev_input -> current_input
                 flow_rgb_tensor = self._compute_flow_to_rgb_tensor(self.prev_input, input_tensor)
-                
+
                 # Check output format
-                output_format = self.params.get('output_format', 'concat')
+                output_format = self.params.get("output_format", "concat")
                 if output_format == "concat":
                     # Concatenate prev_input + flow_RGB for TemporalNet2 (6 channels)
                     result_tensor = self._concatenate_frames_tensor(self.prev_input, flow_rgb_tensor)
                 else:
                     # Return only flow RGB (3 channels)
                     result_tensor = flow_rgb_tensor
-                
+
                 # Ensure correct output format
                 if result_tensor.dim() == 3:
                     result_tensor = result_tensor.unsqueeze(0)
-                
+
                 result = result_tensor.to(device=self.device, dtype=self.dtype)
             except Exception as e:
                 logger.error(f"_process_tensor_core: TensorRT optical flow failed: {e}")
-                output_format = self.params.get('output_format', 'concat')
+                output_format = self.params.get("output_format", "concat")
                 if output_format == "concat":
                     # Create 6-channel fallback by concatenating prev_input with itself
                     result_tensor = self._concatenate_frames_tensor(self.prev_input, self.prev_input)
@@ -385,19 +392,19 @@ class TemporalNetTensorRTPreprocessor(PipelineAwareProcessor):
             self._first_frame = False
             if tensor.dim() == 3:
                 tensor = tensor.unsqueeze(0)
-            
+
             # Handle 6-channel output for first frame
-            output_format = self.params.get('output_format', 'concat')
+            output_format = self.params.get("output_format", "concat")
             if output_format == "concat":
                 # For first frame, concatenate current frame with zeros (no flow)
                 if tensor.dim() == 4 and tensor.shape[0] == 1:
                     current_tensor = tensor[0]
                 else:
                     current_tensor = tensor
-                
+
                 # Create zero tensor for flow (same shape as current_tensor)
                 zero_flow = torch.zeros_like(current_tensor, device=self.device, dtype=current_tensor.dtype)
-                
+
                 result_tensor = self._concatenate_frames_tensor(current_tensor, zero_flow)
                 if result_tensor.dim() == 3:
                     result_tensor = result_tensor.unsqueeze(0)
@@ -412,164 +419,148 @@ class TemporalNetTensorRTPreprocessor(PipelineAwareProcessor):
                 if result_tensor.dim() == 3:
                     result_tensor = result_tensor.unsqueeze(0)
                 result = result_tensor.to(device=self.device, dtype=self.dtype)
-        
+
         # Store current input as previous for next frame
         self.prev_input = input_tensor.clone()
-        
+
         return result
-    
-    def _compute_flow_to_rgb_tensor(self, prev_input_tensor: torch.Tensor, current_input_tensor: torch.Tensor) -> torch.Tensor:
+
+    def _compute_flow_to_rgb_tensor(
+        self, prev_input_tensor: torch.Tensor, current_input_tensor: torch.Tensor
+    ) -> torch.Tensor:
         """
         Compute optical flow between prev_input -> current_input and convert to RGB visualization
-        
+
         Args:
             prev_input_tensor: Previous input frame tensor (CHW format, [0,1]) on GPU
             current_input_tensor: Current input frame tensor (CHW format, [0,1]) on GPU
-            
+
         Returns:
             Flow visualization as RGB tensor (CHW format, [0,1]) on GPU
         """
         target_width, target_height = self.get_target_dimensions()
-        
+
         # Convert to float32 for TensorRT processing
         prev_tensor = prev_input_tensor.to(device=self.device, dtype=torch.float32)
         current_tensor = current_input_tensor.to(device=self.device, dtype=torch.float32)
-        
+
         # Resize for flow computation if needed (keep on GPU)
         if current_tensor.shape[-1] != self.width or current_tensor.shape[-2] != self.height:
             prev_resized = F.interpolate(
-                prev_tensor.unsqueeze(0),
-                size=(self.height, self.width), 
-                mode='bilinear',
-                align_corners=False
+                prev_tensor.unsqueeze(0), size=(self.height, self.width), mode="bilinear", align_corners=False
             ).squeeze(0)
             current_resized = F.interpolate(
-                current_tensor.unsqueeze(0), 
-                size=(self.height, self.width),
-                mode='bilinear', 
-                align_corners=False
+                current_tensor.unsqueeze(0), size=(self.height, self.width), mode="bilinear", align_corners=False
             ).squeeze(0)
         else:
             prev_resized = prev_tensor
             current_resized = current_tensor
-        
+
         # Compute optical flow using TensorRT: prev_input -> current_input
         flow = self._compute_optical_flow_tensorrt(prev_resized, current_resized)
-        
+
         # Apply flow strength scaling (GPU operation)
-        flow_strength = self.params.get('flow_strength', 1.0)
+        flow_strength = self.params.get("flow_strength", 1.0)
         if flow_strength != 1.0:
             flow = flow * flow_strength
-        
+
         # Convert flow to RGB visualization using torchvision's flow_to_image
         # flow_to_image expects (2, H, W) and returns (3, H, W) in range [0, 255]
         flow_rgb = flow_to_image(flow)  # Returns uint8 tensor [0, 255]
-        
+
         # Convert to float [0, 1] range
         flow_rgb = flow_rgb.float() / 255.0
-        
+
         # Resize back to target resolution if needed (keep on GPU)
         if flow_rgb.shape[-1] != target_width or flow_rgb.shape[-2] != target_height:
             flow_rgb = F.interpolate(
-                flow_rgb.unsqueeze(0),
-                size=(target_height, target_width),
-                mode='bilinear',
-                align_corners=False
+                flow_rgb.unsqueeze(0), size=(target_height, target_width), mode="bilinear", align_corners=False
             ).squeeze(0)
-        
+
         # Convert to processor's dtype only at the very end
         result = flow_rgb.to(dtype=self.dtype)
-        
+
         return result
-    
+
     def _compute_optical_flow_tensorrt(self, frame1: torch.Tensor, frame2: torch.Tensor) -> torch.Tensor:
         """
         Compute optical flow between two frames using TensorRT-accelerated RAFT
-        
+
         Args:
             frame1: First frame tensor (CHW format, [0,1])
             frame2: Second frame tensor (CHW format, [0,1])
-            
+
         Returns:
             Optical flow tensor (2HW format)
         """
-        
+
         if self.trt_engine is None:
             raise RuntimeError("_compute_optical_flow_tensorrt: TensorRT engine not loaded")
-        
+
         # Prepare inputs for TensorRT
         frame1_batch = frame1.unsqueeze(0)
         frame2_batch = frame2.unsqueeze(0)
-        
+
         # Apply RAFT preprocessing if available
         weights = Raft_Small_Weights.DEFAULT
-        if hasattr(weights, 'transforms') and weights.transforms is not None:
+        if hasattr(weights, "transforms") and weights.transforms is not None:
             transforms = weights.transforms()
             frame1_batch, frame2_batch = transforms(frame1_batch, frame2_batch)
-        
+
         # Run TensorRT inference
-        feed_dict = {
-            'frame1': frame1_batch,
-            'frame2': frame2_batch
-        }
-        
+        feed_dict = {"frame1": frame1_batch, "frame2": frame2_batch}
+
         cuda_stream = torch.cuda.current_stream().cuda_stream
         result = self.trt_engine.infer(feed_dict, cuda_stream)
-        flow = result['flow'][0]  # Remove batch dimension
-        
-        return flow
-    
+        flow = result["flow"][0]  # Remove batch dimension
 
-    
+        return flow
+
     def _warp_frame_tensor(self, frame: torch.Tensor, flow: torch.Tensor) -> torch.Tensor:
         """
         Warp frame using optical flow with cached coordinate grids
-        
+
         Args:
             frame: Frame to warp (CHW format)
             flow: Optical flow (2HW format)
-            
+
         Returns:
             Warped frame tensor
         """
         H, W = frame.shape[-2:]
-        
+
         # Use cached grid if available
         grid_key = (H, W)
         if grid_key not in self._grid_cache:
             grid_y, grid_x = torch.meshgrid(
                 torch.arange(H, device=self.device, dtype=torch.float32),
                 torch.arange(W, device=self.device, dtype=torch.float32),
-                indexing='ij'
+                indexing="ij",
             )
             self._grid_cache[grid_key] = (grid_x, grid_y)
         else:
             grid_x, grid_y = self._grid_cache[grid_key]
-        
+
         # Apply flow to coordinates
         new_x = grid_x + flow[0]
         new_y = grid_y + flow[1]
-        
+
         # Normalize coordinates to [-1, 1] for grid_sample
         new_x = 2.0 * new_x / (W - 1) - 1.0
         new_y = 2.0 * new_y / (H - 1) - 1.0
-        
+
         # Create sampling grid (HW2 format for grid_sample)
         grid = torch.stack([new_x, new_y], dim=-1).unsqueeze(0)
-        
+
         # Warp frame
         warped_batch = F.grid_sample(
-            frame.unsqueeze(0), 
-            grid, 
-            mode='bilinear', 
-            padding_mode='border',
-            align_corners=True
+            frame.unsqueeze(0), grid, mode="bilinear", padding_mode="border", align_corners=True
         )
-        
+
         result = warped_batch.squeeze(0)
-        
+
         return result
-    
+
     def _concatenate_frames(self, current_image: Image.Image, warped_image: Image.Image) -> Image.Image:
         """Concatenate current frame and warped previous frame for TemporalNet2 (6-channel input)"""
         # Convert to tensors and use tensor concatenation for consistency
@@ -577,43 +568,43 @@ class TemporalNetTensorRTPreprocessor(PipelineAwareProcessor):
         warped_tensor = self.pil_to_tensor(warped_image).squeeze(0)
         result_tensor = self._concatenate_frames_tensor(current_tensor, warped_tensor)
         return self.tensor_to_pil(result_tensor)
-    
+
     def _concatenate_frames_tensor(self, current_tensor: torch.Tensor, warped_tensor: torch.Tensor) -> torch.Tensor:
         """
         Concatenate current frame and warped previous frame tensors for TemporalNet2 (6-channel input)
-        
+
         Args:
             current_tensor: Current input frame tensor (CHW format)
             warped_tensor: Warped previous frame tensor (CHW format)
-            
+
         Returns:
             Concatenated tensor (6CHW format)
         """
         # Ensure same size
         if current_tensor.shape != warped_tensor.shape:
             target_width, target_height = self.get_target_dimensions()
-            
+
             if current_tensor.shape[-2:] != (target_height, target_width):
                 current_tensor = F.interpolate(
                     current_tensor.unsqueeze(0),
                     size=(target_height, target_width),
-                    mode='bilinear',
-                    align_corners=False
+                    mode="bilinear",
+                    align_corners=False,
                 ).squeeze(0)
-            
+
             if warped_tensor.shape[-2:] != (target_height, target_width):
                 warped_tensor = F.interpolate(
                     warped_tensor.unsqueeze(0),
                     size=(target_height, target_width),
-                    mode='bilinear',
-                    align_corners=False
+                    mode="bilinear",
+                    align_corners=False,
                 ).squeeze(0)
-        
+
         # Concatenate along channel dimension: [current_R, current_G, current_B, warped_R, warped_G, warped_B]
         concatenated = torch.cat([current_tensor, warped_tensor], dim=0)
-        
+
         return concatenated
-    
+
     def reset(self):
         """
         Reset the preprocessor state (useful for new sequences)

--- a/src/streamdiffusion/preprocessing/processors/upscale.py
+++ b/src/streamdiffusion/preprocessing/processors/upscale.py
@@ -1,7 +1,9 @@
+from typing import Literal
+
 import torch
 import torch.nn.functional as F
 from PIL import Image
-from typing import Literal
+
 from .base import BasePreprocessor
 
 
@@ -10,8 +12,8 @@ class UpscalePreprocessor(BasePreprocessor):
     Image upscaling preprocessor with multiple interpolation algorithms.
     Supports bilinear, lanczos, bicubic, and nearest neighbor upscaling.
     """
-    
-    @classmethod 
+
+    @classmethod
     def get_preprocessor_metadata(cls):
         return {
             "display_name": "Upscale",
@@ -21,71 +23,71 @@ class UpscalePreprocessor(BasePreprocessor):
                     "type": "float",
                     "default": 2.0,
                     "range": [1.0, 4.0],
-                    "description": "Upscaling factor"
+                    "description": "Upscaling factor",
                 },
                 "algorithm": {
                     "type": "str",
                     "default": "bilinear",
                     "options": ["bilinear", "lanczos", "bicubic", "nearest"],
-                    "description": "Interpolation algorithm: bilinear (fast), lanczos (high quality), bicubic (balanced), nearest (pixel art)"
-                }
+                    "description": "Interpolation algorithm: bilinear (fast), lanczos (high quality), bicubic (balanced), nearest (pixel art)",
+                },
             },
-            "use_cases": ["Real-time upscaling", "Image enhancement", "Resolution conversion"]
+            "use_cases": ["Real-time upscaling", "Image enhancement", "Resolution conversion"],
         }
-    
-    def __init__(self, scale_factor: float = 2.0, algorithm: Literal["bilinear", "lanczos", "bicubic", "nearest"] = "bilinear", **kwargs):
+
+    def __init__(
+        self,
+        scale_factor: float = 2.0,
+        algorithm: Literal["bilinear", "lanczos", "bicubic", "nearest"] = "bilinear",
+        **kwargs,
+    ):
         super().__init__(scale_factor=scale_factor, algorithm=algorithm, **kwargs)
         self.scale_factor = scale_factor
         self.algorithm = algorithm
-        
+
         # Map algorithm names to PIL and PyTorch modes
         self.pil_resample_map = {
             "bilinear": Image.BILINEAR,
             "lanczos": Image.LANCZOS,
             "bicubic": Image.BICUBIC,
-            "nearest": Image.NEAREST
+            "nearest": Image.NEAREST,
         }
-        
+
         self.torch_mode_map = {
             "bilinear": "bilinear",
             "lanczos": "bicubic",  # PyTorch doesn't have lanczos, use bicubic as closest
             "bicubic": "bicubic",
-            "nearest": "nearest"
+            "nearest": "nearest",
         }
-    
+
     def _process_core(self, image: Image.Image) -> Image.Image:
         """PIL-based upscaling"""
         target_width, target_height = self.get_target_dimensions()
         resample_method = self.pil_resample_map.get(self.algorithm, Image.BILINEAR)
         return image.resize((target_width, target_height), resample_method)
-    
+
     def _process_tensor_core(self, tensor: torch.Tensor) -> torch.Tensor:
         """Tensor-based upscaling"""
         target_width, target_height = self.get_target_dimensions()
-        
+
         if tensor.dim() == 3:
             tensor = tensor.unsqueeze(0)
-        
+
         mode = self.torch_mode_map.get(self.algorithm, "bilinear")
-        
+
         if mode in ["bilinear", "bicubic"]:
-            return F.interpolate(tensor, size=(target_height, target_width), 
-                               mode=mode, align_corners=False)
+            return F.interpolate(tensor, size=(target_height, target_width), mode=mode, align_corners=False)
         else:  # nearest
-            return F.interpolate(tensor, size=(target_height, target_width), 
-                               mode=mode)
-    
+            return F.interpolate(tensor, size=(target_height, target_width), mode=mode)
+
     def get_target_dimensions(self):
         """Handle scale factor for dimensions"""
-        width = self.params.get('image_width')
-        height = self.params.get('image_height')
-        
+        width = self.params.get("image_width")
+        height = self.params.get("image_height")
+
         if width is not None and height is not None:
             return (int(width * self.scale_factor), int(height * self.scale_factor))
-        
-        base_resolution = self.params.get('image_resolution', 512)
+
+        base_resolution = self.params.get("image_resolution", 512)
         target_resolution = int(base_resolution * self.scale_factor)
         return (target_resolution, target_resolution)
-
-
-

--- a/src/streamdiffusion/stream_parameter_updater.py
+++ b/src/streamdiffusion/stream_parameter_updater.py
@@ -367,29 +367,25 @@ class StreamParameterUpdater(OrchestratorUser):
 
                 if cache_maxframes is not None:
                     old_cache_maxframes = self.stream.cache_maxframes
-                    self.stream.cache_maxframes = cache_maxframes
                     if old_cache_maxframes != cache_maxframes:
-                        for i, cache_tensor in enumerate(self.stream.kvo_cache):
-                            current_shape = cache_tensor.shape
-                            new_shape = (
-                                current_shape[0],
-                                cache_maxframes,
-                                current_shape[2],
-                                current_shape[3],
-                                current_shape[4],
+                        # KVO cache tensors are allocated at max_cache_maxframes and never resized at
+                        # runtime — resizing one-at-a-time races with TRT inference (causes "Dimensions
+                        # with name C must be equal" errors). cache_maxframes is a logical write window.
+                        actual_cache_size = (
+                            self.stream.kvo_cache[0].shape[1]
+                            if self.stream.kvo_cache
+                            else cache_maxframes
+                        )
+                        if cache_maxframes > actual_cache_size:
+                            logger.warning(
+                                f"update_stream_params: Requested cache_maxframes={cache_maxframes} "
+                                f"exceeds allocated buffer size={actual_cache_size}. Clamping."
                             )
-                            new_cache_tensor = torch.zeros(
-                                new_shape, dtype=cache_tensor.dtype, device=cache_tensor.device
-                            )
-
-                            if cache_maxframes > old_cache_maxframes:
-                                new_cache_tensor[:, :old_cache_maxframes] = cache_tensor
-                            else:
-                                new_cache_tensor[:, :] = cache_tensor[:, -cache_maxframes:]
-
-                            self.stream.kvo_cache[i] = new_cache_tensor
+                            cache_maxframes = actual_cache_size
+                        self.stream.cache_maxframes = cache_maxframes
                         logger.info(
-                            f"update_stream_params: Cache maxframes updated from {old_cache_maxframes} to {cache_maxframes}, kvo_cache tensors resized"
+                            f"update_stream_params: Cache maxframes {old_cache_maxframes} -> "
+                            f"{cache_maxframes} (buffer size: {actual_cache_size}, no tensor resize)"
                         )
                     else:
                         logger.info(f"update_stream_params: Cache maxframes set to {cache_maxframes}")
@@ -729,6 +725,12 @@ class StreamParameterUpdater(OrchestratorUser):
 
         # Reset stock_noise to match the new init_noise
         self.stream.stock_noise = torch.zeros_like(self.stream.init_noise)
+
+        # Keep pre-computed rotation in sync with new init_noise
+        if self.stream._init_noise_rotated is not None:
+            self.stream._init_noise_rotated = torch.cat(
+                [self.stream.init_noise[1:], self.stream.init_noise[0:1]], dim=0
+            )
 
     def _get_scheduler_scalings(self, timestep):
         """Get LCM/TCD-specific scaling factors for boundary conditions."""

--- a/src/streamdiffusion/stream_parameter_updater.py
+++ b/src/streamdiffusion/stream_parameter_updater.py
@@ -1,15 +1,18 @@
-from typing import List, Optional, Dict, Tuple, Literal, Any, Callable
+import logging
 import threading
+from typing import Any, Dict, List, Literal, Optional, Tuple
+
 import torch
 import torch.nn.functional as F
-import gc
 
-import logging
+
 logger = logging.getLogger(__name__)
 from .preprocessing.orchestrator_user import OrchestratorUser
 
+
 class CacheStats:
     """Helper class to track cache statistics"""
+
     def __init__(self):
         self.hits = 0
         self.misses = 0
@@ -22,7 +25,13 @@ class CacheStats:
 
 
 class StreamParameterUpdater(OrchestratorUser):
-    def __init__(self, stream_diffusion, wrapper=None, normalize_prompt_weights: bool = True, normalize_seed_weights: bool = True):
+    def __init__(
+        self,
+        stream_diffusion,
+        wrapper=None,
+        normalize_prompt_weights: bool = True,
+        normalize_seed_weights: bool = True,
+    ):
         self.stream = stream_diffusion
         self.wrapper = wrapper  # Reference to wrapper for accessing pipeline structure
         self.normalize_prompt_weights = normalize_prompt_weights
@@ -39,8 +48,7 @@ class StreamParameterUpdater(OrchestratorUser):
         self._seed_cache: Dict[int, Dict] = {}
         self._current_seed_list: List[Tuple[int, float]] = []
         self._seed_cache_stats = CacheStats()
-        
-        
+
         # Attach shared orchestrator once (lazy-creates on stream if absent)
         self.attach_orchestrator(self.stream)
 
@@ -50,6 +58,7 @@ class StreamParameterUpdater(OrchestratorUser):
         self._current_style_images: Dict[str, Any] = {}
         # Use the shared orchestrator attached via OrchestratorUser
         self._embedding_orchestrator = self._preprocessing_orchestrator
+
     def get_cache_info(self) -> Dict:
         """Get cache statistics for monitoring performance."""
         total_requests = self._prompt_cache_stats.hits + self._prompt_cache_stats.misses
@@ -68,7 +77,7 @@ class StreamParameterUpdater(OrchestratorUser):
             "seed_cache_hits": self._seed_cache_stats.hits,
             "seed_cache_misses": self._seed_cache_stats.misses,
             "seed_hit_rate": f"{seed_hit_rate:.2%}",
-            "current_seeds": len(self._current_seed_list)
+            "current_seeds": len(self._current_seed_list),
         }
 
     def clear_caches(self) -> None:
@@ -81,7 +90,7 @@ class StreamParameterUpdater(OrchestratorUser):
         self._seed_cache.clear()
         self._current_seed_list.clear()
         self._seed_cache_stats = CacheStats()
-        
+
         # Clear embedding caches
         self._embedding_cache.clear()
         self._current_style_images.clear()
@@ -93,13 +102,13 @@ class StreamParameterUpdater(OrchestratorUser):
     def get_normalize_seed_weights(self) -> bool:
         """Get the current seed weight normalization setting."""
         return self.normalize_seed_weights
-    
+
     # Deprecated enhancer registration removed; embedding composition is handled via stream.embedding_hooks
 
     def register_embedding_preprocessor(self, preprocessor: Any, style_image_key: str) -> None:
         """
         Register an embedding preprocessor for parallel processing.
-        
+
         Args:
             preprocessor: IPAdapterEmbeddingPreprocessor instance
             style_image_key: Unique key for the style image this preprocessor handles
@@ -108,28 +117,27 @@ class StreamParameterUpdater(OrchestratorUser):
             # Ensure orchestrator is present
             self.attach_orchestrator(self.stream)
             self._embedding_orchestrator = self._preprocessing_orchestrator
-        
+
         self._embedding_preprocessors.append((preprocessor, style_image_key))
-    
+
     def unregister_embedding_preprocessor(self, style_image_key: str) -> None:
         """Unregister an embedding preprocessor by style image key."""
         original_count = len(self._embedding_preprocessors)
         self._embedding_preprocessors = [
-            (preprocessor, key) for preprocessor, key in self._embedding_preprocessors 
-            if key != style_image_key
+            (preprocessor, key) for preprocessor, key in self._embedding_preprocessors if key != style_image_key
         ]
         removed_count = original_count - len(self._embedding_preprocessors)
-        
+
         # Clear cached embeddings for this key
         if style_image_key in self._embedding_cache:
             del self._embedding_cache[style_image_key]
         if style_image_key in self._current_style_images:
             del self._current_style_images[style_image_key]
-    
+
     def update_style_image(self, style_image_key: str, style_image: Any, is_stream: bool = False) -> None:
         """
         Update a style image and trigger embedding preprocessing.
-        
+
         Args:
             style_image_key: Unique key for the style image
             style_image: The style image (PIL Image, path, etc.)
@@ -138,14 +146,16 @@ class StreamParameterUpdater(OrchestratorUser):
         """
         # Store the style image
         self._current_style_images[style_image_key] = style_image
-        
+
         # Trigger preprocessing for this style image
         self._preprocess_style_image_parallel(style_image_key, style_image, is_stream)
-    
-    def _preprocess_style_image_parallel(self, style_image_key: str, style_image: Any, is_stream: bool = False) -> None:
+
+    def _preprocess_style_image_parallel(
+        self, style_image_key: str, style_image: Any, is_stream: bool = False
+    ) -> None:
         """
         Preprocessing for a specific style image with mode selection
-        
+
         Args:
             style_image_key: Unique key for the style image
             style_image: The style image to process
@@ -153,56 +163,46 @@ class StreamParameterUpdater(OrchestratorUser):
         """
         if not self._embedding_preprocessors or self._embedding_orchestrator is None:
             return
-        
+
         # Find preprocessors for this key
         relevant_preprocessors = [
-            preprocessor for preprocessor, key in self._embedding_preprocessors 
-            if key == style_image_key
+            preprocessor for preprocessor, key in self._embedding_preprocessors if key == style_image_key
         ]
-        
+
         if not relevant_preprocessors:
             return
-        
+
         # Choose processing mode based on is_stream parameter
         try:
             if is_stream:
                 # Pipelined processing - optimized for throughput with 1-frame lag
                 embedding_results = self._embedding_orchestrator.process_pipelined(
-                    style_image,
-                    relevant_preprocessors,
-                    None,
-                    self.stream.width,
-                    self.stream.height,
-                    "ipadapter"
+                    style_image, relevant_preprocessors, None, self.stream.width, self.stream.height, "ipadapter"
                 )
             else:
                 # Synchronous processing - immediate results for discrete updates
                 embedding_results = self._embedding_orchestrator.process_sync(
-                    style_image,
-                    relevant_preprocessors,
-                    None,
-                    self.stream.width,
-                    self.stream.height,
-                    None,
-                    "ipadapter"
+                    style_image, relevant_preprocessors, None, self.stream.width, self.stream.height, None, "ipadapter"
                 )
-            
+
             # Cache results for this style image key
             if embedding_results and embedding_results[0] is not None:
                 self._embedding_cache[style_image_key] = embedding_results[0]
             else:
                 # This is an error condition - we should always have results
-                raise RuntimeError(f"_preprocess_style_image_parallel: Failed to generate embeddings for style image '{style_image_key}'")
-                
-        except Exception as e:
+                raise RuntimeError(
+                    f"_preprocess_style_image_parallel: Failed to generate embeddings for style image '{style_image_key}'"
+                )
+
+        except Exception:
             import traceback
+
             traceback.print_exc()
-    
+
     def get_cached_embeddings(self, style_image_key: str) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
         """Get cached embeddings for a style image key"""
         cached_result = self._embedding_cache.get(style_image_key, None)
         return cached_result
-
 
     def _normalize_weights(self, weights: List[float], normalize: bool) -> torch.Tensor:
         """Generic weight normalization helper"""
@@ -218,7 +218,7 @@ class StreamParameterUpdater(OrchestratorUser):
             return False
 
         if index < 0 or index >= len(item_list):
-            logger.warning(f"{operation_name}: Warning: Index {index} out of range (0-{len(item_list)-1})")
+            logger.warning(f"{operation_name}: Warning: Index {index} out of range (0-{len(item_list) - 1})")
             return False
 
         return True
@@ -281,28 +281,27 @@ class StreamParameterUpdater(OrchestratorUser):
                             f"provided t_index_list (max index: {max_t_index}). Adjusting to {max_t_index + 1}."
                         )
                         num_inference_steps = max_t_index + 1
-                
+
                 old_num_steps = len(self.stream.timesteps)
                 self.stream.scheduler.set_timesteps(num_inference_steps, self.stream.device)
                 self.stream.timesteps = self.stream.scheduler.timesteps.to(self.stream.device)
-                
+
                 # If t_index_list wasn't explicitly provided, rescale existing t_list proportionally
                 if t_index_list is None and old_num_steps > 0:
                     # Rescale each index proportionally to the new number of steps
                     # e.g., if t_list = [0, 16, 32, 45] with 50 steps -> [0, 3, 6, 8] with 9 steps
                     scale_factor = (num_inference_steps - 1) / (old_num_steps - 1) if old_num_steps > 1 else 1.0
-                    t_index_list = [
-                        min(round(t * scale_factor), num_inference_steps - 1) 
-                        for t in self.stream.t_list
-                    ]
-            
+                    t_index_list = [min(round(t * scale_factor), num_inference_steps - 1) for t in self.stream.t_list]
+
             # Now update timestep-dependent parameters with the correct t_index_list
             if t_index_list is not None:
                 self._recalculate_timestep_dependent_params(t_index_list)
 
             if guidance_scale is not None:
                 if self.stream.cfg_type == "none" and guidance_scale > 1.0:
-                    logger.warning("update_stream_params: Warning: guidance_scale > 1.0 with cfg_type='none' will have no effect")
+                    logger.warning(
+                        "update_stream_params: Warning: guidance_scale > 1.0 with cfg_type='none' will have no effect"
+                    )
                 self.stream.guidance_scale = guidance_scale
 
             if delta is not None:
@@ -310,7 +309,7 @@ class StreamParameterUpdater(OrchestratorUser):
 
             if seed is not None:
                 self._update_seed(seed)
-            
+
             if normalize_prompt_weights is not None:
                 self.normalize_prompt_weights = normalize_prompt_weights
                 logger.info(f"update_stream_params: Prompt weight normalization set to {normalize_prompt_weights}")
@@ -324,44 +323,42 @@ class StreamParameterUpdater(OrchestratorUser):
                 self._update_blended_prompts(
                     prompt_list=prompt_list,
                     negative_prompt=negative_prompt or self._current_negative_prompt,
-                    prompt_interpolation_method=prompt_interpolation_method
+                    prompt_interpolation_method=prompt_interpolation_method,
                 )
 
             # Handle seed blending if seed_list is provided
             if seed_list is not None:
-                self._update_blended_seeds(
-                    seed_list=seed_list,
-                    interpolation_method=seed_interpolation_method
-                )
-
+                self._update_blended_seeds(seed_list=seed_list, interpolation_method=seed_interpolation_method)
 
             # Handle ControlNet configuration updates
             if controlnet_config is not None:
-                #TODO: happy path for control images
+                # TODO: happy path for control images
                 self._update_controlnet_config(controlnet_config)
-            
+
             # Handle IPAdapter configuration updates
             if ipadapter_config is not None:
-                logger.info(f"update_stream_params: Updating IPAdapter configuration")
+                logger.info("update_stream_params: Updating IPAdapter configuration")
                 self._update_ipadapter_config(ipadapter_config)
-            
+
             # Handle Hook configuration updates
             if image_preprocessing_config is not None:
-                logger.info(f"update_stream_params: Updating image preprocessing configuration with {len(image_preprocessing_config)} processors")
+                logger.info(
+                    f"update_stream_params: Updating image preprocessing configuration with {len(image_preprocessing_config)} processors"
+                )
                 logger.info(f"update_stream_params: image_preprocessing_config = {image_preprocessing_config}")
-                self._update_hook_config('image_preprocessing', image_preprocessing_config)
-            
+                self._update_hook_config("image_preprocessing", image_preprocessing_config)
+
             if image_postprocessing_config is not None:
-                logger.info(f"update_stream_params: Updating image postprocessing configuration")
-                self._update_hook_config('image_postprocessing', image_postprocessing_config)
-            
+                logger.info("update_stream_params: Updating image postprocessing configuration")
+                self._update_hook_config("image_postprocessing", image_postprocessing_config)
+
             if latent_preprocessing_config is not None:
-                logger.info(f"update_stream_params: Updating latent preprocessing configuration")
-                self._update_hook_config('latent_preprocessing', latent_preprocessing_config)
-            
+                logger.info("update_stream_params: Updating latent preprocessing configuration")
+                self._update_hook_config("latent_preprocessing", latent_preprocessing_config)
+
             if latent_postprocessing_config is not None:
-                logger.info(f"update_stream_params: Updating latent postprocessing configuration")
-                self._update_hook_config('latent_postprocessing', latent_postprocessing_config)
+                logger.info("update_stream_params: Updating latent postprocessing configuration")
+                self._update_hook_config("latent_postprocessing", latent_postprocessing_config)
 
             if self.stream.kvo_cache:
                 if cache_interval is not None:
@@ -374,28 +371,32 @@ class StreamParameterUpdater(OrchestratorUser):
                     if old_cache_maxframes != cache_maxframes:
                         for i, cache_tensor in enumerate(self.stream.kvo_cache):
                             current_shape = cache_tensor.shape
-                            new_shape = (current_shape[0], cache_maxframes, current_shape[2], current_shape[3], current_shape[4])
-                            new_cache_tensor = torch.zeros(
-                                new_shape,
-                                dtype=cache_tensor.dtype,
-                                device=cache_tensor.device
+                            new_shape = (
+                                current_shape[0],
+                                cache_maxframes,
+                                current_shape[2],
+                                current_shape[3],
+                                current_shape[4],
                             )
-                    
+                            new_cache_tensor = torch.zeros(
+                                new_shape, dtype=cache_tensor.dtype, device=cache_tensor.device
+                            )
+
                             if cache_maxframes > old_cache_maxframes:
                                 new_cache_tensor[:, :old_cache_maxframes] = cache_tensor
                             else:
                                 new_cache_tensor[:, :] = cache_tensor[:, -cache_maxframes:]
-                            
+
                             self.stream.kvo_cache[i] = new_cache_tensor
-                        logger.info(f"update_stream_params: Cache maxframes updated from {old_cache_maxframes} to {cache_maxframes}, kvo_cache tensors resized")
+                        logger.info(
+                            f"update_stream_params: Cache maxframes updated from {old_cache_maxframes} to {cache_maxframes}, kvo_cache tensors resized"
+                        )
                     else:
                         logger.info(f"update_stream_params: Cache maxframes set to {cache_maxframes}")
 
     @torch.inference_mode()
     def update_prompt_weights(
-        self,
-        prompt_weights: List[float],
-        prompt_interpolation_method: Literal["linear", "slerp"] = "slerp"
+        self, prompt_weights: List[float], prompt_interpolation_method: Literal["linear", "slerp"] = "slerp"
     ) -> None:
         """Update weights for current prompt list without re-encoding prompts."""
         if not self._current_prompt_list:
@@ -403,7 +404,9 @@ class StreamParameterUpdater(OrchestratorUser):
             return
 
         if len(prompt_weights) != len(self._current_prompt_list):
-            logger.warning(f"update_prompt_weights: Warning: Weight count {len(prompt_weights)} doesn't match prompt count {len(self._current_prompt_list)}")
+            logger.warning(
+                f"update_prompt_weights: Warning: Weight count {len(prompt_weights)} doesn't match prompt count {len(self._current_prompt_list)}"
+            )
             return
 
         # Update the current prompt list with new weights
@@ -418,9 +421,7 @@ class StreamParameterUpdater(OrchestratorUser):
 
     @torch.inference_mode()
     def update_seed_weights(
-        self,
-        seed_weights: List[float],
-        interpolation_method: Literal["linear", "slerp"] = "linear"
+        self, seed_weights: List[float], interpolation_method: Literal["linear", "slerp"] = "linear"
     ) -> None:
         """Update weights for current seed list without regenerating noise."""
         if not self._current_seed_list:
@@ -428,7 +429,9 @@ class StreamParameterUpdater(OrchestratorUser):
             return
 
         if len(seed_weights) != len(self._current_seed_list):
-            logger.warning(f"update_seed_weights: Warning: Weight count {len(seed_weights)} doesn't match seed count {len(self._current_seed_list)}")
+            logger.warning(
+                f"update_seed_weights: Warning: Weight count {len(seed_weights)} doesn't match seed count {len(self._current_seed_list)}"
+            )
             return
 
         # Update the current seed list with new weights
@@ -446,7 +449,7 @@ class StreamParameterUpdater(OrchestratorUser):
         self,
         prompt_list: List[Tuple[str, float]],
         negative_prompt: str = "",
-        prompt_interpolation_method: Literal["linear", "slerp"] = "slerp"
+        prompt_interpolation_method: Literal["linear", "slerp"] = "slerp",
     ) -> None:
         """Update prompt embeddings using multiple weighted prompts."""
         # Store current state
@@ -459,14 +462,10 @@ class StreamParameterUpdater(OrchestratorUser):
         # Apply blending
         self._apply_prompt_blending(prompt_interpolation_method)
 
-    def _cache_prompt_embeddings(
-        self,
-        prompt_list: List[Tuple[str, float]],
-        negative_prompt: str
-    ) -> None:
+    def _cache_prompt_embeddings(self, prompt_list: List[Tuple[str, float]], negative_prompt: str) -> None:
         """Cache prompt embeddings for efficient reuse."""
         for idx, (prompt_text, weight) in enumerate(prompt_list):
-            if idx not in self._prompt_cache or self._prompt_cache[idx]['text'] != prompt_text:
+            if idx not in self._prompt_cache or self._prompt_cache[idx]["text"] != prompt_text:
                 # Cache miss - encode the prompt
                 self._prompt_cache_stats.record_miss()
                 encoder_output = self.stream.pipe.encode_prompt(
@@ -480,10 +479,7 @@ class StreamParameterUpdater(OrchestratorUser):
                 if len(self._prompt_cache) >= 32:
                     oldest_key = next(iter(self._prompt_cache))
                     del self._prompt_cache[oldest_key]
-                self._prompt_cache[idx] = {
-                    'embed': encoder_output[0],
-                    'text': prompt_text
-                }
+                self._prompt_cache[idx] = {"embed": encoder_output[0], "text": prompt_text}
             else:
                 # Cache hit
                 self._prompt_cache_stats.record_hit()
@@ -498,7 +494,7 @@ class StreamParameterUpdater(OrchestratorUser):
 
         for idx, (prompt_text, weight) in enumerate(self._current_prompt_list):
             if idx in self._prompt_cache:
-                embeddings.append(self._prompt_cache[idx]['embed'])
+                embeddings.append(self._prompt_cache[idx]["embed"])
                 weights.append(weight)
 
         if not embeddings:
@@ -543,13 +539,14 @@ class StreamParameterUpdater(OrchestratorUser):
             # No CFG, just use the blended embeddings
             final_prompt_embeds = combined_embeds.repeat(self.stream.batch_size, 1, 1)
             final_negative_embeds = None  # Will be set by enhancers if needed
-        
+
         # Enhancer mechanism removed in favor of embedding_hooks
 
         # Run embedding hooks to compose final embeddings (e.g., append IP-Adapter tokens)
         try:
-            if hasattr(self.stream, 'embedding_hooks') and self.stream.embedding_hooks:
+            if hasattr(self.stream, "embedding_hooks") and self.stream.embedding_hooks:
                 from .hooks import EmbedsCtx  # local import to avoid cycles
+
                 embeds_ctx = EmbedsCtx(
                     prompt_embeds=final_prompt_embeds,
                     negative_prompt_embeds=final_negative_embeds,
@@ -560,8 +557,9 @@ class StreamParameterUpdater(OrchestratorUser):
                 final_negative_embeds = embeds_ctx.negative_prompt_embeds
         except Exception as e:
             import logging
+
             logging.getLogger(__name__).error(f"_apply_prompt_blending: embedding hook failed: {e}")
-        
+
         # Set final embeddings on stream
         self.stream.prompt_embeds = final_prompt_embeds
         if final_negative_embeds is not None:
@@ -602,9 +600,7 @@ class StreamParameterUpdater(OrchestratorUser):
 
     @torch.inference_mode()
     def _update_blended_seeds(
-        self,
-        seed_list: List[Tuple[int, float]],
-        interpolation_method: Literal["linear", "slerp"] = "linear"
+        self, seed_list: List[Tuple[int, float]], interpolation_method: Literal["linear", "slerp"] = "linear"
     ) -> None:
         """Update seed tensors using multiple weighted seeds."""
         # Store current state
@@ -619,7 +615,7 @@ class StreamParameterUpdater(OrchestratorUser):
     def _cache_seed_noise(self, seed_list: List[Tuple[int, float]]) -> None:
         """Cache seed noise tensors for efficient reuse."""
         for idx, (seed_value, weight) in enumerate(seed_list):
-            if idx not in self._seed_cache or self._seed_cache[idx]['seed'] != seed_value:
+            if idx not in self._seed_cache or self._seed_cache[idx]["seed"] != seed_value:
                 # Cache miss - generate noise for the seed
                 self._seed_cache_stats.record_miss()
                 generator = torch.Generator(device=self.stream.device)
@@ -629,13 +625,10 @@ class StreamParameterUpdater(OrchestratorUser):
                     (self.stream.batch_size, 4, self.stream.latent_height, self.stream.latent_width),
                     generator=generator,
                     device=self.stream.device,
-                    dtype=self.stream.dtype
+                    dtype=self.stream.dtype,
                 )
 
-                self._seed_cache[idx] = {
-                    'noise': noise,
-                    'seed': seed_value
-                }
+                self._seed_cache[idx] = {"noise": noise, "seed": seed_value}
             else:
                 # Cache hit
                 self._seed_cache_stats.record_hit()
@@ -650,7 +643,7 @@ class StreamParameterUpdater(OrchestratorUser):
 
         for idx, (seed_value, weight) in enumerate(self._current_seed_list):
             if idx in self._seed_cache:
-                noise_tensors.append(self._seed_cache[idx]['noise'])
+                noise_tensors.append(self._seed_cache[idx]["noise"])
                 weights.append(weight)
 
         if not noise_tensors:
@@ -671,7 +664,7 @@ class StreamParameterUpdater(OrchestratorUser):
             combined_noise = torch.zeros_like(noise_tensors[0])
             for noise, weight in zip(noise_tensors, weights):
                 combined_noise += weight * noise
-            
+
             # Preserve noise magnitude when weights are normalized
             if self.normalize_seed_weights and len(noise_tensors) > 1:
                 original_magnitude = torch.mean(torch.stack([torch.norm(noise) for noise in noise_tensors]))
@@ -740,6 +733,7 @@ class StreamParameterUpdater(OrchestratorUser):
     def _get_scheduler_scalings(self, timestep):
         """Get LCM/TCD-specific scaling factors for boundary conditions."""
         from diffusers import LCMScheduler
+
         if isinstance(self.stream.scheduler, LCMScheduler):
             c_skip, c_out = self.stream.scheduler.get_scalings_for_boundary_condition_discrete(timestep)
             return c_skip, c_out
@@ -757,9 +751,7 @@ class StreamParameterUpdater(OrchestratorUser):
         for t in self.stream.t_list:
             self.stream.sub_timesteps.append(self.stream.timesteps[t])
 
-        sub_timesteps_tensor = torch.tensor(
-            self.stream.sub_timesteps, dtype=torch.long, device=self.stream.device
-        )
+        sub_timesteps_tensor = torch.tensor(self.stream.sub_timesteps, dtype=torch.long, device=self.stream.device)
         self.stream.sub_timesteps_tensor = torch.repeat_interleave(
             sub_timesteps_tensor,
             repeats=self.stream.frame_bff_size if self.stream.use_denoising_batch else 1,
@@ -785,12 +777,8 @@ class StreamParameterUpdater(OrchestratorUser):
         )
 
         if self.stream.use_denoising_batch:
-            self.stream.c_skip = torch.repeat_interleave(
-                self.stream.c_skip, repeats=self.stream.frame_bff_size, dim=0
-            )
-            self.stream.c_out = torch.repeat_interleave(
-                self.stream.c_out, repeats=self.stream.frame_bff_size, dim=0
-            )
+            self.stream.c_skip = torch.repeat_interleave(self.stream.c_skip, repeats=self.stream.frame_bff_size, dim=0)
+            self.stream.c_out = torch.repeat_interleave(self.stream.c_out, repeats=self.stream.frame_bff_size, dim=0)
 
         # Update alpha_prod_t_sqrt and beta_prod_t_sqrt
         alpha_prod_t_sqrt_list = []
@@ -830,29 +818,25 @@ class StreamParameterUpdater(OrchestratorUser):
 
     def _recalculate_timestep_dependent_params(self, t_index_list: List[int]) -> None:
         """Recalculate all parameters that depend on t_index_list."""
-        
+
         # Check if this is a structural change (length) or just value change
         if len(t_index_list) == len(self.stream.t_list):
             # Same length - only values changed, use lightweight update (working branch behavior)
             self._update_timestep_values_only(t_index_list)
             return
-        
+
         # Length changed - do full recalculation including batch-dependent parameters (broken branch logic - but it works for this case!)
         self.stream.t_list = t_index_list
         self.stream.denoising_steps_num = len(self.stream.t_list)
 
         old_batch_size = self.stream.batch_size
-        
+
         if self.stream.use_denoising_batch:
             self.stream.batch_size = self.stream.denoising_steps_num * self.stream.frame_bff_size
             if self.stream.cfg_type == "initialize":
-                self.stream.trt_unet_batch_size = (
-                    self.stream.denoising_steps_num + 1
-                ) * self.stream.frame_bff_size
+                self.stream.trt_unet_batch_size = (self.stream.denoising_steps_num + 1) * self.stream.frame_bff_size
             elif self.stream.cfg_type == "full":
-                self.stream.trt_unet_batch_size = (
-                    2 * self.stream.denoising_steps_num * self.stream.frame_bff_size
-                )
+                self.stream.trt_unet_batch_size = 2 * self.stream.denoising_steps_num * self.stream.frame_bff_size
             else:
                 self.stream.trt_unet_batch_size = self.stream.denoising_steps_num * self.stream.frame_bff_size
         else:
@@ -883,23 +867,29 @@ class StreamParameterUpdater(OrchestratorUser):
 
         # Resize kvo_cache tensors if batch size changed
         if self.stream.kvo_cache and old_batch_size != self.stream.batch_size:
-            logger.info(f"_recalculate_timestep_dependent_params: Resizing kvo_cache tensors from batch_size {old_batch_size} to {self.stream.batch_size}")
+            logger.info(
+                f"_recalculate_timestep_dependent_params: Resizing kvo_cache tensors from batch_size {old_batch_size} to {self.stream.batch_size}"
+            )
             for i, cache_tensor in enumerate(self.stream.kvo_cache):
                 # KVO cache shape: (2, cache_maxframes, batch_size, seq_length, hidden_dim)
                 current_shape = cache_tensor.shape
-                new_shape = (current_shape[0], current_shape[1], self.stream.batch_size, current_shape[3], current_shape[4])
-                new_cache_tensor = torch.zeros(
-                    new_shape,
-                    dtype=cache_tensor.dtype,
-                    device=cache_tensor.device
+                new_shape = (
+                    current_shape[0],
+                    current_shape[1],
+                    self.stream.batch_size,
+                    current_shape[3],
+                    current_shape[4],
                 )
-                
+                new_cache_tensor = torch.zeros(new_shape, dtype=cache_tensor.dtype, device=cache_tensor.device)
+
                 # Copy over as much data as possible from old cache
                 min_batch = min(old_batch_size, self.stream.batch_size)
                 new_cache_tensor[:, :, :min_batch, :, :] = cache_tensor[:, :, :min_batch, :, :]
-                
+
                 self.stream.kvo_cache[i] = new_cache_tensor
-            logger.info(f"_recalculate_timestep_dependent_params: KVO cache tensors resized to new batch_size {self.stream.batch_size}")
+            logger.info(
+                f"_recalculate_timestep_dependent_params: KVO cache tensors resized to new batch_size {self.stream.batch_size}"
+            )
 
         # Update timestep-dependent calculations (shared with value-only path)
         self._update_timestep_calculations()
@@ -918,10 +908,7 @@ class StreamParameterUpdater(OrchestratorUser):
 
     @torch.inference_mode()
     def update_prompt_at_index(
-        self,
-        index: int,
-        new_prompt: str,
-        prompt_interpolation_method: Literal["linear", "slerp"] = "slerp"
+        self, index: int, new_prompt: str, prompt_interpolation_method: Literal["linear", "slerp"] = "slerp"
     ) -> None:
         """Update a single prompt at the specified index without re-encoding others."""
         if not self._validate_index(index, self._current_prompt_list, "update_prompt_at_index"):
@@ -935,11 +922,11 @@ class StreamParameterUpdater(OrchestratorUser):
         self._cache_prompt_embeddings([(new_prompt, weight)], self._current_negative_prompt)
 
         # Update cache index to point to the new prompt
-        if index in self._prompt_cache and self._prompt_cache[index]['text'] != new_prompt:
+        if index in self._prompt_cache and self._prompt_cache[index]["text"] != new_prompt:
             # Find if this prompt is already cached elsewhere
             existing_cache_key = None
             for cache_idx, cache_data in self._prompt_cache.items():
-                if cache_data['text'] == new_prompt:
+                if cache_data["text"] == new_prompt:
                     existing_cache_key = cache_idx
                     break
 
@@ -957,10 +944,7 @@ class StreamParameterUpdater(OrchestratorUser):
                     do_classifier_free_guidance=False,
                     negative_prompt=self._current_negative_prompt,
                 )
-                self._prompt_cache[index] = {
-                    'embed': encoder_output[0],
-                    'text': new_prompt
-                }
+                self._prompt_cache[index] = {"embed": encoder_output[0], "text": new_prompt}
 
         # Recompute blended embeddings with updated prompt
         self._apply_prompt_blending(prompt_interpolation_method)
@@ -972,15 +956,11 @@ class StreamParameterUpdater(OrchestratorUser):
 
     @torch.inference_mode()
     def add_prompt(
-        self,
-        prompt: str,
-        weight: float = 1.0,
-        prompt_interpolation_method: Literal["linear", "slerp"] = "slerp"
+        self, prompt: str, weight: float = 1.0, prompt_interpolation_method: Literal["linear", "slerp"] = "slerp"
     ) -> None:
         """Add a new prompt to the current list."""
         new_index = len(self._current_prompt_list)
         self._current_prompt_list.append((prompt, weight))
-
 
         # Cache the new prompt
         encoder_output = self.stream.pipe.encode_prompt(
@@ -990,10 +970,7 @@ class StreamParameterUpdater(OrchestratorUser):
             do_classifier_free_guidance=False,
             negative_prompt=self._current_negative_prompt,
         )
-        self._prompt_cache[new_index] = {
-            'embed': encoder_output[0],
-            'text': prompt
-        }
+        self._prompt_cache[new_index] = {"embed": encoder_output[0], "text": prompt}
         self._prompt_cache_stats.record_miss()
 
         # Recompute blended embeddings
@@ -1001,9 +978,7 @@ class StreamParameterUpdater(OrchestratorUser):
 
     @torch.inference_mode()
     def remove_prompt_at_index(
-        self,
-        index: int,
-        prompt_interpolation_method: Literal["linear", "slerp"] = "slerp"
+        self, index: int, prompt_interpolation_method: Literal["linear", "slerp"] = "slerp"
     ) -> None:
         """Remove a prompt at the specified index."""
         if not self._validate_index(index, self._current_prompt_list, "remove_prompt_at_index"):
@@ -1028,10 +1003,7 @@ class StreamParameterUpdater(OrchestratorUser):
 
     @torch.inference_mode()
     def update_seed_at_index(
-        self,
-        index: int,
-        new_seed: int,
-        interpolation_method: Literal["linear", "slerp"] = "linear"
+        self, index: int, new_seed: int, interpolation_method: Literal["linear", "slerp"] = "linear"
     ) -> None:
         """Update a single seed at the specified index without regenerating others."""
         if not self._validate_index(index, self._current_seed_list, "update_seed_at_index"):
@@ -1041,16 +1013,15 @@ class StreamParameterUpdater(OrchestratorUser):
         old_seed, weight = self._current_seed_list[index]
         self._current_seed_list[index] = (new_seed, weight)
 
-
         # Cache the new seed noise
         self._cache_seed_noise([(new_seed, weight)])
 
         # Update cache index to point to the new seed
-        if index in self._seed_cache and self._seed_cache[index]['seed'] != new_seed:
+        if index in self._seed_cache and self._seed_cache[index]["seed"] != new_seed:
             # Find if this seed is already cached elsewhere
             existing_cache_key = None
             for cache_idx, cache_data in self._seed_cache.items():
-                if cache_data['seed'] == new_seed:
+                if cache_data["seed"] == new_seed:
                     existing_cache_key = cache_idx
                     break
 
@@ -1068,13 +1039,10 @@ class StreamParameterUpdater(OrchestratorUser):
                     (self.stream.batch_size, 4, self.stream.latent_height, self.stream.latent_width),
                     generator=generator,
                     device=self.stream.device,
-                    dtype=self.stream.dtype
+                    dtype=self.stream.dtype,
                 )
 
-                self._seed_cache[index] = {
-                    'noise': noise,
-                    'seed': new_seed
-                }
+                self._seed_cache[index] = {"noise": noise, "seed": new_seed}
 
         # Recompute blended noise with updated seed
         self._apply_seed_blending(interpolation_method)
@@ -1086,10 +1054,7 @@ class StreamParameterUpdater(OrchestratorUser):
 
     @torch.inference_mode()
     def add_seed(
-        self,
-        seed: int,
-        weight: float = 1.0,
-        interpolation_method: Literal["linear", "slerp"] = "linear"
+        self, seed: int, weight: float = 1.0, interpolation_method: Literal["linear", "slerp"] = "linear"
     ) -> None:
         """Add a new seed to the current list."""
         new_index = len(self._current_seed_list)
@@ -1105,24 +1070,17 @@ class StreamParameterUpdater(OrchestratorUser):
             (self.stream.batch_size, 4, self.stream.latent_height, self.stream.latent_width),
             generator=generator,
             device=self.stream.device,
-            dtype=self.stream.dtype
+            dtype=self.stream.dtype,
         )
 
-        self._seed_cache[new_index] = {
-            'noise': noise,
-            'seed': seed
-        }
+        self._seed_cache[new_index] = {"noise": noise, "seed": seed}
         self._seed_cache_stats.record_miss()
 
         # Recompute blended noise
         self._apply_seed_blending(interpolation_method)
 
     @torch.inference_mode()
-    def remove_seed_at_index(
-        self,
-        index: int,
-        interpolation_method: Literal["linear", "slerp"] = "linear"
-    ) -> None:
+    def remove_seed_at_index(self, index: int, interpolation_method: Literal["linear", "slerp"] = "linear") -> None:
         """Remove a seed at the specified index."""
         if not self._validate_index(index, self._current_seed_list, "remove_seed_at_index"):
             return
@@ -1147,7 +1105,7 @@ class StreamParameterUpdater(OrchestratorUser):
     def _update_controlnet_config(self, desired_config: List[Dict[str, Any]]) -> None:
         """
         Update ControlNet configuration by diffing current vs desired state.
-        
+
         Args:
             desired_config: Complete ControlNet configuration list defining the desired state.
                            Each dict contains: model_id, preprocessor, conditioning_scale, enabled, etc.
@@ -1155,41 +1113,47 @@ class StreamParameterUpdater(OrchestratorUser):
         # Find the ControlNet pipeline/module (module-aware)
         controlnet_pipeline = self._get_controlnet_pipeline()
         if not controlnet_pipeline:
-            logger.debug("_update_controlnet_config: No ControlNet pipeline found (expected when ControlNet not loaded)")
+            logger.debug(
+                "_update_controlnet_config: No ControlNet pipeline found (expected when ControlNet not loaded)"
+            )
             return
-        
+
         current_config = self._get_current_controlnet_config()
-        
+
         # Simple approach: detect what changed and apply minimal updates
-        current_models = {i: getattr(cn, 'model_id', f'controlnet_{i}') for i, cn in enumerate(controlnet_pipeline.controlnets)}
-        desired_models = {cfg['model_id']: cfg for cfg in desired_config}
-        
+        current_models = {
+            i: getattr(cn, "model_id", f"controlnet_{i}") for i, cn in enumerate(controlnet_pipeline.controlnets)
+        }
+        desired_models = {cfg["model_id"]: cfg for cfg in desired_config}
+
         # Reorder to match desired order (module supports stable reordering)
         try:
-            desired_order = [cfg['model_id'] for cfg in desired_config if 'model_id' in cfg]
-            if hasattr(controlnet_pipeline, 'reorder_controlnets_by_model_ids'):
+            desired_order = [cfg["model_id"] for cfg in desired_config if "model_id" in cfg]
+            if hasattr(controlnet_pipeline, "reorder_controlnets_by_model_ids"):
                 controlnet_pipeline.reorder_controlnets_by_model_ids(desired_order)
         except Exception:
             pass
 
         # Recompute current models after potential reorder
-        current_models = {i: getattr(cn, 'model_id', f'controlnet_{i}') for i, cn in enumerate(controlnet_pipeline.controlnets)}
+        current_models = {
+            i: getattr(cn, "model_id", f"controlnet_{i}") for i, cn in enumerate(controlnet_pipeline.controlnets)
+        }
 
         # Remove controlnets not in desired config
         for i in reversed(range(len(controlnet_pipeline.controlnets))):
-            model_id = current_models.get(i, f'controlnet_{i}')
+            model_id = current_models.get(i, f"controlnet_{i}")
             if model_id not in desired_models:
                 logger.info(f"_update_controlnet_config: Removing ControlNet {model_id}")
                 try:
                     controlnet_pipeline.remove_controlnet(i)
                 except Exception:
                     raise
-        
+
         # Add new controlnets and update existing ones
         for desired_cfg in desired_config:
-            model_id = desired_cfg['model_id']
+            model_id = desired_cfg["model_id"]
             existing_index = next((i for i, mid in current_models.items() if mid == model_id), None)
-            
+
             if existing_index is None:
                 # Add new controlnet
                 logger.info(f"_update_controlnet_config: Adding ControlNet {model_id}")
@@ -1197,15 +1161,16 @@ class StreamParameterUpdater(OrchestratorUser):
                     # Prefer module path: construct ControlNetConfig
                     try:
                         from .modules.controlnet_module import ControlNetConfig  # type: ignore
+
                         cn_cfg = ControlNetConfig(
-                            model_id=desired_cfg.get('model_id'),
-                            preprocessor=desired_cfg.get('preprocessor'),
-                            conditioning_scale=desired_cfg.get('conditioning_scale', 1.0),
-                            enabled=desired_cfg.get('enabled', True),
-                            conditioning_channels=desired_cfg.get('conditioning_channels'),
-                            preprocessor_params=desired_cfg.get('preprocessor_params'),
+                            model_id=desired_cfg.get("model_id"),
+                            preprocessor=desired_cfg.get("preprocessor"),
+                            conditioning_scale=desired_cfg.get("conditioning_scale", 1.0),
+                            enabled=desired_cfg.get("enabled", True),
+                            conditioning_channels=desired_cfg.get("conditioning_channels"),
+                            preprocessor_params=desired_cfg.get("preprocessor_params"),
                         )
-                        controlnet_pipeline.add_controlnet(cn_cfg, desired_cfg.get('control_image'))
+                        controlnet_pipeline.add_controlnet(cn_cfg, desired_cfg.get("control_image"))
                     except Exception:
                         # No fallback
                         raise
@@ -1213,114 +1178,136 @@ class StreamParameterUpdater(OrchestratorUser):
                     logger.error(f"_update_controlnet_config: add_controlnet failed for {model_id}: {e}")
             else:
                 # Update existing controlnet
-                if 'conditioning_scale' in desired_cfg:
-                    current_scale = current_config[existing_index].get('conditioning_scale', 1.0)
-                    desired_scale = desired_cfg['conditioning_scale']
-                    
-                    if current_scale != desired_scale:
-                        logger.info(f"_update_controlnet_config: Updating {model_id} scale: {current_scale} → {desired_scale}")
-                        if hasattr(controlnet_pipeline, 'controlnet_scales') and 0 <= existing_index < len(controlnet_pipeline.controlnet_scales):
-                            controlnet_pipeline.controlnet_scales[existing_index] = float(desired_scale)
-                
-                # Enable/disable toggle
-                if 'enabled' in desired_cfg and hasattr(controlnet_pipeline, 'enabled_list'):
-                    if 0 <= existing_index < len(controlnet_pipeline.enabled_list):
-                        controlnet_pipeline.enabled_list[existing_index] = bool(desired_cfg['enabled'])
+                if "conditioning_scale" in desired_cfg:
+                    current_scale = current_config[existing_index].get("conditioning_scale", 1.0)
+                    desired_scale = desired_cfg["conditioning_scale"]
 
-                if 'preprocessor_params' in desired_cfg and hasattr(controlnet_pipeline, 'preprocessors') and controlnet_pipeline.preprocessors[existing_index]:
+                    if current_scale != desired_scale:
+                        logger.info(
+                            f"_update_controlnet_config: Updating {model_id} scale: {current_scale} → {desired_scale}"
+                        )
+                        if hasattr(controlnet_pipeline, "controlnet_scales") and 0 <= existing_index < len(
+                            controlnet_pipeline.controlnet_scales
+                        ):
+                            controlnet_pipeline.controlnet_scales[existing_index] = float(desired_scale)
+
+                # Enable/disable toggle
+                if "enabled" in desired_cfg and hasattr(controlnet_pipeline, "enabled_list"):
+                    if 0 <= existing_index < len(controlnet_pipeline.enabled_list):
+                        controlnet_pipeline.enabled_list[existing_index] = bool(desired_cfg["enabled"])
+
+                if (
+                    "preprocessor_params" in desired_cfg
+                    and hasattr(controlnet_pipeline, "preprocessors")
+                    and controlnet_pipeline.preprocessors[existing_index]
+                ):
                     preprocessor = controlnet_pipeline.preprocessors[existing_index]
-                    preprocessor.params.update(desired_cfg['preprocessor_params'])
-                    for param_name, param_value in desired_cfg['preprocessor_params'].items():
+                    preprocessor.params.update(desired_cfg["preprocessor_params"])
+                    for param_name, param_value in desired_cfg["preprocessor_params"].items():
                         if hasattr(preprocessor, param_name):
                             setattr(preprocessor, param_name, param_value)
-                
+
                 # Pipeline references are now automatically managed during preprocessor creation
                 # No need to manually re-establish pipeline references for pipeline-aware processors
-
 
     def _get_controlnet_pipeline(self):
         """
         Get the ControlNet module or legacy pipeline from the structure (module-aware).
         """
         # Module-installed path
-        if hasattr(self.stream, '_controlnet_module'):
+        if hasattr(self.stream, "_controlnet_module"):
             return self.stream._controlnet_module
         # Legacy paths
-        if hasattr(self.stream, 'controlnets'):
+        if hasattr(self.stream, "controlnets"):
             return self.stream
-        if hasattr(self.stream, 'stream') and hasattr(self.stream.stream, 'controlnets'):
+        if hasattr(self.stream, "stream") and hasattr(self.stream.stream, "controlnets"):
             return self.stream.stream
-        if self.wrapper and hasattr(self.wrapper, 'stream'):
-            if hasattr(self.wrapper.stream, '_controlnet_module'):
+        if self.wrapper and hasattr(self.wrapper, "stream"):
+            if hasattr(self.wrapper.stream, "_controlnet_module"):
                 return self.wrapper.stream._controlnet_module
-            if hasattr(self.wrapper.stream, 'controlnets'):
+            if hasattr(self.wrapper.stream, "controlnets"):
                 return self.wrapper.stream
-            if hasattr(self.wrapper.stream, 'stream') and hasattr(self.wrapper.stream.stream, 'controlnets'):
+            if hasattr(self.wrapper.stream, "stream") and hasattr(self.wrapper.stream.stream, "controlnets"):
                 return self.wrapper.stream.stream
         return None
 
     def _get_current_controlnet_config(self) -> List[Dict[str, Any]]:
         """
         Get current ControlNet configuration state.
-        
+
         Returns:
             List of current ControlNet configurations
         """
         controlnet_pipeline = self._get_controlnet_pipeline()
-        if not controlnet_pipeline or not hasattr(controlnet_pipeline, 'controlnets') or not controlnet_pipeline.controlnets:
+        if (
+            not controlnet_pipeline
+            or not hasattr(controlnet_pipeline, "controlnets")
+            or not controlnet_pipeline.controlnets
+        ):
             return []
-        
+
         current_config = []
         for i, controlnet in enumerate(controlnet_pipeline.controlnets):
-            model_id = getattr(controlnet, 'model_id', f'controlnet_{i}')
-            scale = controlnet_pipeline.controlnet_scales[i] if hasattr(controlnet_pipeline, 'controlnet_scales') and i < len(controlnet_pipeline.controlnet_scales) else 1.0
+            model_id = getattr(controlnet, "model_id", f"controlnet_{i}")
+            scale = (
+                controlnet_pipeline.controlnet_scales[i]
+                if hasattr(controlnet_pipeline, "controlnet_scales") and i < len(controlnet_pipeline.controlnet_scales)
+                else 1.0
+            )
             enabled_val = True
             try:
-                if hasattr(controlnet_pipeline, 'enabled_list') and i < len(controlnet_pipeline.enabled_list):
+                if hasattr(controlnet_pipeline, "enabled_list") and i < len(controlnet_pipeline.enabled_list):
                     enabled_val = bool(controlnet_pipeline.enabled_list[i])
             except Exception:
                 enabled_val = True
             config = {
-                'model_id': model_id,
-                'conditioning_scale': scale,
-                'preprocessor_params': getattr(controlnet_pipeline.preprocessors[i], 'params', {}) if hasattr(controlnet_pipeline, 'preprocessors') and controlnet_pipeline.preprocessors[i] else {},
-                'enabled': enabled_val,
+                "model_id": model_id,
+                "conditioning_scale": scale,
+                "preprocessor_params": getattr(controlnet_pipeline.preprocessors[i], "params", {})
+                if hasattr(controlnet_pipeline, "preprocessors") and controlnet_pipeline.preprocessors[i]
+                else {},
+                "enabled": enabled_val,
             }
             current_config.append(config)
-        
+
         return current_config
 
     def _update_ipadapter_config(self, desired_config: Dict[str, Any]) -> None:
         """
         Update IPAdapter configuration.
-        
+
         Args:
-            desired_config: IPAdapter configuration dict containing: 
+            desired_config: IPAdapter configuration dict containing:
                            ipadapter_model_path, image_encoder_path, style_image, scale, enabled, etc.
         """
         # Find the IPAdapter pipeline
         ipadapter_pipeline = self._get_ipadapter_pipeline()
-        
+
         if not ipadapter_pipeline:
-            logger.warning(f"_update_ipadapter_config: No IPAdapter pipeline found")
+            logger.warning("_update_ipadapter_config: No IPAdapter pipeline found")
             return
-        
-        if 'scale' in desired_config and desired_config['scale'] is not None:
-            desired_scale = float(desired_config['scale'])
+
+        if "scale" in desired_config and desired_config["scale"] is not None:
+            desired_scale = float(desired_config["scale"])
             # Get current scale from IPAdapter instance
-            current_scale = getattr(self.stream.ipadapter, 'scale', 1.0) if hasattr(self.stream, 'ipadapter') else 1.0
-            
+            current_scale = getattr(self.stream.ipadapter, "scale", 1.0) if hasattr(self.stream, "ipadapter") else 1.0
+
             if current_scale != desired_scale:
                 logger.info(f"_update_ipadapter_config: Updating scale: {current_scale} → {desired_scale}")
-                
+
                 # Get weight_type from IPAdapter instance
-                weight_type = getattr(self.stream.ipadapter, 'weight_type', None) if hasattr(self.stream, 'ipadapter') else None
-                
+                weight_type = (
+                    getattr(self.stream.ipadapter, "weight_type", None) if hasattr(self.stream, "ipadapter") else None
+                )
+
                 # Apply scale with weight type consideration
-                if weight_type is not None and hasattr(self.stream, 'ipadapter'):
+                if weight_type is not None and hasattr(self.stream, "ipadapter"):
                     try:
                         from diffusers_ipadapter.ip_adapter.attention_processor import build_layer_weights
-                        ip_procs = [p for p in self.stream.pipe.unet.attn_processors.values() if hasattr(p, "_ip_layer_index")]
+
+                        ip_procs = [
+                            p for p in self.stream.pipe.unet.attn_processors.values() if hasattr(p, "_ip_layer_index")
+                        ]
                         num_layers = len(ip_procs)
                         weights = build_layer_weights(num_layers, desired_scale, weight_type)
                         if weights is not None:
@@ -1328,47 +1315,51 @@ class StreamParameterUpdater(OrchestratorUser):
                         else:
                             self.stream.ipadapter.set_scale(desired_scale)
                         # Update our tracking attribute
-                        setattr(self.stream.ipadapter, 'scale', desired_scale)
+                        setattr(self.stream.ipadapter, "scale", desired_scale)
                     except Exception:
                         # Do not add fallback mechanisms
                         raise
                 else:
                     # Simple uniform scale
-                    if hasattr(self.stream, 'ipadapter'):
+                    if hasattr(self.stream, "ipadapter"):
                         # Tell diffusers_ipadapter to set the scale
                         self.stream.ipadapter.set_scale(desired_scale)
                         # Update our tracking attribute
-                        setattr(self.stream.ipadapter, 'scale', desired_scale)
-        
+                        setattr(self.stream.ipadapter, "scale", desired_scale)
 
         # Update enabled state if provided
-        if 'enabled' in desired_config and desired_config['enabled'] is not None:
-            enabled_state = bool(desired_config['enabled'])
+        if "enabled" in desired_config and desired_config["enabled"] is not None:
+            enabled_state = bool(desired_config["enabled"])
             # Update IPAdapter instance
-            if hasattr(self.stream, 'ipadapter'):
-                current_enabled = getattr(self.stream.ipadapter, 'enabled', True)
+            if hasattr(self.stream, "ipadapter"):
+                current_enabled = getattr(self.stream.ipadapter, "enabled", True)
                 if current_enabled != enabled_state:
-                    logger.info(f"_update_ipadapter_config: Updating enabled state: {current_enabled} → {enabled_state}")
-                    setattr(self.stream.ipadapter, 'enabled', enabled_state)
+                    logger.info(
+                        f"_update_ipadapter_config: Updating enabled state: {current_enabled} → {enabled_state}"
+                    )
+                    setattr(self.stream.ipadapter, "enabled", enabled_state)
 
         # Update weight type if provided (affects per-layer distribution and/or per-step factor)
-        if 'weight_type' in desired_config and desired_config['weight_type'] is not None:
-            weight_type = desired_config['weight_type']
+        if "weight_type" in desired_config and desired_config["weight_type"] is not None:
+            weight_type = desired_config["weight_type"]
             # Update IPAdapter instance
-            if hasattr(self.stream, 'ipadapter'):
-                setattr(self.stream.ipadapter, 'weight_type', weight_type)
-                
+            if hasattr(self.stream, "ipadapter"):
+                setattr(self.stream.ipadapter, "weight_type", weight_type)
+
                 # For PyTorch UNet, immediately apply a per-layer scale vector so layers reflect selection types
                 try:
-                    is_tensorrt_engine = hasattr(self.stream.unet, 'engine') and hasattr(self.stream.unet, 'stream')
+                    is_tensorrt_engine = hasattr(self.stream.unet, "engine") and hasattr(self.stream.unet, "stream")
                     if not is_tensorrt_engine:
                         # Compute per-layer vector using Diffusers_IPAdapter helper
                         from diffusers_ipadapter.ip_adapter.attention_processor import build_layer_weights
+
                         # Count installed IP layers by scanning processors with _ip_layer_index
-                        ip_procs = [p for p in self.stream.pipe.unet.attn_processors.values() if hasattr(p, "_ip_layer_index")]
+                        ip_procs = [
+                            p for p in self.stream.pipe.unet.attn_processors.values() if hasattr(p, "_ip_layer_index")
+                        ]
                         num_layers = len(ip_procs)
                         # Get base weight from IPAdapter instance
-                        base_weight = float(getattr(self.stream.ipadapter, 'scale', 1.0))
+                        base_weight = float(getattr(self.stream.ipadapter, "scale", 1.0))
                         weights = build_layer_weights(num_layers, base_weight, weight_type)
                         # If None, keep uniform base scale; else set per-layer vector
                         if weights is not None:
@@ -1376,7 +1367,7 @@ class StreamParameterUpdater(OrchestratorUser):
                         else:
                             self.stream.ipadapter.set_scale(base_weight)
                         # Keep our tracking attribute in sync
-                        setattr(self.stream.ipadapter, 'scale', base_weight)
+                        setattr(self.stream.ipadapter, "scale", base_weight)
                 except Exception:
                     # Do not add fallback mechanisms
                     raise
@@ -1384,191 +1375,207 @@ class StreamParameterUpdater(OrchestratorUser):
     def _get_ipadapter_pipeline(self):
         """
         Get the IPAdapter pipeline from the pipeline structure (following ControlNet pattern).
-        
+
         Returns:
             IPAdapter pipeline object or None if not found
         """
         # Check if stream is IPAdapter pipeline directly
-        if hasattr(self.stream, 'ipadapter'):
+        if hasattr(self.stream, "ipadapter"):
             return self.stream
-            
+
         # Check if stream has nested stream (ControlNet wrapper)
-        if hasattr(self.stream, 'stream') and hasattr(self.stream.stream, 'ipadapter'):
+        if hasattr(self.stream, "stream") and hasattr(self.stream.stream, "ipadapter"):
             return self.stream.stream
-        
+
         # Check if we have a wrapper reference and can access through it
-        if self.wrapper and hasattr(self.wrapper, 'stream'):
-            if hasattr(self.wrapper.stream, 'ipadapter'):
+        if self.wrapper and hasattr(self.wrapper, "stream"):
+            if hasattr(self.wrapper.stream, "ipadapter"):
                 return self.wrapper.stream
-            elif hasattr(self.wrapper.stream, 'stream') and hasattr(self.wrapper.stream.stream, 'ipadapter'):
+            elif hasattr(self.wrapper.stream, "stream") and hasattr(self.wrapper.stream.stream, "ipadapter"):
                 return self.wrapper.stream.stream
-        
+
         return None
 
     def _get_current_ipadapter_config(self) -> Optional[Dict[str, Any]]:
         """
         Get current IPAdapter configuration by introspecting the IPAdapter instance.
-        
+
         Returns:
             Current IPAdapter configuration dict or None if no IPAdapter
         """
         # Get config from IPAdapter instance
-        if hasattr(self.stream, 'ipadapter') and self.stream.ipadapter is not None:
+        if hasattr(self.stream, "ipadapter") and self.stream.ipadapter is not None:
             ipadapter = self.stream.ipadapter
-            
+
             config = {
-                'scale': getattr(ipadapter, 'scale', 1.0),
-                'weight_type': getattr(ipadapter, 'weight_type', None),
-                'enabled': getattr(ipadapter, 'enabled', True),  # Check actual enabled state
+                "scale": getattr(ipadapter, "scale", 1.0),
+                "weight_type": getattr(ipadapter, "weight_type", None),
+                "enabled": getattr(ipadapter, "enabled", True),  # Check actual enabled state
             }
-            
+
             # Add static initialization fields
-            if hasattr(self.stream, '_ipadapter_module'):
+            if hasattr(self.stream, "_ipadapter_module"):
                 module_config = self.stream._ipadapter_module.config
-                config.update({
-                    'style_image_key': module_config.style_image_key,
-                    'num_image_tokens': module_config.num_image_tokens,
-                    'type': module_config.type.value,
-                })
-            
+                config.update(
+                    {
+                        "style_image_key": module_config.style_image_key,
+                        "num_image_tokens": module_config.num_image_tokens,
+                        "type": module_config.type.value,
+                    }
+                )
+
             # Check if style image is set
             ipadapter_pipeline = self._get_ipadapter_pipeline()
-            if ipadapter_pipeline and hasattr(ipadapter_pipeline, 'style_image') and ipadapter_pipeline.style_image:
-                config['has_style_image'] = True
+            if ipadapter_pipeline and hasattr(ipadapter_pipeline, "style_image") and ipadapter_pipeline.style_image:
+                config["has_style_image"] = True
             else:
-                config['has_style_image'] = False
-            
+                config["has_style_image"] = False
+
             return config
-        
+
         # No IPAdapter instance found
         return None
 
     def _get_current_hook_config(self, hook_type: str) -> List[Dict[str, Any]]:
         """
         Get current hook configuration by introspecting the hook module state.
-        
+
         Args:
             hook_type: Type of hook (image_preprocessing, image_postprocessing, etc.)
-            
+
         Returns:
             List of processor configurations or empty list if no module
         """
         # Get the hook module
         module_attr_name = f"_{hook_type}_module"
         hook_module = getattr(self.stream, module_attr_name, None)
-        
+
         if not hook_module:
             return []
-        
+
         # Get processors from the module
-        processors = getattr(hook_module, 'processors', [])
-        
+        processors = getattr(hook_module, "processors", [])
+
         config = []
         for i, processor in enumerate(processors):
             proc_config = {
-                'type': getattr(processor, '__class__').__name__,
-                'order': getattr(processor, 'order', i),
-                'enabled': getattr(processor, 'enabled', True),
+                "type": getattr(processor, "__class__").__name__,
+                "order": getattr(processor, "order", i),
+                "enabled": getattr(processor, "enabled", True),
             }
-            
+
             # Try to get processor parameters
-            if hasattr(processor, 'params'):
-                proc_config['params'] = dict(processor.params)
-            
+            if hasattr(processor, "params"):
+                proc_config["params"] = dict(processor.params)
+
             config.append(proc_config)
-        
+
         return config
 
     def _update_hook_config(self, hook_type: str, desired_config: List[Dict[str, Any]]) -> None:
         """
         Update hook configuration by modifying existing processors in-place instead of recreating them.
-        
+
         Args:
             hook_type: Type of hook (image_preprocessing, image_postprocessing, etc.)
             desired_config: List of processor configurations
         """
         logger.info(f"_update_hook_config: Updating {hook_type} with {len(desired_config)} processors")
-        
+
         # Get or create the hook module
         module_attr_name = f"_{hook_type}_module"
         hook_module = getattr(self.stream, module_attr_name, None)
-        
+
         if not hook_module:
             logger.info(f"_update_hook_config: No existing {hook_type} module, creating new one")
             # Create the appropriate hook module
             try:
                 if hook_type in ["image_preprocessing", "image_postprocessing"]:
-                    from streamdiffusion.modules.image_processing_module import ImagePreprocessingModule, ImagePostprocessingModule
+                    from streamdiffusion.modules.image_processing_module import (
+                        ImagePostprocessingModule,
+                        ImagePreprocessingModule,
+                    )
+
                     if hook_type == "image_preprocessing":
                         hook_module = ImagePreprocessingModule()
                     else:
                         hook_module = ImagePostprocessingModule()
                 elif hook_type in ["latent_preprocessing", "latent_postprocessing"]:
-                    from streamdiffusion.modules.latent_processing_module import LatentPreprocessingModule, LatentPostprocessingModule
+                    from streamdiffusion.modules.latent_processing_module import (
+                        LatentPostprocessingModule,
+                        LatentPreprocessingModule,
+                    )
+
                     if hook_type == "latent_preprocessing":
                         hook_module = LatentPreprocessingModule()
                     else:
                         hook_module = LatentPostprocessingModule()
                 else:
                     raise ValueError(f"Unknown hook type: {hook_type}")
-                
+
                 # Install the module
                 hook_module.install(self.stream)
                 setattr(self.stream, module_attr_name, hook_module)
                 logger.info(f"_update_hook_config: Created and installed {hook_type} module")
-                
+
             except Exception as e:
                 logger.error(f"_update_hook_config: Failed to create {hook_type} module: {e}")
                 return
-        
-        logger.info(f"_update_hook_config: Found existing {hook_type} module with {len(hook_module.processors)} processors")
-        
+
+        logger.info(
+            f"_update_hook_config: Found existing {hook_type} module with {len(hook_module.processors)} processors"
+        )
+
         # Modify existing processors in-place instead of clearing and recreating
         for i, proc_config in enumerate(desired_config):
-            processor_type = proc_config.get('type', 'unknown')
-            enabled = proc_config.get('enabled', True)
-            params = proc_config.get('params', {})
-            
+            processor_type = proc_config.get("type", "unknown")
+            enabled = proc_config.get("enabled", True)
+            params = proc_config.get("params", {})
+
             logger.info(f"_update_hook_config: Processing config {i}: type={processor_type}, enabled={enabled}")
-            
+
             if i < len(hook_module.processors):
                 # Modify existing processor
                 existing_processor = hook_module.processors[i]
-                
+
                 # Get the current processor type from registry name if available, otherwise use class name
-                current_type = existing_processor.params.get('_registry_name') if hasattr(existing_processor, 'params') else None
+                current_type = (
+                    existing_processor.params.get("_registry_name") if hasattr(existing_processor, "params") else None
+                )
                 if not current_type:
                     current_type = existing_processor.__class__.__name__
-                
-                logger.info(f"_update_hook_config: Modifying existing processor {i}: {current_type} -> {processor_type}")
-                
+
+                logger.info(
+                    f"_update_hook_config: Modifying existing processor {i}: {current_type} -> {processor_type}"
+                )
+
                 # If processor type changed, replace it
                 if current_type.lower() != processor_type.lower():
                     logger.info(f"_update_hook_config: Type changed, replacing processor {i}")
                     try:
                         from streamdiffusion.preprocessing.processors import get_preprocessor
-                        
+
                         # Determine normalization context from hook type
-                        if 'latent' in hook_type:
-                            normalization_context = 'latent'
+                        if "latent" in hook_type:
+                            normalization_context = "latent"
                         else:
                             # Image preprocessing/postprocessing uses 'pipeline' context
-                            normalization_context = 'pipeline'
-                        
+                            normalization_context = "pipeline"
+
                         new_processor = get_preprocessor(
-                            processor_type, 
-                            pipeline_ref=getattr(self, 'stream', None),
-                            normalization_context=normalization_context
+                            processor_type,
+                            pipeline_ref=getattr(self, "stream", None),
+                            normalization_context=normalization_context,
                         )
-                        
+
                         # Copy attributes from old processor
-                        setattr(new_processor, 'order', getattr(existing_processor, 'order', i))
-                        setattr(new_processor, 'enabled', enabled)
-                        
+                        setattr(new_processor, "order", getattr(existing_processor, "order", i))
+                        setattr(new_processor, "enabled", enabled)
+
                         # Set parameters
-                        if hasattr(new_processor, 'params'):
+                        if hasattr(new_processor, "params"):
                             new_processor.params.update(params)
-                        
+
                         hook_module.processors[i] = new_processor
                         logger.info(f"_update_hook_config: Successfully replaced processor {i} with {processor_type}")
                     except Exception as e:
@@ -1576,15 +1583,15 @@ class StreamParameterUpdater(OrchestratorUser):
                 else:
                     # Same type, just update attributes
                     logger.info(f"_update_hook_config: Same type, updating attributes for processor {i}")
-                    setattr(existing_processor, 'enabled', enabled)
-                    
+                    setattr(existing_processor, "enabled", enabled)
+
                     # Update parameters
-                    if hasattr(existing_processor, 'params'):
+                    if hasattr(existing_processor, "params"):
                         existing_processor.params.update(params)
                     for param_name, param_value in params.items():
                         if hasattr(existing_processor, param_name):
                             setattr(existing_processor, param_name, param_value)
-                    
+
                     logger.info(f"_update_hook_config: Updated processor {i} enabled={enabled}, params={params}")
             else:
                 # Add new processor
@@ -1594,12 +1601,15 @@ class StreamParameterUpdater(OrchestratorUser):
                     logger.info(f"_update_hook_config: Successfully added processor {i}: {processor_type}")
                 except Exception as e:
                     logger.error(f"_update_hook_config: Failed to add processor {i}: {e}")
-        
+
         # Remove extra processors if config is shorter
         while len(hook_module.processors) > len(desired_config):
             removed_idx = len(hook_module.processors) - 1
             removed_processor = hook_module.processors.pop()
-            logger.info(f"_update_hook_config: Removed extra processor {removed_idx}: {removed_processor.__class__.__name__}")
-        
-        logger.info(f"_update_hook_config: Finished updating {hook_type}, now has {len(hook_module.processors)} processors")
+            logger.info(
+                f"_update_hook_config: Removed extra processor {removed_idx}: {removed_processor.__class__.__name__}"
+            )
 
+        logger.info(
+            f"_update_hook_config: Finished updating {hook_type}, now has {len(hook_module.processors)} processors"
+        )

--- a/src/streamdiffusion/tools/compile_raft_tensorrt.py
+++ b/src/streamdiffusion/tools/compile_raft_tensorrt.py
@@ -148,7 +148,7 @@ def build_tensorrt_engine(
 
     try:
         builder = trt.Builder(trt.Logger(trt.Logger.INFO))
-        network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
+        network = builder.create_network()  # EXPLICIT_BATCH deprecated/ignored in TRT 10.x
         parser = trt.OnnxParser(network, trt.Logger(trt.Logger.WARNING))
 
         logger.info("Parsing ONNX model...")

--- a/src/streamdiffusion/tools/compile_raft_tensorrt.py
+++ b/src/streamdiffusion/tools/compile_raft_tensorrt.py
@@ -1,21 +1,24 @@
-import torch
 import logging
 from pathlib import Path
-from typing import Optional
-import fire
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+import fire
+import torch
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 try:
     import tensorrt as trt
+
     TENSORRT_AVAILABLE = True
 except ImportError:
     TENSORRT_AVAILABLE = False
     logger.error("TensorRT not available. Please install it first.")
 
 try:
-    from torchvision.models.optical_flow import raft_small, Raft_Small_Weights
+    from torchvision.models.optical_flow import Raft_Small_Weights, raft_small
+
     TORCHVISION_AVAILABLE = True
 except ImportError:
     TORCHVISION_AVAILABLE = False
@@ -28,11 +31,11 @@ def export_raft_to_onnx(
     min_width: int = 512,
     max_height: int = 512,
     max_width: int = 512,
-    device: str = "cuda"
+    device: str = "cuda",
 ) -> bool:
     """
     Export RAFT model to ONNX format
-    
+
     Args:
         onnx_path: Path to save the ONNX model
         min_height: Minimum input height for the model
@@ -40,41 +43,41 @@ def export_raft_to_onnx(
         max_height: Maximum input height for the model
         max_width: Maximum input width for the model
         device: Device to use for export
-        
+
     Returns:
         True if successful, False otherwise
     """
     if not TORCHVISION_AVAILABLE:
         logger.error("torchvision is required but not installed")
         return False
-    
+
     logger.info(f"Exporting RAFT model to ONNX: {onnx_path}")
     logger.info(f"Resolution range: {min_height}x{min_width} - {max_height}x{max_width}")
-    
+
     try:
         # Load RAFT model
         logger.info("Loading RAFT Small model...")
         raft_model = raft_small(weights=Raft_Small_Weights.DEFAULT, progress=True)
         raft_model = raft_model.to(device=device)
         raft_model.eval()
-        
+
         # Create dummy inputs using max resolution for export
         dummy_frame1 = torch.randn(1, 3, max_height, max_width).to(device)
         dummy_frame2 = torch.randn(1, 3, max_height, max_width).to(device)
-        
+
         # Apply RAFT preprocessing if available
         weights = Raft_Small_Weights.DEFAULT
-        if hasattr(weights, 'transforms') and weights.transforms is not None:
+        if hasattr(weights, "transforms") and weights.transforms is not None:
             transforms = weights.transforms()
             dummy_frame1, dummy_frame2 = transforms(dummy_frame1, dummy_frame2)
-        
+
         # Make batch, height, and width dimensions dynamic
         dynamic_axes = {
             "frame1": {0: "batch_size", 2: "height", 3: "width"},
             "frame2": {0: "batch_size", 2: "height", 3: "width"},
             "flow": {0: "batch_size", 2: "height", 3: "width"},
         }
-        
+
         logger.info("Exporting to ONNX...")
         with torch.no_grad():
             torch.onnx.export(
@@ -82,22 +85,23 @@ def export_raft_to_onnx(
                 (dummy_frame1, dummy_frame2),
                 str(onnx_path),
                 verbose=False,
-                input_names=['frame1', 'frame2'],
-                output_names=['flow'],
+                input_names=["frame1", "frame2"],
+                output_names=["flow"],
                 opset_version=17,
                 export_params=True,
                 dynamic_axes=dynamic_axes,
             )
-        
+
         del raft_model
         torch.cuda.empty_cache()
-        
+
         logger.info(f"Successfully exported ONNX model to {onnx_path}")
         return True
-        
+
     except Exception as e:
         logger.error(f"Failed to export ONNX model: {e}")
         import traceback
+
         traceback.print_exc()
         return False
 
@@ -110,11 +114,11 @@ def build_tensorrt_engine(
     max_height: int = 512,
     max_width: int = 512,
     fp16: bool = True,
-    workspace_size_gb: int = 4
+    workspace_size_gb: int = 4,
 ) -> bool:
     """
     Build TensorRT engine from ONNX model
-    
+
     Args:
         onnx_path: Path to the ONNX model
         engine_path: Path to save the TensorRT engine
@@ -124,74 +128,74 @@ def build_tensorrt_engine(
         max_width: Maximum input width for optimization
         fp16: Enable FP16 precision mode
         workspace_size_gb: Maximum workspace size in GB
-        
+
     Returns:
         True if successful, False otherwise
     """
     if not TENSORRT_AVAILABLE:
         logger.error("TensorRT is required but not installed")
         return False
-    
+
     if not onnx_path.exists():
         logger.error(f"ONNX model not found: {onnx_path}")
         return False
-    
+
     logger.info(f"Building TensorRT engine from ONNX model: {onnx_path}")
     logger.info(f"Output path: {engine_path}")
     logger.info(f"Resolution range: {min_height}x{min_width} - {max_height}x{max_width}")
     logger.info(f"FP16 mode: {fp16}")
     logger.info("This may take several minutes...")
-    
+
     try:
         builder = trt.Builder(trt.Logger(trt.Logger.INFO))
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
         parser = trt.OnnxParser(network, trt.Logger(trt.Logger.WARNING))
-        
+
         logger.info("Parsing ONNX model...")
-        with open(onnx_path, 'rb') as model:
+        with open(onnx_path, "rb") as model:
             if not parser.parse(model.read()):
                 logger.error("Failed to parse ONNX model")
                 for error in range(parser.num_errors):
                     logger.error(f"Parser error: {parser.get_error(error)}")
                 return False
-        
+
         logger.info("Configuring TensorRT builder...")
         config = builder.create_builder_config()
-        
+
         config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_size_gb * (1 << 30))
-        
+
         if fp16:
             config.set_flag(trt.BuilderFlag.FP16)
             logger.info("FP16 mode enabled")
-        
+
         # Calculate optimal resolution (middle point)
         opt_height = (min_height + max_height) // 2
         opt_width = (min_width + max_width) // 2
-        
+
         profile = builder.create_optimization_profile()
         min_shape = (1, 3, min_height, min_width)
         opt_shape = (1, 3, opt_height, opt_width)
         max_shape = (1, 3, max_height, max_width)
-        
+
         profile.set_shape("frame1", min_shape, opt_shape, max_shape)
         profile.set_shape("frame2", min_shape, opt_shape, max_shape)
         config.add_optimization_profile(profile)
-        
+
         logger.info("Building TensorRT engine... (this will take a while)")
         engine = builder.build_serialized_network(network, config)
-        
+
         if engine is None:
             logger.error("Failed to build TensorRT engine")
             return False
-        
+
         logger.info(f"Saving engine to {engine_path}")
         engine_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(engine_path, 'wb') as f:
+        with open(engine_path, "wb") as f:
             f.write(engine)
-        
+
         logger.info(f"Successfully built and saved TensorRT engine: {engine_path}")
-        logger.info(f"Engine size: {engine_path.stat().st_size / (1024*1024):.2f} MB")
-        
+        logger.info(f"Engine size: {engine_path.stat().st_size / (1024 * 1024):.2f} MB")
+
         # Delete ONNX file after successful engine creation
         try:
             if onnx_path.exists():
@@ -199,12 +203,13 @@ def build_tensorrt_engine(
                 logger.info(f"Deleted ONNX file: {onnx_path}")
         except Exception as e:
             logger.warning(f"Failed to delete ONNX file: {e}")
-        
+
         return True
-        
+
     except Exception as e:
         logger.error(f"Failed to build TensorRT engine: {e}")
         import traceback
+
         traceback.print_exc()
         return False
 
@@ -216,11 +221,11 @@ def compile_raft(
     device: str = "cuda",
     fp16: bool = True,
     workspace_size_gb: int = 4,
-    force_rebuild: bool = False
+    force_rebuild: bool = False,
 ):
     """
     Main function to compile RAFT model to TensorRT engine
-    
+
     Args:
         min_resolution: Minimum input resolution as "HxW" (e.g., "512x512") (default: "512x512")
         max_resolution: Maximum input resolution as "HxW" (e.g., "1024x1024") (default: "512x512")
@@ -234,46 +239,46 @@ def compile_raft(
         logger.error("TensorRT is not available. Please install it first using:")
         logger.error("  python -m streamdiffusion.tools.install-tensorrt")
         return
-    
+
     if not TORCHVISION_AVAILABLE:
         logger.error("torchvision is not available. Please install it first using:")
         logger.error("  pip install torchvision")
         return
-    
+
     # Parse resolution strings
     try:
-        min_height, min_width = map(int, min_resolution.split('x'))
+        min_height, min_width = map(int, min_resolution.split("x"))
     except:
         logger.error(f"Invalid min_resolution format: {min_resolution}. Expected format: HxW (e.g., 512x512)")
         return
-    
+
     try:
-        max_height, max_width = map(int, max_resolution.split('x'))
+        max_height, max_width = map(int, max_resolution.split("x"))
     except:
         logger.error(f"Invalid max_resolution format: {max_resolution}. Expected format: HxW (e.g., 1024x1024)")
         return
-    
+
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
-    
+
     # Add resolution suffix to filenames
     onnx_path = output_path / f"raft_small_min_{min_resolution}_max_{max_resolution}.onnx"
     engine_path = output_path / f"raft_small_min_{min_resolution}_max_{max_resolution}.engine"
-    
-    logger.info("="*80)
+
+    logger.info("=" * 80)
     logger.info("RAFT TensorRT Compilation")
-    logger.info("="*80)
+    logger.info("=" * 80)
     logger.info(f"Output directory: {output_path.absolute()}")
     logger.info(f"Resolution range: {min_resolution} - {max_resolution}")
     logger.info(f"ONNX path: {onnx_path}")
     logger.info(f"Engine path: {engine_path}")
-    logger.info("="*80)
-    
+    logger.info("=" * 80)
+
     if engine_path.exists() and not force_rebuild:
         logger.info(f"TensorRT engine already exists: {engine_path}")
         logger.info("Use --force_rebuild to rebuild it")
         return
-    
+
     if not onnx_path.exists() or force_rebuild:
         logger.info("\n[Step 1/2] Exporting RAFT to ONNX...")
         if not export_raft_to_onnx(onnx_path, min_height, min_width, max_height, max_width, device):
@@ -281,21 +286,22 @@ def compile_raft(
             return
     else:
         logger.info(f"\n[Step 1/2] ONNX model already exists: {onnx_path}")
-    
+
     logger.info("\n[Step 2/2] Building TensorRT engine...")
-    if not build_tensorrt_engine(onnx_path, engine_path, min_height, min_width, max_height, max_width, fp16, workspace_size_gb):
+    if not build_tensorrt_engine(
+        onnx_path, engine_path, min_height, min_width, max_height, max_width, fp16, workspace_size_gb
+    ):
         logger.error("Failed to build TensorRT engine")
         return
-    
-    logger.info("\n" + "="*80)
+
+    logger.info("\n" + "=" * 80)
     logger.info("✓ Compilation completed successfully!")
-    logger.info("="*80)
+    logger.info("=" * 80)
     logger.info(f"Engine path: {engine_path.absolute()}")
     logger.info("\nYou can now use this engine in TemporalNetTensorRTPreprocessor:")
     logger.info(f'  engine_path="{engine_path.absolute()}"')
-    logger.info("="*80)
+    logger.info("=" * 80)
 
 
 if __name__ == "__main__":
     fire.Fire(compile_raft)
-

--- a/src/streamdiffusion/tools/cuda_l2_cache.py
+++ b/src/streamdiffusion/tools/cuda_l2_cache.py
@@ -315,10 +315,11 @@ def pin_hot_unet_weights(
     if hot_prefixes is None:
         hot_prefixes = _DEFAULT_HOT_LAYER_PREFIXES
 
-    # Tier 1: Reserve L2 persisting region
-    tier1_ok = reserve_l2_persisting_cache(persist_mb)
-    if not tier1_ok:
-        return 0
+    # Tier 1: Reserve L2 persisting region (skip if persist_mb=0, caller already reserved)
+    if persist_mb > 0:
+        tier1_ok = reserve_l2_persisting_cache(persist_mb)
+        if not tier1_ok:
+            return 0
 
     # Tier 2: Set access policy on hot attention weights
     # Target: to_q, to_k, to_v, to_out weights in hot transformer blocks.

--- a/src/streamdiffusion/tools/cuda_l2_cache.py
+++ b/src/streamdiffusion/tools/cuda_l2_cache.py
@@ -313,6 +313,10 @@ def pin_hot_unet_weights(
         if not tier1_ok:
             return 0
 
+    # TRT engine objects don't expose PyTorch parameters — skip Tier 2 gracefully
+    if not hasattr(unet, "named_parameters"):
+        return 0
+
     # Tier 2: Set access policy on hot attention weights
     # Target: to_q, to_k, to_v, to_out weights in hot transformer blocks.
     # These are small-to-medium GEMMs that benefit most from L2 hits.
@@ -341,15 +345,64 @@ def pin_hot_unet_weights(
     return pinned_count
 
 
-def setup_l2_persistence(unet: torch.nn.Module) -> bool:
+def set_trt_persistent_cache(unet, persist_mb: int = L2_PERSIST_MB) -> bool:
+    """
+    Enable TRT activation caching in L2 for a TensorRT UNet engine.
+
+    Sets IExecutionContext.persistent_cache_limit so TRT retains intermediate
+    activations in the L2 persisting region already reserved by Tier 1.
+
+    TRT checks the current cudaLimitPersistingL2CacheSize at assignment time
+    (not at context creation), so calling this after reserve_l2_persisting_cache()
+    is correct — no reordering of engine initialization is needed.
+
+    Args:
+        unet: UNet2DConditionModelEngine (must have .engine.context attribute).
+        persist_mb: Target L2 budget in MB. Uses Tier 1 reservation size (L2/2),
+                    which is guaranteed <= persistingL2CacheMaxSize on Ampere+.
+
+    Returns:
+        True if activation caching was enabled successfully.
+    """
+    if not L2_PERSIST_ENABLED:
+        return False
+
+    try:
+        context = unet.engine.context
+    except AttributeError:
+        return False
+
+    if not hasattr(context, "persistent_cache_limit"):
+        return False
+
+    persist_bytes = persist_mb * 1024 * 1024
+    try:
+        context.persistent_cache_limit = persist_bytes
+        actual = context.persistent_cache_limit
+        print(
+            f"[L2] TRT UNet activation caching: {actual / (1024 * 1024):.0f}MB "
+            f"of L2 persisting region allocated for activation persistence"
+        )
+        return actual > 0
+    except Exception as e:
+        print(f"[L2] TRT persistent_cache_limit failed: {e}")
+        return False
+
+
+def setup_l2_persistence(unet) -> bool:
     """
     Main entry point: set up L2 cache persistence for UNet inference.
 
-    Call this AFTER model is loaded and BEFORE torch.compile.
-    For best results with frozen weights, call AFTER torch.compile with freezing=True.
+    Dispatches between two strategies based on UNet type:
+    - PyTorch UNet (nn.Module): pin hot attention weight tensors via
+      cudaStreamSetAttribute access policy windows (Tier 2).
+    - TRT UNet engine: enable TRT's native activation caching in L2 via
+      IExecutionContext.persistent_cache_limit.
+
+    Both paths share Tier 1 (cudaDeviceSetLimit L2 reservation).
 
     Args:
-        unet: The UNet model on CUDA.
+        unet: The UNet model — either a PyTorch nn.Module or a TRT engine wrapper.
 
     Returns:
         True if at least Tier 1 (L2 reservation) succeeded.
@@ -363,12 +416,16 @@ def setup_l2_persistence(unet: torch.nn.Module) -> bool:
     tier1_ok = reserve_l2_persisting_cache(L2_PERSIST_MB)
 
     if tier1_ok:
-        # Tier 2: per-tensor access policy (best-effort)
-        pinned = pin_hot_unet_weights(unet, persist_mb=0)  # Tier 1 already reserved
-        if pinned == 0:
-            print(
-                "[L2] Tier 2 access policy skipped (call pin_hot_unet_weights() "
-                "after compile+freeze for per-tensor control)"
-            )
+        if hasattr(unet, "named_parameters"):
+            # PyTorch path: pin hot attention weight tensors in L2
+            pinned = pin_hot_unet_weights(unet, persist_mb=0)  # Tier 1 already reserved
+            if pinned == 0:
+                print(
+                    "[L2] Tier 2 access policy skipped (call pin_hot_unet_weights() "
+                    "after compile+freeze for per-tensor control)"
+                )
+        else:
+            # TRT engine path: use TRT's native activation caching instead
+            set_trt_persistent_cache(unet, persist_mb=L2_PERSIST_MB)
 
     return tier1_ok

--- a/src/streamdiffusion/tools/cuda_l2_cache.py
+++ b/src/streamdiffusion/tools/cuda_l2_cache.py
@@ -112,17 +112,11 @@ def _get_cudart() -> Optional[ctypes.CDLL]:
 
     # Option 1: PyTorch ships cudart in torch/lib/
     torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib")
-    candidates = sorted(
-        glob.glob(os.path.join(torch_lib, "cudart64_*.dll")), reverse=True
-    )
+    candidates = sorted(glob.glob(os.path.join(torch_lib, "cudart64_*.dll")), reverse=True)
 
     # Option 2: CUDA toolkit installation
-    cuda_path = os.environ.get(
-        "CUDA_PATH", r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8"
-    )
-    candidates += sorted(
-        glob.glob(os.path.join(cuda_path, "bin", "cudart64_*.dll")), reverse=True
-    )
+    cuda_path = os.environ.get("CUDA_PATH", r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8")
+    candidates += sorted(glob.glob(os.path.join(cuda_path, "bin", "cudart64_*.dll")), reverse=True)
 
     for dll_path in candidates:
         try:
@@ -162,9 +156,7 @@ def reserve_l2_persisting_cache(persist_mb: int = L2_PERSIST_MB) -> bool:
     props = torch.cuda.get_device_properties(device)
     major, minor = props.major, props.minor
     if major < 8:
-        print(
-            f"[L2] L2 persistence skipped — compute {major}.{minor} < 8.0 (Ampere required)"
-        )
+        print(f"[L2] L2 persistence skipped — compute {major}.{minor} < 8.0 (Ampere required)")
         return False
 
     l2_total_mb = props.L2_cache_size // (1024 * 1024)
@@ -344,9 +336,7 @@ def pin_hot_unet_weights(
             f"({pinned_bytes / 1024 / 1024:.1f}MB) in L2 persisting cache"
         )
     else:
-        print(
-            "[L2] No tensors pinned (params may require_grad=True before compile — call after freeze)"
-        )
+        print("[L2] No tensors pinned (params may require_grad=True before compile — call after freeze)")
 
     return pinned_count
 
@@ -367,10 +357,7 @@ def setup_l2_persistence(unet: torch.nn.Module) -> bool:
     if not L2_PERSIST_ENABLED:
         return False
 
-    print(
-        f"\n[L2] Setting up L2 cache persistence "
-        f"(SDTD_L2_PERSIST_MB={L2_PERSIST_MB})..."
-    )
+    print(f"\n[L2] Setting up L2 cache persistence (SDTD_L2_PERSIST_MB={L2_PERSIST_MB})...")
 
     # Tier 1 is the reliable baseline — always attempt
     tier1_ok = reserve_l2_persisting_cache(L2_PERSIST_MB)

--- a/src/streamdiffusion/tools/cuda_l2_cache.py
+++ b/src/streamdiffusion/tools/cuda_l2_cache.py
@@ -375,7 +375,8 @@ def set_trt_persistent_cache(unet, persist_mb: int = L2_PERSIST_MB) -> bool:
     if not hasattr(context, "persistent_cache_limit"):
         return False
 
-    persist_bytes = persist_mb * 1024 * 1024
+    props = torch.cuda.get_device_properties(torch.cuda.current_device())
+    persist_bytes = min(persist_mb * 1024 * 1024, props.L2_cache_size // 2)
     try:
         context.persistent_cache_limit = persist_bytes
         actual = context.persistent_cache_limit

--- a/src/streamdiffusion/tools/cuda_l2_cache.py
+++ b/src/streamdiffusion/tools/cuda_l2_cache.py
@@ -1,0 +1,386 @@
+"""
+L2 Cache Persistence Utility for StreamDiffusion UNet.
+
+Reserves a portion of the GPU's L2 cache for persistent data (UNet weights),
+reducing cache evictions for memory-bandwidth-bound layers.
+
+Requires: CUDA >= 11.2, compute capability >= 8.0 (Ampere+).
+RTX 5090 has 128MB L2, compute 12.0 — full support.
+
+Environment variables:
+    SDTD_L2_PERSIST=1         Enable L2 persistence (default: 1)
+    SDTD_L2_PERSIST_MB=64     MB of L2 to reserve for persistent data (default: 64)
+    SDTD_L2_PERSIST_LAYERS=   Comma-separated layer names for access policy (default: auto)
+
+Expected impact: 5-16% on memory-bandwidth-bound layers (normalization, small GEMMs).
+Hot layers on SDXL: mid_block, up_blocks.1 (most FF hooks + V2V cached attention).
+"""
+
+import ctypes
+import os
+import sys
+from typing import Optional
+
+import torch
+
+
+# =============================================================================
+# Environment Controls
+# =============================================================================
+
+L2_PERSIST_ENABLED = os.environ.get("SDTD_L2_PERSIST", "1") == "1"
+L2_PERSIST_MB = int(os.environ.get("SDTD_L2_PERSIST_MB", "64"))
+
+# Hot layer prefixes — these contain the most attention + FF hook computation.
+# mid_block: 1 transformer block, seq_len=1024, 16 FF hooks
+# up_blocks.1: up-sampling path, seq_len=4096
+_DEFAULT_HOT_LAYER_PREFIXES = ["mid_block", "up_blocks.1"]
+
+
+# =============================================================================
+# CUDA Runtime Access Policy Structs (for Tier 2 per-tensor persistence)
+# =============================================================================
+
+
+class _CudaAccessPolicyWindow(ctypes.Structure):
+    """cudaAccessPolicyWindow struct for cudaStreamSetAttribute."""
+
+    _fields_ = [
+        ("base_ptr", ctypes.c_void_p),  # void* — start of memory region
+        ("num_bytes", ctypes.c_size_t),  # size_t — size of region in bytes
+        ("hitRatio", ctypes.c_float),  # float — fraction in [0, 1] to keep persistent
+        (
+            "hitProp",
+            ctypes.c_int,
+        ),  # cudaAccessProperty: 2 = cudaAccessPropertyPersisting
+        (
+            "missProp",
+            ctypes.c_int,
+        ),  # cudaAccessProperty: 1 = cudaAccessPropertyStreaming
+    ]
+
+
+# cudaAccessProperty enum values
+_CUDA_ACCESS_PROPERTY_NORMAL = 0
+_CUDA_ACCESS_PROPERTY_STREAMING = 1
+_CUDA_ACCESS_PROPERTY_PERSISTING = 2
+
+# cudaStreamAttrID
+_CUDA_STREAM_ATTRIBUTE_ACCESS_POLICY_WINDOW = 1
+
+# cudaLimit enum (CUDA 11.2+)
+# 0x06 = cudaLimitPersistingL2CacheSize (size in bytes — correct for L2 persistence)
+_CUDA_LIMIT_PERSISTING_L2_CACHE_SIZE = 0x06
+
+
+# =============================================================================
+# CUDA Runtime Handle
+# =============================================================================
+
+_cudart: Optional[ctypes.CDLL] = None
+_cudart_loaded: bool = False
+
+
+def _get_cudart() -> Optional[ctypes.CDLL]:
+    """Load the CUDA runtime DLL. Cached after first call."""
+    global _cudart, _cudart_loaded
+    if _cudart_loaded:
+        return _cudart
+
+    _cudart_loaded = True
+
+    if sys.platform != "win32":
+        # Non-Windows: use libcudart.so — typically already loaded by PyTorch
+        try:
+            _cudart = ctypes.CDLL("libcudart.so", mode=ctypes.RTLD_GLOBAL)
+            return _cudart
+        except OSError:
+            pass
+        try:
+            from ctypes.util import find_library
+
+            lib = find_library("cudart")
+            if lib:
+                _cudart = ctypes.CDLL(lib)
+                return _cudart
+        except OSError:
+            pass
+        return None
+
+    # Windows: find cudart64_*.dll shipped with PyTorch or CUDA toolkit
+    import glob
+
+    # Option 1: PyTorch ships cudart in torch/lib/
+    torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib")
+    candidates = sorted(
+        glob.glob(os.path.join(torch_lib, "cudart64_*.dll")), reverse=True
+    )
+
+    # Option 2: CUDA toolkit installation
+    cuda_path = os.environ.get(
+        "CUDA_PATH", r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8"
+    )
+    candidates += sorted(
+        glob.glob(os.path.join(cuda_path, "bin", "cudart64_*.dll")), reverse=True
+    )
+
+    for dll_path in candidates:
+        try:
+            _cudart = ctypes.WinDLL(dll_path)
+            return _cudart
+        except OSError:
+            continue
+
+    return None
+
+
+# =============================================================================
+# Tier 1: Reserve L2 Persisting Cache Size
+# =============================================================================
+
+
+def reserve_l2_persisting_cache(persist_mb: int = L2_PERSIST_MB) -> bool:
+    """
+    Reserve a portion of L2 cache for persistent data.
+
+    This is Tier 1 of L2 persistence: informs the driver that `persist_mb` MB
+    of L2 should not be evicted by regular (streaming) accesses. Hot data set
+    via access policy windows will preferentially stay in this reserved region.
+
+    Args:
+        persist_mb: Megabytes of L2 to reserve. Should be <= half of total L2.
+                    RTX 5090 has 128MB L2 → 64MB is a safe default.
+
+    Returns:
+        True if successful, False if unsupported or failed.
+    """
+    if not torch.cuda.is_available():
+        return False
+
+    # Check compute capability — L2 persistence requires Ampere (8.0+)
+    device = torch.cuda.current_device()
+    props = torch.cuda.get_device_properties(device)
+    major, minor = props.major, props.minor
+    if major < 8:
+        print(
+            f"[L2] L2 persistence skipped — compute {major}.{minor} < 8.0 (Ampere required)"
+        )
+        return False
+
+    l2_total_mb = props.L2_cache_size // (1024 * 1024)
+    persist_bytes = min(persist_mb * 1024 * 1024, props.L2_cache_size // 2)
+    persist_mb_actual = persist_bytes // (1024 * 1024)
+
+    cudart = _get_cudart()
+    if cudart is None:
+        print("[L2] CUDA runtime not found — L2 persistence unavailable")
+        return False
+
+    try:
+        result = cudart.cudaDeviceSetLimit(
+            ctypes.c_int(_CUDA_LIMIT_PERSISTING_L2_CACHE_SIZE),
+            ctypes.c_size_t(persist_bytes),
+        )
+        # CRITICAL: Always clear CUDA error state after ctypes calls.
+        # cudaDeviceSetLimit sets the thread-local CUDA error on failure, and
+        # PyTorch's C10_CUDA_KERNEL_LAUNCH_CHECK() reads it on the next kernel
+        # launch — causing a stale error to crash an unrelated operation.
+        cudart.cudaGetLastError()
+        if result != 0:
+            print(f"[L2] cudaDeviceSetLimit failed: error {result}")
+            return False
+
+        print(
+            f"[L2] Reserved {persist_mb_actual}MB of {l2_total_mb}MB L2 for persisting cache "
+            f"(compute {major}.{minor}, {props.name})"
+        )
+        return True
+
+    except (OSError, ctypes.ArgumentError, AttributeError) as e:
+        print(f"[L2] L2 reservation failed: {e}")
+        return False
+
+
+# =============================================================================
+# Tier 2: Per-Tensor Access Policy (stream attribute window)
+# =============================================================================
+
+
+def set_tensor_persisting(tensor: torch.Tensor, hit_ratio: float = 1.0) -> bool:
+    """
+    Mark a tensor's memory region as L2-persistent.
+
+    Uses cudaStreamSetAttribute with cudaAccessPolicyWindow to request that
+    `hit_ratio` fraction of the tensor's data stays in the L2 persisting region.
+
+    Args:
+        tensor: CUDA tensor whose weights should persist in L2.
+        hit_ratio: Fraction [0, 1] of accesses to serve from persisting cache.
+                   1.0 = always try to keep in L2 (good for weights).
+
+    Returns:
+        True if successful.
+    """
+    if not tensor.is_cuda or not tensor.is_contiguous():
+        return False
+
+    cudart = _get_cudart()
+    if cudart is None:
+        return False
+
+    try:
+        stream_ptr = torch.cuda.current_stream().cuda_stream
+
+        window = _CudaAccessPolicyWindow(
+            base_ptr=ctypes.c_void_p(tensor.data_ptr()),
+            num_bytes=ctypes.c_size_t(tensor.nbytes),
+            hitRatio=ctypes.c_float(hit_ratio),
+            hitProp=ctypes.c_int(_CUDA_ACCESS_PROPERTY_PERSISTING),
+            missProp=ctypes.c_int(_CUDA_ACCESS_PROPERTY_STREAMING),
+        )
+
+        result = cudart.cudaStreamSetAttribute(
+            ctypes.c_void_p(stream_ptr),
+            ctypes.c_int(_CUDA_STREAM_ATTRIBUTE_ACCESS_POLICY_WINDOW),
+            ctypes.byref(window),
+        )
+        cudart.cudaGetLastError()  # Clear any stale CUDA error from ctypes call
+        return result == 0
+
+    except (RuntimeError, OSError, ctypes.ArgumentError, AttributeError):
+        return False
+
+
+def clear_tensor_persisting(tensor: torch.Tensor) -> bool:
+    """
+    Remove L2 persistence policy for a tensor (reset to normal access).
+
+    Call when a tensor is no longer hot (e.g., model unload) to release
+    the L2 persisting budget for other tensors.
+    """
+    if not tensor.is_cuda:
+        return False
+
+    cudart = _get_cudart()
+    if cudart is None:
+        return False
+
+    try:
+        stream_ptr = torch.cuda.current_stream().cuda_stream
+        window = _CudaAccessPolicyWindow(
+            base_ptr=ctypes.c_void_p(tensor.data_ptr()),
+            num_bytes=ctypes.c_size_t(0),
+            hitRatio=ctypes.c_float(0.0),
+            hitProp=ctypes.c_int(_CUDA_ACCESS_PROPERTY_NORMAL),
+            missProp=ctypes.c_int(_CUDA_ACCESS_PROPERTY_STREAMING),
+        )
+        result = cudart.cudaStreamSetAttribute(
+            ctypes.c_void_p(stream_ptr),
+            ctypes.c_int(_CUDA_STREAM_ATTRIBUTE_ACCESS_POLICY_WINDOW),
+            ctypes.byref(window),
+        )
+        cudart.cudaGetLastError()  # Clear any stale CUDA error from ctypes call
+        return result == 0
+    except (RuntimeError, OSError, ctypes.ArgumentError, AttributeError):
+        return False
+
+
+# =============================================================================
+# High-Level: Pin Hot UNet Layer Weights
+# =============================================================================
+
+
+def pin_hot_unet_weights(
+    unet: torch.nn.Module,
+    hot_prefixes: Optional[list] = None,
+    persist_mb: int = L2_PERSIST_MB,
+) -> int:
+    """
+    Mark hot UNet layer weights as L2-persistent.
+
+    Identifies attention Q/K/V/out projection weights in the hottest layers
+    (mid_block, up_blocks.1) and requests they persist in L2 cache.
+
+    Args:
+        unet: The UNet model (already on CUDA).
+        hot_prefixes: Layer name prefixes to target. Defaults to mid_block + up_blocks.1.
+        persist_mb: MB of L2 to reserve (passed to reserve_l2_persisting_cache).
+
+    Returns:
+        Number of weight tensors successfully pinned.
+    """
+    if not L2_PERSIST_ENABLED:
+        return 0
+
+    if hot_prefixes is None:
+        hot_prefixes = _DEFAULT_HOT_LAYER_PREFIXES
+
+    # Tier 1: Reserve L2 persisting region
+    tier1_ok = reserve_l2_persisting_cache(persist_mb)
+    if not tier1_ok:
+        return 0
+
+    # Tier 2: Set access policy on hot attention weights
+    # Target: to_q, to_k, to_v, to_out weights in hot transformer blocks.
+    # These are small-to-medium GEMMs that benefit most from L2 hits.
+    _hot_weight_keywords = ["to_q", "to_k", "to_v", "to_out"]
+    pinned_count = 0
+    pinned_bytes = 0
+
+    for name, param in unet.named_parameters():
+        if not param.is_cuda:
+            continue
+        is_hot = any(prefix in name for prefix in hot_prefixes)
+        is_attn_weight = any(kw in name for kw in _hot_weight_keywords)
+        if is_hot and is_attn_weight:
+            if set_tensor_persisting(param.data):
+                pinned_count += 1
+                pinned_bytes += param.data.nbytes
+
+    if pinned_count > 0:
+        print(
+            f"[L2] Pinned {pinned_count} attention weight tensors "
+            f"({pinned_bytes / 1024 / 1024:.1f}MB) in L2 persisting cache"
+        )
+    else:
+        print(
+            "[L2] No tensors pinned (params may require_grad=True before compile — call after freeze)"
+        )
+
+    return pinned_count
+
+
+def setup_l2_persistence(unet: torch.nn.Module) -> bool:
+    """
+    Main entry point: set up L2 cache persistence for UNet inference.
+
+    Call this AFTER model is loaded and BEFORE torch.compile.
+    For best results with frozen weights, call AFTER torch.compile with freezing=True.
+
+    Args:
+        unet: The UNet model on CUDA.
+
+    Returns:
+        True if at least Tier 1 (L2 reservation) succeeded.
+    """
+    if not L2_PERSIST_ENABLED:
+        return False
+
+    print(
+        f"\n[L2] Setting up L2 cache persistence "
+        f"(SDTD_L2_PERSIST_MB={L2_PERSIST_MB})..."
+    )
+
+    # Tier 1 is the reliable baseline — always attempt
+    tier1_ok = reserve_l2_persisting_cache(L2_PERSIST_MB)
+
+    if tier1_ok:
+        # Tier 2: per-tensor access policy (best-effort)
+        pinned = pin_hot_unet_weights(unet, persist_mb=0)  # Tier 1 already reserved
+        if pinned == 0:
+            print(
+                "[L2] Tier 2 access policy skipped (call pin_hot_unet_weights() "
+                "after compile+freeze for per-tensor control)"
+            )
+
+    return tier1_ok

--- a/src/streamdiffusion/tools/install-tensorrt.py
+++ b/src/streamdiffusion/tools/install-tensorrt.py
@@ -36,6 +36,10 @@ def install(cu: Optional[Literal["11", "12"]] = get_cuda_major()):
     if platform.system() == "Windows" and not is_installed("triton"):
         run_pip("install triton-windows==3.4.0.post21")
 
+    # Pin onnx to IR 10 — onnxruntime-gpu 1.22 max supported IR version is 10
+    # (onnx 1.18+ exports IR 11/12 which breaks polygraphy constant folding)
+    run_pip("install onnx==1.17.0 --no-cache-dir")
+
     # FP8 quantization dependencies (CUDA 12 only)
     # nvidia-modelopt requires cupy; pin cupy 13.x + numpy<2 for mediapipe compat
     if cu == "12":

--- a/src/streamdiffusion/tools/install-tensorrt.py
+++ b/src/streamdiffusion/tools/install-tensorrt.py
@@ -1,10 +1,10 @@
+import platform
 from typing import Literal, Optional
 
 import fire
 from packaging.version import Version
 
-from ..pip_utils import is_installed, run_pip, version, get_cuda_major
-import platform
+from ..pip_utils import get_cuda_major, is_installed, run_pip, version
 
 
 def install(cu: Optional[Literal["11", "12"]] = get_cuda_major()):
@@ -20,28 +20,28 @@ def install(cu: Optional[Literal["11", "12"]] = get_cuda_major()):
 
     cudnn_package, trt_package = (
         ("nvidia-cudnn-cu12==9.7.1.26", "tensorrt==10.12.0.36")
-        if cu == "12" else
-        ("nvidia-cudnn-cu11==8.9.7.29", "tensorrt==9.0.1.post11.dev4")
+        if cu == "12"
+        else ("nvidia-cudnn-cu11==8.9.7.29", "tensorrt==9.0.1.post11.dev4")
     )
     if not is_installed(trt_package):
         run_pip(f"install {cudnn_package} --no-cache-dir")
         run_pip(f"install --extra-index-url https://pypi.nvidia.com {trt_package} --no-cache-dir")
 
     if not is_installed("polygraphy"):
-        run_pip(
-            "install polygraphy==0.49.24 --extra-index-url https://pypi.ngc.nvidia.com"
-        )
+        run_pip("install polygraphy==0.49.24 --extra-index-url https://pypi.ngc.nvidia.com")
     if not is_installed("onnx_graphsurgeon"):
+        run_pip("install onnx-graphsurgeon==0.5.8 --extra-index-url https://pypi.ngc.nvidia.com")
+    if platform.system() == "Windows" and not is_installed("pywin32"):
+        run_pip("install pywin32==306")
+    if platform.system() == "Windows" and not is_installed("triton"):
+        run_pip("install triton-windows==3.4.0.post21")
+
+    # FP8 quantization dependencies (CUDA 12 only)
+    # nvidia-modelopt requires cupy; pin cupy 13.x + numpy<2 for mediapipe compat
+    if cu == "12":
         run_pip(
-            "install onnx-graphsurgeon==0.5.8 --extra-index-url https://pypi.ngc.nvidia.com"
-        )
-    if platform.system() == 'Windows' and not is_installed("pywin32"):
-        run_pip(
-            "install pywin32==306"
-        )
-    if platform.system() == 'Windows' and not is_installed("triton"):
-        run_pip(
-            "install triton-windows==3.4.0.post21"
+            'install "nvidia-modelopt[onnx]" "cupy-cuda12x==13.6.0" "numpy==1.26.4"'
+            " --no-cache-dir"
         )
 
 

--- a/src/streamdiffusion/tools/install-tensorrt.py
+++ b/src/streamdiffusion/tools/install-tensorrt.py
@@ -28,11 +28,11 @@ def install(cu: Optional[Literal["11", "12"]] = get_cuda_major()):
         run_pip(f"install --extra-index-url https://pypi.nvidia.com {trt_package} --no-cache-dir")
 
     if not is_installed("polygraphy"):
-        run_pip("install polygraphy==0.49.24 --extra-index-url https://pypi.ngc.nvidia.com")
+        run_pip("install polygraphy==0.49.26 --extra-index-url https://pypi.ngc.nvidia.com")
     if not is_installed("onnx_graphsurgeon"):
         run_pip("install onnx-graphsurgeon==0.5.8 --extra-index-url https://pypi.ngc.nvidia.com")
     if platform.system() == "Windows" and not is_installed("pywin32"):
-        run_pip("install pywin32==306")
+        run_pip("install pywin32==311")
     if platform.system() == "Windows" and not is_installed("triton"):
         run_pip("install triton-windows==3.4.0.post21")
 

--- a/src/streamdiffusion/tools/install-tensorrt.py
+++ b/src/streamdiffusion/tools/install-tensorrt.py
@@ -36,9 +36,11 @@ def install(cu: Optional[Literal["11", "12"]] = get_cuda_major()):
     if platform.system() == "Windows" and not is_installed("triton"):
         run_pip("install triton-windows==3.4.0.post21")
 
-    # Pin onnx to IR 10 — onnxruntime-gpu 1.22 max supported IR version is 10
-    # (onnx 1.18+ exports IR 11/12 which breaks polygraphy constant folding)
-    run_pip("install onnx==1.17.0 --no-cache-dir")
+    # Pin onnx 1.18 + onnxruntime-gpu 1.24 together:
+    #   - onnx 1.18 exports IR 11; modelopt needs FLOAT4E2M1 added in 1.18
+    #   - onnx 1.19+ exports IR 12 (ORT 1.24 max) and removes float32_to_bfloat16 (onnx-gs needs it)
+    #   - onnxruntime-gpu 1.24 supports IR 11; never co-install CPU onnxruntime (shared files conflict)
+    run_pip("install onnx==1.18.0 onnxruntime-gpu==1.24.3 --no-cache-dir")
 
     # FP8 quantization dependencies (CUDA 12 only)
     # nvidia-modelopt requires cupy; pin cupy 13.x + numpy<2 for mediapipe compat

--- a/src/streamdiffusion/utils/__init__.py
+++ b/src/streamdiffusion/utils/__init__.py
@@ -1,5 +1,6 @@
 from .reporting import report_error
 
+
 __all__ = [
     "report_error",
 ]

--- a/src/streamdiffusion/utils/reporting.py
+++ b/src/streamdiffusion/utils/reporting.py
@@ -25,5 +25,3 @@ def report_error(
         stacklevel=stacklevel,
         extra={"report_error": True},
     )
-
-

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -1542,74 +1542,90 @@ class StreamDiffusionWrapper:
                 
                 # CRITICAL: Install IPAdapter module BEFORE TensorRT compilation to ensure processors are baked into engines
                 if use_ipadapter and ipadapter_config and not hasattr(stream, '_ipadapter_module'):
-                    try:
-                        from streamdiffusion.modules.ipadapter_module import IPAdapterModule, IPAdapterConfig, IPAdapterType
-                        logger.info("Installing IPAdapter module before TensorRT compilation...")
-
-                        # Snapshot processors before install — IPAdapter.set_ip_adapter() replaces them
-                        # before load_state_dict(), so a failure leaves the UNet in corrupted state
-                        _saved_unet_processors = {name: proc for name, proc in stream.unet.attn_processors.items()}
-
-                        # Use first config if list provided
-                        cfg = ipadapter_config[0] if isinstance(ipadapter_config, list) else ipadapter_config
-                        ip_cfg = IPAdapterConfig(
-                            style_image_key=cfg.get('style_image_key') or 'ipadapter_main',
-                            num_image_tokens=cfg.get('num_image_tokens', 4),
-                            ipadapter_model_path=cfg['ipadapter_model_path'],
-                            image_encoder_path=cfg['image_encoder_path'],
-                            style_image=cfg.get('style_image'),
-                            scale=cfg.get('scale', 1.0),
-                            type=IPAdapterType(cfg.get('type', "regular")),
-                            insightface_model_name=cfg.get('insightface_model_name'),
+                    # Check if auto-resolution disabled IP-Adapter (e.g. no adapter released for this arch)
+                    _cfg_check = ipadapter_config[0] if isinstance(ipadapter_config, list) else ipadapter_config
+                    if _cfg_check.get('enabled', True) is False:
+                        logger.info(
+                            "IP-Adapter disabled by auto-resolution (no compatible adapter for this model). Skipping."
                         )
-                        ip_module = IPAdapterModule(ip_cfg)
-                        ip_module.install(stream)
-                        # Expose for later updates
-                        stream._ipadapter_module = ip_module
-                        logger.info("IPAdapter module installed successfully before TensorRT compilation")
-                        
-                        # Cleanup after IPAdapter installation
-                        import gc
-                        gc.collect()
-                        torch.cuda.empty_cache()
-                        torch.cuda.synchronize()
-                        
-                    except torch.cuda.OutOfMemoryError as oom_error:
-                        logger.error(f"CUDA Out of Memory during early IPAdapter installation: {oom_error}")
-                        logger.error("Try reducing batch size, using smaller models, or increasing GPU memory")
-                        raise RuntimeError("Insufficient VRAM for IPAdapter installation. Consider using a GPU with more memory or reducing model complexity.")
+                        use_ipadapter_trt = False
+                    else:
+                        try:
+                            from streamdiffusion.modules.ipadapter_module import IPAdapterModule, IPAdapterConfig, IPAdapterType
+                            logger.info("Installing IPAdapter module before TensorRT compilation...")
 
-                    except RuntimeError as rt_error:
-                        if "size mismatch" in str(rt_error):
-                            unet_dim = getattr(getattr(stream, 'unet', None), 'config', None)
-                            unet_cross_attn = getattr(unet_dim, 'cross_attention_dim', 'unknown') if unet_dim else 'unknown'
-                            logger.warning(
-                                f"IP-Adapter weights are incompatible with this model "
-                                f"(UNet cross_attention_dim={unet_cross_attn}). "
-                                f"Checkpoint dimension does not match — this may be a custom model path "
-                                f"that could not be auto-resolved. "
-                                f"Check ipadapter_model_path in td_config.yaml. "
-                                f"Skipping IP-Adapter and continuing without it."
+                            # Snapshot processors before install — IPAdapter.set_ip_adapter() replaces them
+                            # before load_state_dict(), so a failure leaves the UNet in corrupted state
+                            _saved_unet_processors = {name: proc for name, proc in stream.unet.attn_processors.items()}
+
+                            # Use first config if list provided
+                            cfg = ipadapter_config[0] if isinstance(ipadapter_config, list) else ipadapter_config
+                            ip_cfg = IPAdapterConfig(
+                                style_image_key=cfg.get('style_image_key') or 'ipadapter_main',
+                                num_image_tokens=cfg.get('num_image_tokens', 4),
+                                ipadapter_model_path=cfg['ipadapter_model_path'],
+                                image_encoder_path=cfg['image_encoder_path'],
+                                style_image=cfg.get('style_image'),
+                                scale=cfg.get('scale', 1.0),
+                                type=IPAdapterType(cfg.get('type', "regular")),
+                                insightface_model_name=cfg.get('insightface_model_name'),
                             )
-                            # Restore original processors — IPAdapter.set_ip_adapter() already replaced
-                            # them before load_state_dict() failed, leaving the UNet in a corrupted state
+                            ip_module = IPAdapterModule(ip_cfg)
+                            ip_module.install(stream)
+                            # Expose for later updates
+                            stream._ipadapter_module = ip_module
+                            logger.info("IPAdapter module installed successfully before TensorRT compilation")
+
+                            # Cleanup after IPAdapter installation
+                            import gc
+                            gc.collect()
+                            torch.cuda.empty_cache()
+                            torch.cuda.synchronize()
+
+                        except torch.cuda.OutOfMemoryError as oom_error:
+                            logger.error(f"CUDA Out of Memory during early IPAdapter installation: {oom_error}")
+                            logger.error("Try reducing batch size, using smaller models, or increasing GPU memory")
+                            raise RuntimeError("Insufficient VRAM for IPAdapter installation. Consider using a GPU with more memory or reducing model complexity.")
+
+                        except RuntimeError as rt_error:
+                            if "size mismatch" in str(rt_error):
+                                unet_dim = getattr(getattr(stream, 'unet', None), 'config', None)
+                                unet_cross_attn = getattr(unet_dim, 'cross_attention_dim', 'unknown') if unet_dim else 'unknown'
+                                logger.warning(
+                                    f"IP-Adapter weights are incompatible with this model "
+                                    f"(UNet cross_attention_dim={unet_cross_attn}). "
+                                    f"Checkpoint dimension does not match — this may be a custom model path "
+                                    f"that could not be auto-resolved. "
+                                    f"Check ipadapter_model_path in td_config.yaml. "
+                                    f"Skipping IP-Adapter and continuing without it."
+                                )
+                                # Restore original processors — IPAdapter.set_ip_adapter() already replaced
+                                # them before load_state_dict() failed, leaving the UNet in a corrupted state
+                                try:
+                                    stream.unet.set_attn_processor(_saved_unet_processors)
+                                    logger.info("Restored original UNet attention processors after IP-Adapter failure.")
+                                except Exception as restore_err:
+                                    logger.warning(f"Could not restore UNet processors: {restore_err}")
+                                use_ipadapter_trt = False
+                            else:
+                                import traceback
+                                traceback.print_exc()
+                                logger.error("Failed to install IPAdapterModule before TensorRT compilation")
+                                raise
+
+                        except Exception as e:
+                            import traceback
+                            traceback.print_exc()
+                            logger.warning(
+                                f"Failed to install IPAdapterModule: {e}. "
+                                f"Continuing without IP-Adapter."
+                            )
                             try:
                                 stream.unet.set_attn_processor(_saved_unet_processors)
                                 logger.info("Restored original UNet attention processors after IP-Adapter failure.")
                             except Exception as restore_err:
                                 logger.warning(f"Could not restore UNet processors: {restore_err}")
                             use_ipadapter_trt = False
-                        else:
-                            import traceback
-                            traceback.print_exc()
-                            logger.error("Failed to install IPAdapterModule before TensorRT compilation")
-                            raise
-
-                    except Exception:
-                        import traceback
-                        traceback.print_exc()
-                        logger.error("Failed to install IPAdapterModule before TensorRT compilation")
-                        raise
 
                 # NOTE: When IPAdapter is enabled, we must pass num_ip_layers. We cannot know it until after
                 # installing processors in the export wrapper. We construct the wrapper first to discover it,

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -1510,6 +1510,7 @@ class StreamDiffusionWrapper:
                     use_cached_attn=use_cached_attn,
                     use_controlnet=use_controlnet_trt,
                     fp8=fp8,
+                    resolution=(self.height, self.width),
                 )
                 vae_encoder_path = engine_manager.get_engine_path(
                     EngineType.VAE_ENCODER,
@@ -1522,6 +1523,7 @@ class StreamDiffusionWrapper:
                     ipadapter_scale=ipadapter_scale,
                     ipadapter_tokens=ipadapter_tokens,
                     is_faceid=is_faceid if use_ipadapter_trt else None,
+                    resolution=(self.height, self.width),
                 )
                 vae_decoder_path = engine_manager.get_engine_path(
                     EngineType.VAE_DECODER,
@@ -1534,6 +1536,7 @@ class StreamDiffusionWrapper:
                     ipadapter_scale=ipadapter_scale,
                     ipadapter_tokens=ipadapter_tokens,
                     is_faceid=is_faceid if use_ipadapter_trt else None,
+                    resolution=(self.height, self.width),
                 )
 
                 # Check if all required engines exist
@@ -1786,10 +1789,7 @@ class StreamDiffusionWrapper:
                     engine_build_options={
                         "opt_image_height": self.height,
                         "opt_image_width": self.width,
-                        "build_dynamic_shape": True,
-                        "min_image_resolution": 384,
-                        "max_image_resolution": 1024,
-                        "build_all_tactics": True,
+                        "build_dynamic_shape": False,
                     },
                 )
 
@@ -1812,10 +1812,7 @@ class StreamDiffusionWrapper:
                     engine_build_options={
                         "opt_image_height": self.height,
                         "opt_image_width": self.width,
-                        "build_dynamic_shape": True,
-                        "min_image_resolution": 384,
-                        "max_image_resolution": 1024,
-                        "build_all_tactics": True,
+                        "build_dynamic_shape": False,
                     },
                 )
 
@@ -1830,7 +1827,7 @@ class StreamDiffusionWrapper:
                     _unet_build_opts = {
                         "opt_image_height": self.height,
                         "opt_image_width": self.width,
-                        "build_all_tactics": True,
+                        "build_dynamic_shape": False,
                     }
                     if fp8:
                         from streamdiffusion.acceleration.tensorrt.fp8_quantize import (

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -1,17 +1,18 @@
+import logging
 import os
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Union, Any, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
-import torch
 import numpy as np
+import torch
+from diffusers import AutoencoderTiny, AutoPipelineForText2Image, StableDiffusionPipeline, StableDiffusionXLPipeline
 from PIL import Image
-from diffusers import AutoencoderTiny, StableDiffusionPipeline, StableDiffusionXLPipeline, AutoPipelineForText2Image
 
-from .pipeline import StreamDiffusion
-from .model_detection import detect_model
 from .image_utils import postprocess_image
+from .model_detection import detect_model
+from .pipeline import StreamDiffusion
 
-import logging
+
 logger = logging.getLogger(__name__)
 
 torch.set_grad_enabled(False)
@@ -66,6 +67,7 @@ class StreamDiffusionWrapper:
     - Use get_cache_info() to inspect cache statistics
     - Use clear_caches() to free memory
     """
+
     def __init__(
         self,
         model_id_or_path: str,
@@ -122,6 +124,7 @@ class StreamDiffusionWrapper:
         cache_interval: int = 1,
         min_cache_maxframes: int = 1,
         max_cache_maxframes: int = 4,
+        fp8: bool = False,
     ):
         """
         Initializes the StreamDiffusionWrapper.
@@ -243,7 +246,7 @@ class StreamDiffusionWrapper:
         """
         if compile_engines_only:
             logger.info("compile_engines_only is True, will only compile engines and not load the model")
-        
+
         # Store use_lcm_lora for backwards compatibility processing in _load_model
         self.use_lcm_lora = use_lcm_lora
 
@@ -251,7 +254,7 @@ class StreamDiffusionWrapper:
         self.use_controlnet = use_controlnet
         self.use_ipadapter = use_ipadapter
         self.ipadapter_config = ipadapter_config
-        
+
         # Store pipeline hook configurations
         self.image_preprocessing_config = image_preprocessing_config
         self.image_postprocessing_config = image_postprocessing_config
@@ -260,20 +263,14 @@ class StreamDiffusionWrapper:
 
         if mode == "txt2img":
             if cfg_type != "none":
-                raise ValueError(
-                    f"txt2img mode accepts only cfg_type = 'none', but got {cfg_type}"
-                )
+                raise ValueError(f"txt2img mode accepts only cfg_type = 'none', but got {cfg_type}")
             if use_denoising_batch and frame_buffer_size > 1:
                 if not self.sd_turbo:
-                    raise ValueError(
-                        "txt2img mode cannot use denoising batch with frame_buffer_size > 1."
-                    )
+                    raise ValueError("txt2img mode cannot use denoising batch with frame_buffer_size > 1.")
 
         if mode == "img2img":
             if not use_denoising_batch:
-                raise NotImplementedError(
-                    "img2img mode must use denoising batch for now."
-                )
+                raise NotImplementedError("img2img mode must use denoising batch for now.")
 
         self.device = device
         self.dtype = dtype
@@ -282,11 +279,7 @@ class StreamDiffusionWrapper:
         self.mode = mode
         self.output_type = output_type
         self.frame_buffer_size = frame_buffer_size
-        self.batch_size = (
-            len(t_index_list) * frame_buffer_size
-            if use_denoising_batch
-            else frame_buffer_size
-        )
+        self.batch_size = len(t_index_list) * frame_buffer_size if use_denoising_batch else frame_buffer_size
         self.min_batch_size = min_batch_size
         self.max_batch_size = max_batch_size
 
@@ -296,6 +289,7 @@ class StreamDiffusionWrapper:
         self.set_nsfw_fallback_img(height, width)
         self.safety_checker_fallback_type = safety_checker_fallback_type
         self.safety_checker_threshold = safety_checker_threshold
+        self.fp8 = fp8
 
         self.stream: StreamDiffusion = self._load_model(
             model_id_or_path=model_id_or_path,
@@ -304,7 +298,7 @@ class StreamDiffusionWrapper:
             t_index_list=t_index_list,
             acceleration=acceleration,
             do_add_noise=do_add_noise,
-            use_lcm_lora=use_lcm_lora, # Deprecated:Backwards compatibility
+            use_lcm_lora=use_lcm_lora,  # Deprecated:Backwards compatibility
             use_tiny_vae=use_tiny_vae,
             cfg_type=cfg_type,
             engine_dir=engine_dir,
@@ -328,6 +322,7 @@ class StreamDiffusionWrapper:
             cache_interval=cache_interval,
             min_cache_maxframes=min_cache_maxframes,
             max_cache_maxframes=max_cache_maxframes,
+            fp8=fp8,
         )
 
         # Store skip_diffusion on wrapper for execution flow control
@@ -343,9 +338,7 @@ class StreamDiffusionWrapper:
             "",
             "",
             num_inference_steps=50,
-            guidance_scale=1.1
-            if self.stream.cfg_type in ["full", "self", "initialize"]
-            else 1.0,
+            guidance_scale=1.1 if self.stream.cfg_type in ["full", "self", "initialize"] else 1.0,
             generator=torch.manual_seed(seed),
             seed=seed,
         )
@@ -363,9 +356,7 @@ class StreamDiffusionWrapper:
         self._engine_dir = engine_dir
 
         if device_ids is not None:
-            self.stream.unet = torch.nn.DataParallel(
-                self.stream.unet, device_ids=device_ids
-            )
+            self.stream.unet = torch.nn.DataParallel(self.stream.unet, device_ids=device_ids)
 
         if enable_similar_image_filter:
             self.stream.enable_similar_image_filter(
@@ -413,7 +404,6 @@ class StreamDiffusionWrapper:
         seed_interpolation_method : Literal["linear", "slerp"], optional
             Method for interpolating between seed noise tensors, by default "linear".
         """
-
 
         # Handle both single prompt and prompt blending
         if isinstance(prompt, str):
@@ -500,7 +490,7 @@ class StreamDiffusionWrapper:
         negative_prompt: str = "",
         prompt_interpolation_method: Literal["linear", "slerp"] = "slerp",
         clear_blending: bool = True,
-        warn_about_conflicts: bool = True
+        warn_about_conflicts: bool = True,
     ) -> None:
         """
         Update to a new prompt or prompt blending configuration.
@@ -631,8 +621,8 @@ class StreamDiffusionWrapper:
             When False, weights > 1 will amplify noise.
         controlnet_config : Optional[List[Dict[str, Any]]]
             Complete ControlNet configuration list defining the desired state.
-            Each dict contains: model_id, preprocessor, conditioning_scale, enabled, 
-            preprocessor_params, etc. System will diff current vs desired state and 
+            Each dict contains: model_id, preprocessor, conditioning_scale, enabled,
+            preprocessor_params, etc. System will diff current vs desired state and
             perform minimal add/remove/update operations.
         ipadapter_config : Optional[Dict[str, Any]]
             IPAdapter configuration dict containing scale, style_image, etc.
@@ -699,45 +689,44 @@ class StreamDiffusionWrapper:
         """
         if self.skip_diffusion:
             return self._process_skip_diffusion(image, prompt)
-        
+
         if self.mode == "img2img":
             return self.img2img(image, prompt)
         else:
             return self.txt2img(prompt)
 
     def _process_skip_diffusion(
-        self, 
-        image: Optional[Union[str, Image.Image, torch.Tensor]] = None, 
-        prompt: Optional[str] = None
+        self, image: Optional[Union[str, Image.Image, torch.Tensor]] = None, prompt: Optional[str] = None
     ) -> Union[Image.Image, List[Image.Image], torch.Tensor, np.ndarray]:
         """
         Process input directly without diffusion, applying pre/post processing hooks.
-        
+
         This method bypasses VAE encoding, diffusion, and VAE decoding, but still
         applies image preprocessing and postprocessing hooks for consistent processing.
-        
+
         Parameters
         ----------
         image : Optional[Union[str, Image.Image, torch.Tensor]]
             The image to process directly.
         prompt : Optional[str]
             Prompt (ignored in skip mode, but kept for API consistency).
-            
+
         Returns
         -------
         Union[Image.Image, List[Image.Image], torch.Tensor, np.ndarray]
             The processed image with hooks applied.
         """
 
-        #TODO: add safety checker call somewhere in this method
-
+        # TODO: add safety checker call somewhere in this method
 
         if self.mode == "txt2img":
-            raise RuntimeError("_process_skip_diffusion: skip_diffusion mode not applicable for txt2img - no input image")
-        
+            raise RuntimeError(
+                "_process_skip_diffusion: skip_diffusion mode not applicable for txt2img - no input image"
+            )
+
         if image is None:
             raise ValueError("_process_skip_diffusion: image required for skip diffusion mode")
-        
+
         # Handle input tensor normalization to [-1,1] pipeline range
         if isinstance(image, str) or isinstance(image, Image.Image):
             processed_tensor = self.preprocess_image(image)
@@ -749,19 +738,17 @@ class StreamDiffusionWrapper:
             preprocessor_input = image
 
         preprocessor_output = self.stream._apply_image_preprocessing_hooks(preprocessor_input)
-        
+
         # Convert [0,1] -> [-1,1] back to pipeline range for postprocessing hooks
         processed_tensor = self._normalize_on_gpu(preprocessor_output)
-        
+
         # Apply image postprocessing hooks (expect [-1,1] range - post-VAE decoding)
         processed_tensor = self.stream._apply_image_postprocessing_hooks(processed_tensor)
-        
+
         # Final postprocessing for output format
         return self.postprocess_image(processed_tensor, output_type=self.output_type)
 
-    def txt2img(
-        self, prompt: Optional[str] = None
-    ) -> Union[Image.Image, List[Image.Image], torch.Tensor, np.ndarray]:
+    def txt2img(self, prompt: Optional[str] = None) -> Union[Image.Image, List[Image.Image], torch.Tensor, np.ndarray]:
         """
         Performs txt2img.
 
@@ -778,12 +765,12 @@ class StreamDiffusionWrapper:
         """
         if prompt is not None:
             self.update_prompt(prompt, warn_about_conflicts=True)
-        
+
         if self.sd_turbo:
             image_tensor = self.stream.txt2img_sd_turbo(self.batch_size)
         else:
             image_tensor = self.stream.txt2img(self.frame_buffer_size)
-        
+
         image = self.postprocess_image(image_tensor, output_type=self.output_type)
 
         if self.use_safety_checker:
@@ -856,15 +843,15 @@ class StreamDiffusionWrapper:
         # Use stream's current resolution instead of wrapper's cached values
         current_width = self.stream.width
         current_height = self.stream.height
-        
+
         if isinstance(image, str):
             image = Image.open(image).convert("RGB").resize((current_width, current_height))
         if isinstance(image, Image.Image):
             image = image.convert("RGB").resize((current_width, current_height))
 
-        return self.stream.image_processor.preprocess(
-            image, current_height, current_width
-        ).to(device=self.device, dtype=self.dtype)
+        return self.stream.image_processor.preprocess(image, current_height, current_width).to(
+            device=self.device, dtype=self.dtype
+        )
 
     def postprocess_image(
         self, image_tensor: torch.Tensor, output_type: str = "pil"
@@ -893,14 +880,12 @@ class StreamDiffusionWrapper:
             denormalized = self._denormalize_on_gpu(image_tensor)
             return denormalized.cpu().permute(0, 2, 3, 1).float().numpy()
 
-
         # PIL output path (optimized)
         if output_type == "pil":
             if self.frame_buffer_size > 1:
                 return self._tensor_to_pil_optimized(image_tensor)
             else:
                 return self._tensor_to_pil_optimized(image_tensor)[0]
-
 
         # Fallback to original method for any unexpected output types
         if self.frame_buffer_size > 1:
@@ -965,27 +950,22 @@ class StreamDiffusionWrapper:
         # Denormalize on GPU first
         denormalized = self._denormalize_on_gpu(image_tensor)
 
-
         # Convert to uint8 on GPU to reduce transfer size
         # Scale to [0, 255] and convert to uint8
         # Scale to [0, 255] and convert to uint8
         uint8_tensor = (denormalized * 255).clamp(0, 255).to(torch.uint8)
 
-
         # Single efficient CPU transfer
         cpu_tensor = uint8_tensor.cpu()
-
 
         # Convert to HWC format for PIL
         # From BCHW to BHWC
         cpu_tensor = cpu_tensor.permute(0, 2, 3, 1)
 
-
         # Convert to PIL images efficiently
         pil_images = []
         for i in range(cpu_tensor.shape[0]):
             img_array = cpu_tensor[i].numpy()
-
 
             if img_array.shape[-1] == 1:
                 # Grayscale
@@ -993,7 +973,6 @@ class StreamDiffusionWrapper:
             else:
                 # RGB
                 pil_images.append(Image.fromarray(img_array))
-
 
         return pil_images
 
@@ -1054,6 +1033,7 @@ class StreamDiffusionWrapper:
         cache_interval: int = 1,
         min_cache_maxframes: int = 1,
         max_cache_maxframes: int = 4,
+        fp8: bool = False,
     ) -> StreamDiffusion:
         """
         Loads the model.
@@ -1149,7 +1129,7 @@ class StreamDiffusionWrapper:
             self.cleanup_gpu_memory()
         except Exception as e:
             logger.warning(f"GPU cleanup warning: {e}")
-        
+
         # Reset CUDA context to prevent corruption from previous runs
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
@@ -1162,14 +1142,14 @@ class StreamDiffusionWrapper:
         # TODO: CAN we do this step with model_detection.py?
         is_sdxl_model = False
         model_path_lower = model_id_or_path.lower()
-        
+
         # Check path for SDXL indicators
-        if any(indicator in model_path_lower for indicator in ['sdxl', 'xl', '1024']):
+        if any(indicator in model_path_lower for indicator in ["sdxl", "xl", "1024"]):
             is_sdxl_model = True
             logger.info(f"_load_model: Path suggests SDXL model: {model_id_or_path}")
-        
+
         # For .safetensor files, we need to be more careful about pipeline selection
-        if model_id_or_path.endswith('.safetensors'):
+        if model_id_or_path.endswith(".safetensors"):
             # For .safetensor files, try SDXL pipeline first if path suggests SDXL
             if is_sdxl_model:
                 loading_methods = [
@@ -1181,14 +1161,14 @@ class StreamDiffusionWrapper:
                 loading_methods = [
                     (AutoPipelineForText2Image.from_pretrained, "AutoPipeline from_pretrained"),
                     (StableDiffusionPipeline.from_single_file, "SD from_single_file"),
-                    (StableDiffusionXLPipeline.from_single_file, "SDXL from_single_file")
+                    (StableDiffusionXLPipeline.from_single_file, "SDXL from_single_file"),
                 ]
         else:
             # For regular model directories or checkpoints, use the original order
             loading_methods = [
                 (AutoPipelineForText2Image.from_pretrained, "AutoPipeline from_pretrained"),
                 (StableDiffusionPipeline.from_single_file, "SD from_single_file"),
-                (StableDiffusionXLPipeline.from_single_file, "SDXL from_single_file")
+                (StableDiffusionXLPipeline.from_single_file, "SDXL from_single_file"),
             ]
 
         pipe = None
@@ -1198,19 +1178,19 @@ class StreamDiffusionWrapper:
                 logger.info(f"_load_model: Attempting to load with {method_name}...")
                 pipe = method(model_id_or_path).to(dtype=self.dtype)
                 logger.info(f"_load_model: Successfully loaded using {method_name}")
-                
+
                 # Verify that we have the right pipeline type for SDXL models
                 if is_sdxl_model and not isinstance(pipe, StableDiffusionXLPipeline):
                     logger.warning(f"_load_model: SDXL model detected but loaded with non-SDXL pipeline: {type(pipe)}")
                     # Try to explicitly load with SDXL pipeline instead
                     try:
-                        logger.info(f"_load_model: Retrying with StableDiffusionXLPipeline...")
+                        logger.info("_load_model: Retrying with StableDiffusionXLPipeline...")
                         pipe = StableDiffusionXLPipeline.from_single_file(model_id_or_path).to(dtype=self.dtype)
-                        logger.info(f"_load_model: Successfully loaded using SDXL pipeline on retry")
+                        logger.info("_load_model: Successfully loaded using SDXL pipeline on retry")
                     except Exception as retry_error:
                         logger.warning(f"_load_model: SDXL pipeline retry failed: {retry_error}")
                         # Continue with the originally loaded pipeline
-                
+
                 break
             except Exception as e:
                 logger.warning(f"_load_model: {method_name} failed: {e}")
@@ -1218,11 +1198,14 @@ class StreamDiffusionWrapper:
                 continue
 
         if pipe is None:
-            error_msg = f"_load_model: All loading methods failed for model '{model_id_or_path}'. Last error: {last_error}"
+            error_msg = (
+                f"_load_model: All loading methods failed for model '{model_id_or_path}'. Last error: {last_error}"
+            )
             logger.error(error_msg)
             if last_error:
                 logger.warning("Full traceback of last error:")
                 import traceback
+
                 traceback.print_exc()
             raise RuntimeError(error_msg)
         else:
@@ -1237,34 +1220,35 @@ class StreamDiffusionWrapper:
                 pipe.vae = pipe.vae.to(device=self.device)
 
         # If we get here, the model loaded successfully - break out of retry loop
-        logger.info(f"Model loading succeeded")
+        logger.info("Model loading succeeded")
 
         # Use comprehensive model detection instead of basic detection
         detection_result = detect_model(pipe.unet, pipe)
-        model_type = detection_result['model_type']
-        is_sdxl = detection_result['is_sdxl']
-        is_turbo = detection_result['is_turbo']
-        confidence = detection_result['confidence']
-        
+        model_type = detection_result["model_type"]
+        is_sdxl = detection_result["is_sdxl"]
+        is_turbo = detection_result["is_turbo"]
+        confidence = detection_result["confidence"]
+
         # Store comprehensive model info for later use (after TensorRT conversion)
         self._detected_model_type = model_type
         self._detection_confidence = confidence
         self._is_turbo = is_turbo
         self._is_sdxl = is_sdxl
-        
+
         logger.info(f"_load_model: Detected model type: {model_type} (confidence: {confidence:.2f})")
 
         # Auto-resolve IP-Adapter model/encoder paths for detected architecture.
         # Runs once here so both pre-TRT and post-TRT installation paths see the resolved cfg.
         if use_ipadapter and ipadapter_config:
             from streamdiffusion.modules.ipadapter_module import resolve_ipadapter_paths
+
             _ip_cfgs = ipadapter_config if isinstance(ipadapter_config, list) else [ipadapter_config]
             for _ip_cfg in _ip_cfgs:
                 resolve_ipadapter_paths(_ip_cfg, model_type, is_sdxl)
 
         # DEPRECATED: THIS WILL LOAD LCM_LORA IF USE_LCM_LORA IS TRUE
         # Validate backwards compatibility LCM LoRA selection using proper model detection
-        if hasattr(self, 'use_lcm_lora') and self.use_lcm_lora is not None:
+        if hasattr(self, "use_lcm_lora") and self.use_lcm_lora is not None:
             if self.use_lcm_lora and not self.sd_turbo:
                 if lora_dict is None:
                     lora_dict = {}
@@ -1279,11 +1263,13 @@ class StreamDiffusionWrapper:
                 else:
                     logger.info(f"LCM LoRA {lcm_lora} already present in lora_dict with scale {lora_dict[lcm_lora]}")
             else:
-                logger.info(f"LCM LoRA will not be loaded because use_lcm_lora is {self.use_lcm_lora} and sd_turbo is {self.sd_turbo}")
+                logger.info(
+                    f"LCM LoRA will not be loaded because use_lcm_lora is {self.use_lcm_lora} and sd_turbo is {self.sd_turbo}"
+                )
 
                 # Remove use_lcm_lora from self
                 self.use_lcm_lora = None
-                logger.info(f"use_lcm_lora has been removed from self")
+                logger.info("use_lcm_lora has been removed from self")
 
         # Get kvo_cache_structure before stream init (needed for TRT export wrapper).
         # Actual cache tensors are created AFTER stream init so we can use
@@ -1291,6 +1277,7 @@ class StreamDiffusionWrapper:
         # (e.g. TCD sets trt_unet_batch_size = frame_buffer_size, not denoising_steps * frame_buffer_size).
         if use_cached_attn:
             from streamdiffusion.acceleration.tensorrt.models.utils import get_kvo_cache_info
+
             _, kvo_cache_structure, _ = get_kvo_cache_info(pipe.unet, self.height, self.width)
         else:
             kvo_cache_structure = []
@@ -1306,7 +1293,7 @@ class StreamDiffusionWrapper:
             frame_buffer_size=self.frame_buffer_size,
             use_denoising_batch=self.use_denoising_batch,
             cfg_type=cfg_type,
-            lora_dict=lora_dict, # We pass this to include loras in engine path names
+            lora_dict=lora_dict,  # We pass this to include loras in engine path names
             normalize_prompt_weights=normalize_prompt_weights,
             normalize_seed_weights=normalize_seed_weights,
             scheduler=scheduler,
@@ -1321,26 +1308,28 @@ class StreamDiffusionWrapper:
         # so this must happen after StreamDiffusion.__init__ to get the correct value.
         if use_cached_attn:
             from streamdiffusion.acceleration.tensorrt.models.utils import create_kvo_cache
-            kvo_cache, _ = create_kvo_cache(pipe.unet,
-                                            batch_size=stream.trt_unet_batch_size,
-                                            cache_maxframes=cache_maxframes,
-                                            height=self.height,
-                                            width=self.width,
-                                            device=self.device,
-                                            dtype=self.dtype)
+
+            kvo_cache, _ = create_kvo_cache(
+                pipe.unet,
+                batch_size=stream.trt_unet_batch_size,
+                cache_maxframes=cache_maxframes,
+                height=self.height,
+                width=self.width,
+                device=self.device,
+                dtype=self.dtype,
+            )
             stream.kvo_cache = kvo_cache
 
-        
         # Load and properly merge LoRA weights using the standard diffusers approach
         lora_adapters_to_merge = []
         lora_scales_to_merge = []
-        
+
         # Collect all LoRA adapters and their scales from lora_dict
         if lora_dict is not None:
             for i, (lora_name, lora_scale) in enumerate(lora_dict.items()):
                 adapter_name = f"custom_lora_{i}"
                 logger.info(f"_load_model: Loading LoRA '{lora_name}' with scale {lora_scale}")
-                
+
                 try:
                     # Load LoRA weights with unique adapter name
                     stream.pipe.load_lora_weights(lora_name, adapter_name=adapter_name)
@@ -1351,22 +1340,22 @@ class StreamDiffusionWrapper:
                     logger.error(f"Failed to load LoRA {lora_name}: {e}")
                     # Continue with other LoRAs even if one fails
                     continue
-        
+
         # Merge all LoRA adapters using the proper diffusers method
         if lora_adapters_to_merge:
             try:
                 for adapter_name, scale in zip(lora_adapters_to_merge, lora_scales_to_merge):
                     logger.info(f"Merging individual LoRA: {adapter_name} with scale {scale}")
                     stream.pipe.fuse_lora(lora_scale=scale, adapter_names=[adapter_name])
-                
+
                 # Clean up after individual merging
                 stream.pipe.unload_lora_weights()
                 logger.info("Successfully merged LoRAs individually")
-                
+
             except Exception as fallback_error:
                 logger.error(f"LoRA merging fallback also failed: {fallback_error}")
                 logger.warning("Continuing without LoRA merging - LoRAs may not be applied correctly")
-                
+
                 # Clean up any partial state
                 try:
                     stream.pipe.unload_lora_weights()
@@ -1390,20 +1379,22 @@ class StreamDiffusionWrapper:
                 stream.pipe.enable_xformers_memory_efficient_attention()
             if acceleration == "tensorrt":
                 from polygraphy import cuda
+
                 from streamdiffusion.acceleration.tensorrt import TorchVAEEncoder
-                from streamdiffusion.acceleration.tensorrt.runtime_engines.unet_engine import AutoencoderKLEngine, NSFWDetectorEngine
+                from streamdiffusion.acceleration.tensorrt.engine_manager import EngineManager, EngineType
                 from streamdiffusion.acceleration.tensorrt.models.models import (
                     VAE,
+                    NSFWDetector,
                     UNet,
                     VAEEncoder,
-                    NSFWDetector,
                 )
-                from streamdiffusion.acceleration.tensorrt.engine_manager import EngineManager, EngineType
+                from streamdiffusion.acceleration.tensorrt.runtime_engines.unet_engine import (
+                    AutoencoderKLEngine,
+                    NSFWDetectorEngine,
+                )
+
                 # Add ControlNet detection and support
-                from streamdiffusion.model_detection import (
-                    extract_unet_architecture,
-                    validate_architecture
-                )
+                from streamdiffusion.model_detection import extract_unet_architecture, validate_architecture
 
                 # Legacy TensorRT implementation (fallback)
                 # Initialize engine manager
@@ -1415,32 +1406,32 @@ class StreamDiffusionWrapper:
                 unet_arch = {}
                 is_sdxl_model = False
                 load_engine = not compile_engines_only
-                
+
                 # Use the explicit use_ipadapter parameter
                 has_ipadapter = use_ipadapter
-                
+
                 # Determine IP-Adapter presence and token count directly from config (no legacy pipeline)
                 if has_ipadapter and not ipadapter_config:
                     has_ipadapter = False
-                
+
                 try:
                     # Use model detection results already computed during model loading
-                    model_type = getattr(self, '_detected_model_type', 'SD15')
-                    is_sdxl = getattr(self, '_is_sdxl', False)
-                    is_turbo = getattr(self, '_is_turbo', False)
-                    confidence = getattr(self, '_detection_confidence', 0.0)
-                    
+                    model_type = getattr(self, "_detected_model_type", "SD15")
+                    is_sdxl = getattr(self, "_is_sdxl", False)
+                    is_turbo = getattr(self, "_is_turbo", False)
+                    confidence = getattr(self, "_detection_confidence", 0.0)
+
                     if is_sdxl:
                         logger.info(f"Building TensorRT engines for SDXL model: {model_type}")
                         logger.info(f"   Turbo variant: {is_turbo}")
                         logger.info(f"   Detection confidence: {confidence:.2f}")
                     else:
                         logger.info(f"Building TensorRT engines for {model_type}")
-                    
+
                     # Enable IPAdapter TensorRT if configured and available
                     if has_ipadapter:
                         use_ipadapter_trt = True
-                    
+
                     # Only enable ControlNet for legacy TensorRT if ControlNet is actually being used
                     if self.use_controlnet:
                         try:
@@ -1451,7 +1442,7 @@ class StreamDiffusionWrapper:
                         except Exception as e:
                             logger.warning(f"   ControlNet architecture detection failed: {e}")
                             use_controlnet_trt = False
-                    
+
                     # Set up architecture info for enabled modes
                     if use_controlnet_trt and not use_ipadapter_trt:
                         # ControlNet only: Full architecture needed
@@ -1470,28 +1461,28 @@ class StreamDiffusionWrapper:
                     else:
                         # Neither enabled: Standard UNet
                         unet_arch = {}
-                        
+
                 except Exception as e:
                     logger.error(f"Advanced model detection failed: {e}")
                     logger.error("   Falling back to basic TensorRT")
-                    
+
                     # Fallback to basic detection
                     try:
                         detection_result = detect_model(stream.unet, None)
-                        model_type = detection_result['model_type']
-                        is_sdxl = detection_result['is_sdxl']
+                        model_type = detection_result["model_type"]
+                        is_sdxl = detection_result["is_sdxl"]
                         if self.use_controlnet:
                             unet_arch = extract_unet_architecture(stream.unet)
                             unet_arch = validate_architecture(unet_arch, model_type)
                             use_controlnet_trt = True
                     except Exception:
                         pass
-                
+
                 if not use_controlnet_trt and not self.use_controlnet:
                     logger.info("ControlNet not enabled, building engines without ControlNet support")
 
                 # Use the engine_dir parameter passed to this function, with fallback to instance variable
-                engine_dir = engine_dir if engine_dir else getattr(self, '_engine_dir', 'engines')
+                engine_dir = engine_dir if engine_dir else getattr(self, "_engine_dir", "engines")
 
                 # Resolve IP-Adapter runtime params from config
                 # Strength is now a runtime input, so we do NOT bake scale into engine identity
@@ -1500,9 +1491,9 @@ class StreamDiffusionWrapper:
                 if use_ipadapter_trt and has_ipadapter and ipadapter_config:
                     cfg0 = ipadapter_config[0] if isinstance(ipadapter_config, list) else ipadapter_config
                     # scale omitted from engine naming; runtime will pass ipadapter_scale vector
-                    ipadapter_tokens = cfg0.get('num_image_tokens', 4)
+                    ipadapter_tokens = cfg0.get("num_image_tokens", 4)
                     # Determine FaceID type from config for engine naming
-                    is_faceid = (cfg0['type'] == 'faceid')
+                    is_faceid = cfg0["type"] == "faceid"
                 # Generate engine paths using EngineManager
                 unet_path = engine_manager.get_engine_path(
                     EngineType.UNET,
@@ -1517,6 +1508,7 @@ class StreamDiffusionWrapper:
                     is_faceid=is_faceid if use_ipadapter_trt else None,
                     use_cached_attn=use_cached_attn,
                     use_controlnet=use_controlnet_trt,
+                    fp8=fp8,
                 )
                 vae_encoder_path = engine_manager.get_engine_path(
                     EngineType.VAE_ENCODER,
@@ -1528,7 +1520,7 @@ class StreamDiffusionWrapper:
                     lora_dict=lora_dict,
                     ipadapter_scale=ipadapter_scale,
                     ipadapter_tokens=ipadapter_tokens,
-                    is_faceid=is_faceid if use_ipadapter_trt else None
+                    is_faceid=is_faceid if use_ipadapter_trt else None,
                 )
                 vae_decoder_path = engine_manager.get_engine_path(
                     EngineType.VAE_DECODER,
@@ -1540,7 +1532,7 @@ class StreamDiffusionWrapper:
                     lora_dict=lora_dict,
                     ipadapter_scale=ipadapter_scale,
                     ipadapter_tokens=ipadapter_tokens,
-                    is_faceid=is_faceid if use_ipadapter_trt else None
+                    is_faceid=is_faceid if use_ipadapter_trt else None,
                 )
 
                 # Check if all required engines exist
@@ -1554,14 +1546,16 @@ class StreamDiffusionWrapper:
 
                 if missing_engines:
                     if build_engines_if_missing:
-                        logger.info(f"Missing TensorRT engines, building them...")
+                        logger.info("Missing TensorRT engines, building them...")
                         for engine in missing_engines:
                             logger.info(f"  - {engine}")
                     else:
-                        error_msg = f"Required TensorRT engines are missing and build_engines_if_missing=False:\n"
+                        error_msg = "Required TensorRT engines are missing and build_engines_if_missing=False:\n"
                         for engine in missing_engines:
                             error_msg += f"  - {engine}\n"
-                        error_msg += f"\nTo build engines, set build_engines_if_missing=True or run the build script manually."
+                        error_msg += (
+                            "\nTo build engines, set build_engines_if_missing=True or run the build script manually."
+                        )
                         raise RuntimeError(error_msg)
 
                 # Determine correct embedding dimension based on model type
@@ -1577,32 +1571,41 @@ class StreamDiffusionWrapper:
                 # Gather parameters for unified wrapper - validate IPAdapter first for consistent token count
                 control_input_names = None
                 num_tokens = 4  # Default for non-IPAdapter mode
-                
+
                 if use_ipadapter_trt:
                     # Use token count resolved from configuration (default to 4)
                     num_tokens = ipadapter_tokens if isinstance(ipadapter_tokens, int) else 4
 
                 # Compile UNet engine using EngineManager
-                logger.info(f"compile_and_load_engine: Compiling UNet engine for image size: {self.width}x{self.height}")
+                logger.info(
+                    f"compile_and_load_engine: Compiling UNet engine for image size: {self.width}x{self.height}"
+                )
                 try:
-                    logger.debug(f"compile_and_load_engine: use_ipadapter_trt={use_ipadapter_trt}, num_ip_layers={num_ip_layers}, tokens={num_tokens}")
+                    logger.debug(
+                        f"compile_and_load_engine: use_ipadapter_trt={use_ipadapter_trt}, num_ip_layers={num_ip_layers}, tokens={num_tokens}"
+                    )
                 except Exception:
                     pass
-                
+
                 # Note: LoRA weights have already been merged permanently during model loading
-                
+
                 # CRITICAL: Install IPAdapter module BEFORE TensorRT compilation to ensure processors are baked into engines
-                if use_ipadapter and ipadapter_config and not hasattr(stream, '_ipadapter_module'):
+                if use_ipadapter and ipadapter_config and not hasattr(stream, "_ipadapter_module"):
                     # Check if auto-resolution disabled IP-Adapter (e.g. no adapter released for this arch)
                     _cfg_check = ipadapter_config[0] if isinstance(ipadapter_config, list) else ipadapter_config
-                    if _cfg_check.get('enabled', True) is False:
+                    if _cfg_check.get("enabled", True) is False:
                         logger.info(
                             "IP-Adapter disabled by auto-resolution (no compatible adapter for this model). Skipping."
                         )
                         use_ipadapter_trt = False
                     else:
                         try:
-                            from streamdiffusion.modules.ipadapter_module import IPAdapterModule, IPAdapterConfig, IPAdapterType
+                            from streamdiffusion.modules.ipadapter_module import (
+                                IPAdapterConfig,
+                                IPAdapterModule,
+                                IPAdapterType,
+                            )
+
                             logger.info("Installing IPAdapter module before TensorRT compilation...")
 
                             # Snapshot processors before install — IPAdapter.set_ip_adapter() replaces them
@@ -1612,14 +1615,14 @@ class StreamDiffusionWrapper:
                             # Use first config if list provided
                             cfg = ipadapter_config[0] if isinstance(ipadapter_config, list) else ipadapter_config
                             ip_cfg = IPAdapterConfig(
-                                style_image_key=cfg.get('style_image_key') or 'ipadapter_main',
-                                num_image_tokens=cfg.get('num_image_tokens', 4),
-                                ipadapter_model_path=cfg['ipadapter_model_path'],
-                                image_encoder_path=cfg['image_encoder_path'],
-                                style_image=cfg.get('style_image'),
-                                scale=cfg.get('scale', 1.0),
-                                type=IPAdapterType(cfg.get('type', "regular")),
-                                insightface_model_name=cfg.get('insightface_model_name'),
+                                style_image_key=cfg.get("style_image_key") or "ipadapter_main",
+                                num_image_tokens=cfg.get("num_image_tokens", 4),
+                                ipadapter_model_path=cfg["ipadapter_model_path"],
+                                image_encoder_path=cfg["image_encoder_path"],
+                                style_image=cfg.get("style_image"),
+                                scale=cfg.get("scale", 1.0),
+                                type=IPAdapterType(cfg.get("type", "regular")),
+                                insightface_model_name=cfg.get("insightface_model_name"),
                             )
                             ip_module = IPAdapterModule(ip_cfg)
                             ip_module.install(stream)
@@ -1629,6 +1632,7 @@ class StreamDiffusionWrapper:
 
                             # Cleanup after IPAdapter installation
                             import gc
+
                             gc.collect()
                             torch.cuda.empty_cache()
                             torch.cuda.synchronize()
@@ -1636,12 +1640,16 @@ class StreamDiffusionWrapper:
                         except torch.cuda.OutOfMemoryError as oom_error:
                             logger.error(f"CUDA Out of Memory during early IPAdapter installation: {oom_error}")
                             logger.error("Try reducing batch size, using smaller models, or increasing GPU memory")
-                            raise RuntimeError("Insufficient VRAM for IPAdapter installation. Consider using a GPU with more memory or reducing model complexity.")
+                            raise RuntimeError(
+                                "Insufficient VRAM for IPAdapter installation. Consider using a GPU with more memory or reducing model complexity."
+                            )
 
                         except RuntimeError as rt_error:
                             if "size mismatch" in str(rt_error):
-                                unet_dim = getattr(getattr(stream, 'unet', None), 'config', None)
-                                unet_cross_attn = getattr(unet_dim, 'cross_attention_dim', 'unknown') if unet_dim else 'unknown'
+                                unet_dim = getattr(getattr(stream, "unet", None), "config", None)
+                                unet_cross_attn = (
+                                    getattr(unet_dim, "cross_attention_dim", "unknown") if unet_dim else "unknown"
+                                )
                                 logger.warning(
                                     f"IP-Adapter weights are incompatible with this model "
                                     f"(UNet cross_attention_dim={unet_cross_attn}). "
@@ -1654,23 +1662,24 @@ class StreamDiffusionWrapper:
                                 # them before load_state_dict() failed, leaving the UNet in a corrupted state
                                 try:
                                     stream.unet.set_attn_processor(_saved_unet_processors)
-                                    logger.info("Restored original UNet attention processors after IP-Adapter failure.")
+                                    logger.info(
+                                        "Restored original UNet attention processors after IP-Adapter failure."
+                                    )
                                 except Exception as restore_err:
                                     logger.warning(f"Could not restore UNet processors: {restore_err}")
                                 use_ipadapter_trt = False
                             else:
                                 import traceback
+
                                 traceback.print_exc()
                                 logger.error("Failed to install IPAdapterModule before TensorRT compilation")
                                 raise
 
                         except Exception as e:
                             import traceback
+
                             traceback.print_exc()
-                            logger.warning(
-                                f"Failed to install IPAdapterModule: {e}. "
-                                f"Continuing without IP-Adapter."
-                            )
+                            logger.warning(f"Failed to install IPAdapterModule: {e}. Continuing without IP-Adapter.")
                             try:
                                 stream.unet.set_attn_processor(_saved_unet_processors)
                                 logger.info("Restored original UNet attention processors after IP-Adapter failure.")
@@ -1683,20 +1692,23 @@ class StreamDiffusionWrapper:
                 # then construct UNet model with that value.
 
                 # Build a temporary unified wrapper to install processors and discover num_ip_layers
-                from streamdiffusion.acceleration.tensorrt.export_wrappers.unet_unified_export import UnifiedExportWrapper
+                from streamdiffusion.acceleration.tensorrt.export_wrappers.unet_unified_export import (
+                    UnifiedExportWrapper,
+                )
+
                 temp_wrapped_unet = UnifiedExportWrapper(
                     stream.unet,
                     use_controlnet=use_controlnet_trt,
                     use_ipadapter=use_ipadapter_trt,
                     control_input_names=None,
-                    num_tokens=num_tokens
+                    num_tokens=num_tokens,
                 )
 
                 num_ip_layers = None
                 if use_ipadapter_trt:
                     # Access underlying IPAdapter wrapper
-                    if hasattr(temp_wrapped_unet, 'ipadapter_wrapper') and temp_wrapped_unet.ipadapter_wrapper:
-                        num_ip_layers = getattr(temp_wrapped_unet.ipadapter_wrapper, 'num_ip_layers', None)
+                    if hasattr(temp_wrapped_unet, "ipadapter_wrapper") and temp_wrapped_unet.ipadapter_wrapper:
+                        num_ip_layers = getattr(temp_wrapped_unet.ipadapter_wrapper, "num_ip_layers", None)
                         if not isinstance(num_ip_layers, int) or num_ip_layers <= 0:
                             raise RuntimeError("Failed to determine num_ip_layers for IP-Adapter")
                         try:
@@ -1729,9 +1741,9 @@ class StreamDiffusionWrapper:
                 if use_controlnet_trt:
                     # Build control_input_names excluding ipadapter_scale so indices align to 3-base offset
                     all_input_names = unet_model.get_input_names()
-                    control_input_names = [name for name in all_input_names if name != 'ipadapter_scale']
+                    control_input_names = [name for name in all_input_names if name != "ipadapter_scale"]
 
-                # Unified compilation path 
+                # Unified compilation path
                 # Recreate wrapped_unet with control input names if needed (after unet_model is ready)
                 wrapped_unet = UnifiedExportWrapper(
                     stream.unet,
@@ -1744,6 +1756,7 @@ class StreamDiffusionWrapper:
 
                 if use_cached_attn:
                     from .acceleration.tensorrt.models.attention_processors import CachedSTAttnProcessor2_0
+
                     processors = stream.unet.attn_processors
                     for name, processor in processors.items():
                         # Target self-attention layers (attn1) by name — kvo_cache is only passed
@@ -1770,13 +1783,13 @@ class StreamDiffusionWrapper:
                     cuda_stream=None,
                     stream_vae=stream.vae,
                     engine_build_options={
-                        'opt_image_height': self.height,
-                        'opt_image_width': self.width,
-                        'build_dynamic_shape': True,
-                        'min_image_resolution': 384,
-                        'max_image_resolution': 1024,
-                        'build_all_tactics': True,
-                    }
+                        "opt_image_height": self.height,
+                        "opt_image_width": self.width,
+                        "build_dynamic_shape": True,
+                        "min_image_resolution": 384,
+                        "max_image_resolution": 1024,
+                        "build_all_tactics": True,
+                    },
                 )
 
                 # Compile VAE encoder engine using EngineManager
@@ -1796,13 +1809,13 @@ class StreamDiffusionWrapper:
                     batch_size=self.batch_size if self.mode == "txt2img" else stream.frame_bff_size,
                     cuda_stream=None,
                     engine_build_options={
-                        'opt_image_height': self.height,
-                        'opt_image_width': self.width,
-                        'build_dynamic_shape': True,
-                        'min_image_resolution': 384,
-                        'max_image_resolution': 1024,
-                        'build_all_tactics': True,
-                    }
+                        "opt_image_height": self.height,
+                        "opt_image_width": self.width,
+                        "build_dynamic_shape": True,
+                        "min_image_resolution": 384,
+                        "max_image_resolution": 1024,
+                        "build_all_tactics": True,
+                    },
                 )
 
                 cuda_stream = cuda.Stream()
@@ -1812,6 +1825,25 @@ class StreamDiffusionWrapper:
 
                 try:
                     logger.info("Loading TensorRT UNet engine...")
+                    # Build engine_build_options, adding FP8 calibration callback when enabled.
+                    _unet_build_opts = {
+                        "opt_image_height": self.height,
+                        "opt_image_width": self.width,
+                        "build_all_tactics": True,
+                    }
+                    if fp8:
+                        from streamdiffusion.acceleration.tensorrt.fp8_quantize import (
+                            generate_unet_calibration_data,
+                        )
+                        _captured_model = unet_model
+                        _calib_batch = stream.trt_unet_batch_size
+                        _calib_h, _calib_w = self.height, self.width
+                        _unet_build_opts["fp8"] = True
+                        _unet_build_opts["onnx_opset"] = 19  # modelopt FP8 needs opset ≥19 for fp16 Q/DQ scales
+                        _unet_build_opts["calibration_data_fn"] = lambda: generate_unet_calibration_data(
+                            _captured_model, _calib_batch, _calib_h, _calib_w
+                        )
+
                     # Compile and load UNet engine using EngineManager
                     stream.unet = engine_manager.compile_and_load_engine(
                         EngineType.UNET,
@@ -1825,46 +1857,48 @@ class StreamDiffusionWrapper:
                         use_ipadapter_trt=use_ipadapter_trt,
                         unet_arch=unet_arch,
                         num_ip_layers=num_ip_layers if use_ipadapter_trt else None,
-                        engine_build_options={
-                            'opt_image_height': self.height,
-                            'opt_image_width': self.width,
-                            'build_all_tactics': True,
-                        }
+                        engine_build_options=_unet_build_opts,
                     )
                     if load_engine:
                         logger.info("TensorRT UNet engine loaded successfully")
-                    
+
                 except Exception as e:
                     error_msg = str(e).lower()
-                    is_oom_error = ('out of memory' in error_msg or 'outofmemory' in error_msg or 
-                                   'oom' in error_msg or 'cuda error' in error_msg)
-                    
+                    is_oom_error = (
+                        "out of memory" in error_msg
+                        or "outofmemory" in error_msg
+                        or "oom" in error_msg
+                        or "cuda error" in error_msg
+                    )
+
                     if is_oom_error:
                         logger.error(f"TensorRT UNet engine OOM: {e}")
                         logger.info("Falling back to PyTorch UNet (no TensorRT acceleration)")
                         logger.info("This will be slower but should work with less memory")
-                        
+
                         # Clean up any partial TensorRT state
-                        if hasattr(stream, 'unet'):
+                        if hasattr(stream, "unet"):
                             try:
                                 del stream.unet
                             except:
                                 pass
-                        
+
                         self.cleanup_gpu_memory()
-                        
+
                         # Fall back to original PyTorch UNet
                         try:
                             logger.info("Loading PyTorch UNet as fallback...")
                             # Keep the original UNet from the pipe
-                            if hasattr(stream, 'pipe') and hasattr(stream.pipe, 'unet'):
+                            if hasattr(stream, "pipe") and hasattr(stream.pipe, "unet"):
                                 stream.unet = stream.pipe.unet
                                 logger.info("PyTorch UNet fallback successful")
                             else:
                                 raise RuntimeError("No PyTorch UNet available for fallback")
                         except Exception as fallback_error:
                             logger.error(f"PyTorch UNet fallback also failed: {fallback_error}")
-                            raise RuntimeError(f"Both TensorRT and PyTorch UNet loading failed. TensorRT error: {e}, Fallback error: {fallback_error}")
+                            raise RuntimeError(
+                                f"Both TensorRT and PyTorch UNet loading failed. TensorRT error: {e}, Fallback error: {fallback_error}"
+                            )
                     else:
                         # Non-OOM error, re-raise
                         logger.error(f"TensorRT UNet engine loading failed (non-OOM): {e}")
@@ -1872,7 +1906,9 @@ class StreamDiffusionWrapper:
 
                 if load_engine:
                     try:
-                        logger.info(f"Loading TensorRT VAE engines vae_encoder_path: {vae_encoder_path}, vae_decoder_path: {vae_decoder_path}")
+                        logger.info(
+                            f"Loading TensorRT VAE engines vae_encoder_path: {vae_encoder_path}, vae_decoder_path: {vae_decoder_path}"
+                        )
                         stream.vae = AutoencoderKLEngine(
                             str(vae_encoder_path),
                             str(vae_decoder_path),
@@ -1883,38 +1919,44 @@ class StreamDiffusionWrapper:
                         stream.vae.config = vae_config
                         stream.vae.dtype = vae_dtype
                         logger.info("TensorRT VAE engines loaded successfully")
-                        
+
                     except Exception as e:
                         error_msg = str(e).lower()
-                        is_oom_error = ('out of memory' in error_msg or 'outofmemory' in error_msg or 
-                                    'oom' in error_msg or 'cuda error' in error_msg)
-                        
+                        is_oom_error = (
+                            "out of memory" in error_msg
+                            or "outofmemory" in error_msg
+                            or "oom" in error_msg
+                            or "cuda error" in error_msg
+                        )
+
                         if is_oom_error:
                             logger.error(f"TensorRT VAE engine OOM: {e}")
                             logger.info("Falling back to PyTorch VAE (no TensorRT acceleration)")
                             logger.info("This will be slower but should work with less memory")
-                            
+
                             # Clean up any partial TensorRT state
-                            if hasattr(stream, 'vae'):
+                            if hasattr(stream, "vae"):
                                 try:
                                     del stream.vae
                                 except:
                                     pass
-                            
+
                             self.cleanup_gpu_memory()
-                            
+
                             # Fall back to original PyTorch VAE
                             try:
                                 logger.info("Loading PyTorch VAE as fallback...")
                                 # Keep the original VAE from the pipe
-                                if hasattr(stream, 'pipe') and hasattr(stream.pipe, 'vae'):
+                                if hasattr(stream, "pipe") and hasattr(stream.pipe, "vae"):
                                     stream.vae = stream.pipe.vae
                                     logger.info("PyTorch VAE fallback successful")
                                 else:
                                     raise RuntimeError("No PyTorch VAE available for fallback")
                             except Exception as fallback_error:
                                 logger.error(f"PyTorch VAE fallback also failed: {fallback_error}")
-                                raise RuntimeError(f"Both TensorRT and PyTorch VAE loading failed. TensorRT error: {e}, Fallback error: {fallback_error}")
+                                raise RuntimeError(
+                                    f"Both TensorRT and PyTorch VAE loading failed. TensorRT error: {e}, Fallback error: {fallback_error}"
+                                )
                         else:
                             # Non-OOM error, re-raise
                             logger.error(f"TensorRT VAE engine loading failed (non-OOM): {e}")
@@ -1935,6 +1977,7 @@ class StreamDiffusionWrapper:
                 if self.use_safety_checker or safety_checker_engine_exists:
                     if not safety_checker_engine_exists:
                         from transformers import AutoModelForImageClassification
+
                         self.safety_checker = AutoModelForImageClassification.from_pretrained(safety_checker_model_id)
 
                         safety_checker_model = NSFWDetector(
@@ -1952,7 +1995,7 @@ class StreamDiffusionWrapper:
                             cuda_stream=None,
                             load_engine=False,
                         )
-                    
+
                     if load_engine:
                         self.safety_checker = NSFWDetectorEngine(
                             safety_checker_path,
@@ -1960,7 +2003,7 @@ class StreamDiffusionWrapper:
                             use_cuda_graph=True,
                         )
                         logger.info("Safety Checker engine loaded successfully")
-                        
+
             if acceleration == "sfast":
                 from streamdiffusion.acceleration.sfast import (
                     accelerate_with_stable_fast,
@@ -1969,13 +2012,15 @@ class StreamDiffusionWrapper:
                 stream = accelerate_with_stable_fast(stream)
         except Exception:
             import traceback
+
             traceback.print_exc()
             raise Exception("Acceleration has failed.")
 
         # Install modules via hooks instead of patching (wrapper keeps forwarding updates only)
         if use_controlnet:
             try:
-                from streamdiffusion.modules.controlnet_module import ControlNetModule, ControlNetConfig
+                from streamdiffusion.modules.controlnet_module import ControlNetConfig, ControlNetModule
+
                 cn_module = ControlNetModule(device=self.device, dtype=self.dtype)
                 cn_module.install(stream)
                 # Normalize to list of configs
@@ -1987,28 +2032,28 @@ class StreamDiffusionWrapper:
                     else []
                 )
                 for cfg in configs:
-                    if not cfg.get('model_id'):
+                    if not cfg.get("model_id"):
                         continue
                     cn_cfg = ControlNetConfig(
-                        model_id=cfg['model_id'],
-                        preprocessor=cfg.get('preprocessor'),
-                        conditioning_scale=cfg.get('conditioning_scale', 1.0),
-                        enabled=cfg.get('enabled', True),
-                        conditioning_channels=cfg.get('conditioning_channels'),
-                        preprocessor_params=cfg.get('preprocessor_params'),
+                        model_id=cfg["model_id"],
+                        preprocessor=cfg.get("preprocessor"),
+                        conditioning_scale=cfg.get("conditioning_scale", 1.0),
+                        enabled=cfg.get("enabled", True),
+                        conditioning_channels=cfg.get("conditioning_channels"),
+                        preprocessor_params=cfg.get("preprocessor_params"),
                     )
-                    cn_module.add_controlnet(cn_cfg, control_image=cfg.get('control_image'))
+                    cn_module.add_controlnet(cn_cfg, control_image=cfg.get("control_image"))
                 # Expose for later updates if needed by caller code
                 stream._controlnet_module = cn_module
 
                 try:
                     compiled_cn_engines = []
                     for cfg, cn_model in zip(configs, cn_module.controlnets):
-                        if not cfg or not cfg.get('model_id') or cn_model is None:
+                        if not cfg or not cfg.get("model_id") or cn_model is None:
                             continue
                         try:
                             engine = engine_manager.get_or_load_controlnet_engine(
-                                model_id=cfg['model_id'],
+                                model_id=cfg["model_id"],
                                 pytorch_model=cn_model,
                                 model_type=model_type,
                                 batch_size=stream.trt_unet_batch_size,
@@ -2017,29 +2062,33 @@ class StreamDiffusionWrapper:
                                 cuda_stream=cuda_stream,
                                 use_cuda_graph=False,
                                 unet=None,
-                                model_path=cfg['model_id'],
+                                model_path=cfg["model_id"],
                                 load_engine=load_engine,
-                                conditioning_channels=cfg.get('conditioning_channels', 3)
+                                conditioning_channels=cfg.get("conditioning_channels", 3),
                             )
                             try:
-                                setattr(engine, 'model_id', cfg['model_id'])
+                                setattr(engine, "model_id", cfg["model_id"])
                             except Exception:
                                 pass
                             compiled_cn_engines.append(engine)
                         except Exception as e:
                             logger.warning(f"Failed to compile/load ControlNet engine for {cfg.get('model_id')}: {e}")
                     if compiled_cn_engines:
-                        setattr(stream, 'controlnet_engines', compiled_cn_engines)
+                        setattr(stream, "controlnet_engines", compiled_cn_engines)
                         try:
                             logger.info(f"Compiled/loaded {len(compiled_cn_engines)} ControlNet TensorRT engine(s)")
                         except Exception:
                             pass
                 except Exception:
                     import traceback
+
                     traceback.print_exc()
-                    logger.warning("ControlNet TensorRT engine build step encountered an issue; continuing with PyTorch ControlNet")
+                    logger.warning(
+                        "ControlNet TensorRT engine build step encountered an issue; continuing with PyTorch ControlNet"
+                    )
             except Exception:
                 import traceback
+
                 traceback.print_exc()
                 logger.error("Failed to install ControlNetModule")
                 raise
@@ -2048,24 +2097,30 @@ class StreamDiffusionWrapper:
         # This ensures processors are properly baked into the TensorRT engines
         # After TRT compilation, stream.unet is a UNet2DConditionModelEngine with no attn_processors —
         # skip IP-Adapter install entirely in that case.
-        if use_ipadapter and ipadapter_config and not hasattr(stream, '_ipadapter_module') and hasattr(stream.unet, 'attn_processors'):
+        if (
+            use_ipadapter
+            and ipadapter_config
+            and not hasattr(stream, "_ipadapter_module")
+            and hasattr(stream.unet, "attn_processors")
+        ):
             try:
-                from streamdiffusion.modules.ipadapter_module import IPAdapterModule, IPAdapterConfig, IPAdapterType
+                from streamdiffusion.modules.ipadapter_module import IPAdapterConfig, IPAdapterModule, IPAdapterType
+
                 # Use first config if list provided
                 cfg = ipadapter_config[0] if isinstance(ipadapter_config, list) else ipadapter_config
 
                 # Get adapter type from config
-                ipadapter_type = IPAdapterType(cfg['type'])
+                ipadapter_type = IPAdapterType(cfg["type"])
 
                 ip_cfg = IPAdapterConfig(
-                    style_image_key=cfg.get('style_image_key') or 'ipadapter_main',
-                    num_image_tokens=cfg.get('num_image_tokens', 4),
-                    ipadapter_model_path=cfg['ipadapter_model_path'],
-                    image_encoder_path=cfg['image_encoder_path'],
-                    style_image=cfg.get('style_image'),
-                    scale=cfg.get('scale', 1.0),
+                    style_image_key=cfg.get("style_image_key") or "ipadapter_main",
+                    num_image_tokens=cfg.get("num_image_tokens", 4),
+                    ipadapter_model_path=cfg["ipadapter_model_path"],
+                    image_encoder_path=cfg["image_encoder_path"],
+                    style_image=cfg.get("style_image"),
+                    scale=cfg.get("scale", 1.0),
                     type=ipadapter_type,
-                    insightface_model_name=cfg.get('insightface_model_name'),
+                    insightface_model_name=cfg.get("insightface_model_name"),
                 )
                 ip_module = IPAdapterModule(ip_cfg)
                 _saved_unet_processors_post = {name: proc for name, proc in stream.unet.attn_processors.items()}
@@ -2075,8 +2130,8 @@ class StreamDiffusionWrapper:
 
             except RuntimeError as rt_error:
                 if "size mismatch" in str(rt_error):
-                    unet_dim = getattr(getattr(stream, 'unet', None), 'config', None)
-                    unet_cross_attn = getattr(unet_dim, 'cross_attention_dim', 'unknown') if unet_dim else 'unknown'
+                    unet_dim = getattr(getattr(stream, "unet", None), "config", None)
+                    unet_cross_attn = getattr(unet_dim, "cross_attention_dim", "unknown") if unet_dim else "unknown"
                     logger.warning(
                         f"IP-Adapter weights are incompatible with this model "
                         f"(UNet cross_attention_dim={unet_cross_attn}). "
@@ -2088,12 +2143,14 @@ class StreamDiffusionWrapper:
                         logger.warning(f"Could not restore UNet processors: {restore_err}")
                 else:
                     import traceback
+
                     traceback.print_exc()
                     logger.error("Failed to install IPAdapterModule")
                     raise
 
             except Exception:
                 import traceback
+
                 traceback.print_exc()
                 logger.error("Failed to install IPAdapterModule")
                 raise
@@ -2101,45 +2158,49 @@ class StreamDiffusionWrapper:
         # Note: LoRA weights have already been merged permanently during model loading
 
         # Install pipeline hook modules (Phase 4: Configuration Integration)
-        if image_preprocessing_config and image_preprocessing_config.get('enabled', True):
+        if image_preprocessing_config and image_preprocessing_config.get("enabled", True):
             try:
                 from streamdiffusion.modules.image_processing_module import ImagePreprocessingModule
+
                 img_pre_module = ImagePreprocessingModule()
                 img_pre_module.install(stream)
-                for proc_config in image_preprocessing_config.get('processors', []):
+                for proc_config in image_preprocessing_config.get("processors", []):
                     img_pre_module.add_processor(proc_config)
                 stream._image_preprocessing_module = img_pre_module
             except Exception as e:
                 logger.error(f"Failed to install ImagePreprocessingModule: {e}")
-        
-        if image_postprocessing_config and image_postprocessing_config.get('enabled', True):
+
+        if image_postprocessing_config and image_postprocessing_config.get("enabled", True):
             try:
                 from streamdiffusion.modules.image_processing_module import ImagePostprocessingModule
+
                 img_post_module = ImagePostprocessingModule()
                 img_post_module.install(stream)
-                for proc_config in image_postprocessing_config.get('processors', []):
+                for proc_config in image_postprocessing_config.get("processors", []):
                     img_post_module.add_processor(proc_config)
                 stream._image_postprocessing_module = img_post_module
             except Exception as e:
                 logger.error(f"Failed to install ImagePostprocessingModule: {e}")
-        
-        if latent_preprocessing_config and latent_preprocessing_config.get('enabled', True):
+
+        if latent_preprocessing_config and latent_preprocessing_config.get("enabled", True):
             try:
                 from streamdiffusion.modules.latent_processing_module import LatentPreprocessingModule
+
                 latent_pre_module = LatentPreprocessingModule()
                 latent_pre_module.install(stream)
-                for proc_config in latent_preprocessing_config.get('processors', []):
+                for proc_config in latent_preprocessing_config.get("processors", []):
                     latent_pre_module.add_processor(proc_config)
                 stream._latent_preprocessing_module = latent_pre_module
             except Exception as e:
                 logger.error(f"Failed to install LatentPreprocessingModule: {e}")
-        
-        if latent_postprocessing_config and latent_postprocessing_config.get('enabled', True):
+
+        if latent_postprocessing_config and latent_postprocessing_config.get("enabled", True):
             try:
                 from streamdiffusion.modules.latent_processing_module import LatentPostprocessingModule
+
                 latent_post_module = LatentPostprocessingModule()
                 latent_post_module.install(stream)
-                for proc_config in latent_postprocessing_config.get('processors', []):
+                for proc_config in latent_postprocessing_config.get("processors", []):
                     latent_post_module.add_processor(proc_config)
                 stream._latent_postprocessing_module = latent_post_module
             except Exception as e:
@@ -2150,6 +2211,7 @@ class StreamDiffusionWrapper:
         # Requires Ampere+ (compute 8.0+). Expected gain: 2-5% end-to-end on SD1.5/SD-Turbo.
         try:
             from streamdiffusion.tools.cuda_l2_cache import setup_l2_persistence
+
             setup_l2_persistence(stream.unet)
         except Exception as e:
             logger.debug(f"L2 cache persistence setup skipped: {e}")
@@ -2159,39 +2221,45 @@ class StreamDiffusionWrapper:
     def get_last_processed_image(self, index: int) -> Optional[Image.Image]:
         """Forward get_last_processed_image call to the underlying ControlNet pipeline"""
         if not self.use_controlnet:
-            raise RuntimeError("get_last_processed_image: ControlNet support not enabled. Set use_controlnet=True in constructor.")
+            raise RuntimeError(
+                "get_last_processed_image: ControlNet support not enabled. Set use_controlnet=True in constructor."
+            )
 
         return self.stream.get_last_processed_image(index)
-        
+
     def cleanup_controlnets(self) -> None:
         """Cleanup ControlNet resources including background threads and VRAM"""
         if not self.use_controlnet:
             return
-            
-        if hasattr(self, 'stream') and self.stream and hasattr(self.stream, 'cleanup'):
+
+        if hasattr(self, "stream") and self.stream and hasattr(self.stream, "cleanup"):
             self.stream.cleanup_controlnets()
 
     def update_control_image(self, index: int, image: Union[str, Image.Image, torch.Tensor]) -> None:
         """Update control image for specific ControlNet index"""
         if not self.use_controlnet:
-            raise RuntimeError("update_control_image: ControlNet support not enabled. Set use_controlnet=True in constructor.")
+            raise RuntimeError(
+                "update_control_image: ControlNet support not enabled. Set use_controlnet=True in constructor."
+            )
         if not self.skip_diffusion:
             self.stream._controlnet_module.update_control_image_efficient(image, index=index)
         else:
             logger.debug("update_control_image: Skipping ControlNet update in skip diffusion mode")
 
-    def update_style_image(self, image: Union[str, Image.Image, torch.Tensor], is_stream: bool = False, style_key = "ipadapter_main") -> None:
+    def update_style_image(
+        self, image: Union[str, Image.Image, torch.Tensor], is_stream: bool = False, style_key="ipadapter_main"
+    ) -> None:
         """Update IPAdapter style image"""
         if not self.use_ipadapter:
-            raise RuntimeError("update_style_image: IPAdapter support not enabled. Set use_ipadapter=True in constructor.")
-        
+            raise RuntimeError(
+                "update_style_image: IPAdapter support not enabled. Set use_ipadapter=True in constructor."
+            )
+
         if not self.skip_diffusion:
             self.stream._param_updater.update_style_image(style_key, image, is_stream=is_stream)
         else:
             logger.debug("update_style_image: Skipping IPAdapter update in skip diffusion mode")
-        
-        
-        
+
     def clear_caches(self) -> None:
         """Clear all cached prompt embeddings and seed noise tensors."""
         self.stream._param_updater.clear_caches()
@@ -2218,52 +2286,58 @@ class StreamDiffusionWrapper:
         normalize_seed_weights = updater.get_normalize_seed_weights()
 
         # Core runtime params
-        guidance_scale = getattr(stream, 'guidance_scale', None)
-        delta = getattr(stream, 'delta', None)
-        t_index_list = list(getattr(stream, 't_list', []))
-        current_seed = getattr(stream, 'current_seed', None)
+        guidance_scale = getattr(stream, "guidance_scale", None)
+        delta = getattr(stream, "delta", None)
+        t_index_list = list(getattr(stream, "t_list", []))
+        current_seed = getattr(stream, "current_seed", None)
         num_inference_steps = None
         try:
-            if hasattr(stream, 'timesteps') and stream.timesteps is not None:
+            if hasattr(stream, "timesteps") and stream.timesteps is not None:
                 num_inference_steps = int(len(stream.timesteps))
         except Exception:
             pass
 
         # Resolution and model/pipeline info
         state: Dict[str, Any] = {
-            'width': getattr(stream, 'width', None),
-            'height': getattr(stream, 'height', None),
-            'latent_width': getattr(stream, 'latent_width', None),
-            'latent_height': getattr(stream, 'latent_height', None),
-            'device': getattr(stream, 'device', None).type if hasattr(getattr(stream, 'device', None), 'type') else getattr(stream, 'device', None),
-            'dtype': str(getattr(stream, 'dtype', None)),
-            'model_type': getattr(stream, 'model_type', None),
-            'is_sdxl': getattr(stream, 'is_sdxl', None),
-            'is_turbo': getattr(stream, 'is_turbo', None),
-            'cfg_type': getattr(stream, 'cfg_type', None),
-            'use_denoising_batch': getattr(stream, 'use_denoising_batch', None),
-            'batch_size': getattr(stream, 'batch_size', None),
-            'min_batch_size': getattr(stream, 'min_batch_size', None),
-            'max_batch_size': getattr(stream, 'max_batch_size', None),
+            "width": getattr(stream, "width", None),
+            "height": getattr(stream, "height", None),
+            "latent_width": getattr(stream, "latent_width", None),
+            "latent_height": getattr(stream, "latent_height", None),
+            "device": getattr(stream, "device", None).type
+            if hasattr(getattr(stream, "device", None), "type")
+            else getattr(stream, "device", None),
+            "dtype": str(getattr(stream, "dtype", None)),
+            "model_type": getattr(stream, "model_type", None),
+            "is_sdxl": getattr(stream, "is_sdxl", None),
+            "is_turbo": getattr(stream, "is_turbo", None),
+            "cfg_type": getattr(stream, "cfg_type", None),
+            "use_denoising_batch": getattr(stream, "use_denoising_batch", None),
+            "batch_size": getattr(stream, "batch_size", None),
+            "min_batch_size": getattr(stream, "min_batch_size", None),
+            "max_batch_size": getattr(stream, "max_batch_size", None),
         }
 
         # Blending state
-        state.update({
-            'prompt_list': prompts,
-            'seed_list': seeds,
-            'normalize_prompt_weights': normalize_prompt_weights,
-            'normalize_seed_weights': normalize_seed_weights,
-            'negative_prompt': getattr(updater, '_current_negative_prompt', ""),
-        })
+        state.update(
+            {
+                "prompt_list": prompts,
+                "seed_list": seeds,
+                "normalize_prompt_weights": normalize_prompt_weights,
+                "normalize_seed_weights": normalize_seed_weights,
+                "negative_prompt": getattr(updater, "_current_negative_prompt", ""),
+            }
+        )
 
         # Core runtime knobs
-        state.update({
-            'guidance_scale': guidance_scale,
-            'delta': delta,
-            't_index_list': t_index_list,
-            'current_seed': current_seed,
-            'num_inference_steps': num_inference_steps,
-        })
+        state.update(
+            {
+                "guidance_scale": guidance_scale,
+                "delta": delta,
+                "t_index_list": t_index_list,
+                "current_seed": current_seed,
+                "num_inference_steps": num_inference_steps,
+            }
+        )
 
         # Module configs (ControlNet, IP-Adapter)
         try:
@@ -2276,97 +2350,100 @@ class StreamDiffusionWrapper:
             ipadapter_config = None
         # Hook configs
         try:
-            image_preprocessing_config = updater._get_current_hook_config('image_preprocessing')
+            image_preprocessing_config = updater._get_current_hook_config("image_preprocessing")
         except Exception:
             image_preprocessing_config = []
         try:
-            image_postprocessing_config = updater._get_current_hook_config('image_postprocessing')
+            image_postprocessing_config = updater._get_current_hook_config("image_postprocessing")
         except Exception:
             image_postprocessing_config = []
         try:
-            latent_preprocessing_config = updater._get_current_hook_config('latent_preprocessing')
+            latent_preprocessing_config = updater._get_current_hook_config("latent_preprocessing")
         except Exception:
             latent_preprocessing_config = []
         try:
-            latent_postprocessing_config = updater._get_current_hook_config('latent_postprocessing')
+            latent_postprocessing_config = updater._get_current_hook_config("latent_postprocessing")
         except Exception:
             latent_postprocessing_config = []
-            
-        state.update({
-            'controlnet_config': controlnet_config,
-            'ipadapter_config': ipadapter_config,
-            'image_preprocessing_config': image_preprocessing_config,
-            'image_postprocessing_config': image_postprocessing_config,
-            'latent_preprocessing_config': latent_preprocessing_config,
-            'latent_postprocessing_config': latent_postprocessing_config,
-        })
+
+        state.update(
+            {
+                "controlnet_config": controlnet_config,
+                "ipadapter_config": ipadapter_config,
+                "image_preprocessing_config": image_preprocessing_config,
+                "image_postprocessing_config": image_postprocessing_config,
+                "latent_preprocessing_config": latent_preprocessing_config,
+                "latent_postprocessing_config": latent_postprocessing_config,
+            }
+        )
 
         # Optional caches
         if include_caches:
             try:
-                state['caches'] = updater.get_cache_info()
+                state["caches"] = updater.get_cache_info()
             except Exception:
-                state['caches'] = None
+                state["caches"] = None
 
         return state
-    
+
     def cleanup_gpu_memory(self) -> None:
         """Comprehensive GPU memory cleanup for model switching."""
         import gc
+
         import torch
-        
+
         logger.info("Cleaning up GPU memory...")
-        
+
         # Clear prompt caches
-        if hasattr(self, 'stream') and self.stream:
+        if hasattr(self, "stream") and self.stream:
             try:
                 self.stream._param_updater.clear_caches()
                 logger.info("   Cleared prompt caches")
             except:
                 pass
-        
+
         # Enhanced TensorRT engine cleanup
-        if hasattr(self, 'stream') and self.stream:
+        if hasattr(self, "stream") and self.stream:
             try:
                 # Cleanup UNet TensorRT engine
-                if hasattr(self.stream, 'unet'):
+                if hasattr(self.stream, "unet"):
                     unet_engine = self.stream.unet
                     logger.info("   Cleaning up TensorRT UNet engine...")
-                    
+
                     # Check if it's a TensorRT engine and cleanup properly
-                    if hasattr(unet_engine, 'engine') and hasattr(unet_engine.engine, '__del__'):
+                    if hasattr(unet_engine, "engine") and hasattr(unet_engine.engine, "__del__"):
                         try:
                             # Call the engine's destructor explicitly
                             unet_engine.engine.__del__()
                         except:
                             pass
-                    
+
                     # Clear all engine-related attributes
-                    if hasattr(unet_engine, 'context'):
+                    if hasattr(unet_engine, "context"):
                         try:
                             del unet_engine.context
                         except:
                             pass
-                    if hasattr(unet_engine, 'engine'):
+                    if hasattr(unet_engine, "engine"):
                         try:
                             del unet_engine.engine.engine  # TensorRT runtime engine
                             del unet_engine.engine
                         except:
                             pass
-                    
+
                     del self.stream.unet
                     logger.info("   UNet engine cleanup completed")
-                    
+
                 # Cleanup VAE TensorRT engines
-                if hasattr(self.stream, 'vae'):
+                if hasattr(self.stream, "vae"):
                     vae_engine = self.stream.vae
                     logger.info("   Cleaning up TensorRT VAE engines...")
-                    
+
                     # VAE has encoder and decoder engines
-                    for engine_name in ['vae_encoder', 'vae_decoder']:
+                    for engine_name in ["vae_encoder", "vae_decoder"]:
                         if hasattr(vae_engine, engine_name):
                             engine = getattr(vae_engine, engine_name)
-                            if hasattr(engine, 'engine') and hasattr(engine.engine, '__del__'):
+                            if hasattr(engine, "engine") and hasattr(engine.engine, "__del__"):
                                 try:
                                     engine.engine.__del__()
                                 except:
@@ -2375,12 +2452,12 @@ class StreamDiffusionWrapper:
                                 delattr(vae_engine, engine_name)
                             except:
                                 pass
-                    
+
                     del self.stream.vae
                     logger.info("   VAE engines cleanup completed")
-                
+
                 # Cleanup ControlNet engine pool if it exists
-                if hasattr(self.stream, 'controlnet_engine_pool'):
+                if hasattr(self.stream, "controlnet_engine_pool"):
                     logger.info("   Cleaning up ControlNet engine pool...")
                     try:
                         self.stream.controlnet_engine_pool.cleanup()
@@ -2388,76 +2465,78 @@ class StreamDiffusionWrapper:
                         logger.info("   ControlNet engine pool cleanup completed")
                     except:
                         pass
-                    
+
             except Exception as e:
                 logger.error(f"   TensorRT cleanup warning: {e}")
-        
+
         # Clear the entire stream object to free all models
-        if hasattr(self, 'stream'):
+        if hasattr(self, "stream"):
             try:
                 del self.stream
                 logger.info("   Cleared stream object")
             except:
                 pass
             self.stream = None
-        
+
         # Force multiple garbage collection cycles for thorough cleanup
         for i in range(3):
             gc.collect()
-        
+
         # Clear CUDA cache and cleanup IPC handles
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
-        
+
         # Force additional memory cleanup
         torch.cuda.ipc_collect()
-        
+
         # Get memory info
         allocated = torch.cuda.memory_allocated() / (1024**3)  # GB
-        cached = torch.cuda.memory_reserved() / (1024**3)     # GB
+        cached = torch.cuda.memory_reserved() / (1024**3)  # GB
         logger.info(f"   GPU Memory after cleanup: {allocated:.2f}GB allocated, {cached:.2f}GB cached")
-        
+
         logger.info("   Enhanced GPU memory cleanup complete")
 
     def check_gpu_memory_for_engine(self, engine_size_gb: float) -> bool:
         """
         Check if there's enough GPU memory to load a TensorRT engine.
-        
+
         Args:
             engine_size_gb: Expected engine size in GB
-            
+
         Returns:
             True if enough memory is available, False otherwise
         """
         if not torch.cuda.is_available():
             return True  # Assume OK if CUDA not available
-        
+
         try:
             # Get current memory status
             allocated = torch.cuda.memory_allocated() / (1024**3)
             cached = torch.cuda.memory_reserved() / (1024**3)
-            
+
             # Get total GPU memory
             total_memory = torch.cuda.get_device_properties(0).total_memory / (1024**3)
             free_memory = total_memory - allocated
-            
+
             # Add 20% overhead for safety
             required_memory = engine_size_gb * 1.2
-            
-            logger.info(f"GPU Memory Check:")
+
+            logger.info("GPU Memory Check:")
             logger.info(f"   Total: {total_memory:.2f}GB")
-            logger.info(f"   Allocated: {allocated:.2f}GB") 
+            logger.info(f"   Allocated: {allocated:.2f}GB")
             logger.info(f"   Cached: {cached:.2f}GB")
             logger.info(f"   Free: {free_memory:.2f}GB")
             logger.info(f"   Required: {required_memory:.2f}GB (engine: {engine_size_gb:.2f}GB + 20% overhead)")
-            
+
             if free_memory >= required_memory:
-                logger.info(f"   Sufficient memory available")
+                logger.info("   Sufficient memory available")
                 return True
             else:
-                logger.error(f"   Insufficient memory! Need {required_memory:.2f}GB but only {free_memory:.2f}GB available")
+                logger.error(
+                    f"   Insufficient memory! Need {required_memory:.2f}GB but only {free_memory:.2f}GB available"
+                )
                 return False
-                
+
         except Exception as e:
             logger.error(f"   Memory check failed: {e}")
             return True  # Assume OK if check fails
@@ -2465,22 +2544,22 @@ class StreamDiffusionWrapper:
     def cleanup_engines_and_rebuild(self, reduce_batch_size: bool = True, reduce_resolution: bool = False) -> None:
         """
         Clean up TensorRT engines and rebuild with smaller settings to fix OOM issues.
-        
+
         Parameters:
         -----------
         reduce_batch_size : bool
             If True, reduce batch size to 1
-        reduce_resolution : bool  
+        reduce_resolution : bool
             If True, reduce resolution by half
         """
-        import shutil
         import os
-        
+        import shutil
+
         logger.info("Cleaning up engines and rebuilding with smaller settings...")
-        
+
         # Clean up GPU memory first
         self.cleanup_gpu_memory()
-        
+
         # Remove engines directory
         engines_dir = "engines"
         if os.path.exists(engines_dir):
@@ -2489,22 +2568,22 @@ class StreamDiffusionWrapper:
                 logger.info(f"   Removed engines directory: {engines_dir}")
             except Exception as e:
                 logger.error(f"   Failed to remove engines: {e}")
-        
+
         # Reduce settings
         if reduce_batch_size:
-            if hasattr(self, 'batch_size') and self.batch_size > 1:
+            if hasattr(self, "batch_size") and self.batch_size > 1:
                 old_batch = self.batch_size
                 self.batch_size = 1
                 logger.info(f"   Reduced batch size: {old_batch} -> {self.batch_size}")
-            
+
             # Also reduce frame buffer size if needed
-            if hasattr(self, 'frame_buffer_size') and self.frame_buffer_size > 1:
+            if hasattr(self, "frame_buffer_size") and self.frame_buffer_size > 1:
                 old_buffer = self.frame_buffer_size
-                self.frame_buffer_size = 1  
+                self.frame_buffer_size = 1
                 logger.info(f"   Reduced frame buffer size: {old_buffer} -> {self.frame_buffer_size}")
-        
+
         if reduce_resolution:
-            if hasattr(self, 'width') and hasattr(self, 'height'):
+            if hasattr(self, "width") and hasattr(self, "height"):
                 old_width, old_height = self.width, self.height
                 self.width = max(512, self.width // 2)
                 self.height = max(512, self.height // 2)
@@ -2512,5 +2591,5 @@ class StreamDiffusionWrapper:
                 self.width = (self.width // 64) * 64
                 self.height = (self.height // 64) * 64
                 logger.info(f"   Reduced resolution: {old_width}x{old_height} -> {self.width}x{self.height}")
-        
+
         logger.info("   Next model load will rebuild engines with these smaller settings")

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -2094,6 +2094,15 @@ class StreamDiffusionWrapper:
             except Exception as e:
                 logger.error(f"Failed to install LatentPostprocessingModule: {e}")
 
+        # L2 cache persistence: pin hot UNet attention weights in GPU L2 cache.
+        # Gated by SDTD_L2_PERSIST=1 (default on). Silent fallback on unsupported GPUs.
+        # Requires Ampere+ (compute 8.0+). Expected gain: 2-5% end-to-end on SD1.5/SD-Turbo.
+        try:
+            from streamdiffusion.tools.cuda_l2_cache import setup_l2_persistence
+            setup_l2_persistence(stream.unet)
+        except Exception as e:
+            logger.debug(f"L2 cache persistence setup skipped: {e}")
+
         return stream
 
     def get_last_processed_image(self, index: int) -> Optional[Image.Image]:

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -344,10 +344,6 @@ class StreamDiffusionWrapper:
             seed=seed,
         )
 
-        # Offload text encoders to CPU after initial encoding to free ~1.6 GB VRAM (SDXL).
-        # They are reloaded on-demand before each prompt re-encoding call.
-        if acceleration == "tensorrt":
-            self._offload_text_encoders()
 
         # Set wrapper reference on parameter updater so it can access pipeline structure
         self.stream._param_updater.wrapper = self
@@ -465,10 +461,23 @@ class StreamDiffusionWrapper:
             raise TypeError(f"prepare: prompt must be str or List[Tuple[str, float]], got {type(prompt)}")
 
     def _offload_text_encoders(self) -> None:
-        """Move text encoders to CPU to free VRAM (~1.6 GB for SDXL).
+        """No-op during inference: text encoders kept on GPU.
 
-        Called automatically after initial prepare() when using TRT acceleration.
-        Text encoders are reloaded to GPU before each prompt re-encoding call.
+        Prompts change during inference while UNet/VAE/ControlNet are constant.
+        The ~1.6GB text encoder VRAM fits comfortably alongside other components
+        on a 24GB GPU, so the offload-reload cycle is pure overhead.
+        For maximum-VRAM scenarios (engine building, FP8 quantization),
+        use _force_offload_text_encoders() explicitly instead.
+        """
+
+    def _reload_text_encoders(self) -> None:
+        """No-op: text encoders remain on GPU (never offloaded during inference)."""
+
+    def _force_offload_text_encoders(self) -> None:
+        """Force-offload text encoders to CPU. Use during engine building or FP8 quantization only.
+
+        Frees ~1.6GB VRAM for maximum headroom during one-time build processes.
+        Call _force_reload_text_encoders() afterwards to restore state.
         """
         pipe = self.stream.pipe
         if hasattr(pipe, "text_encoder") and pipe.text_encoder is not None:
@@ -477,20 +486,17 @@ class StreamDiffusionWrapper:
         if hasattr(pipe, "text_encoder_2") and pipe.text_encoder_2 is not None:
             if next(pipe.text_encoder_2.parameters(), None) is not None:
                 pipe.text_encoder_2 = pipe.text_encoder_2.to("cpu")
-        # NOTE: torch.cuda.empty_cache() removed — it forces a full CUDA sync
-        # that stalls the GPU pipeline, causing visible stutters during prompt
-        # changes. The freed VRAM stays in PyTorch's allocator cache and gets
-        # reused automatically without the sync penalty.
-        logger.debug("[VRAM] Text encoders offloaded to CPU")
+        torch.cuda.empty_cache()
+        logger.debug("[VRAM] Text encoders force-offloaded to CPU (engine build/quantization)")
 
-    def _reload_text_encoders(self) -> None:
-        """Move text encoders back to GPU before prompt re-encoding."""
+    def _force_reload_text_encoders(self) -> None:
+        """Force-reload text encoders to GPU after engine building or FP8 quantization."""
         pipe = self.stream.pipe
         if hasattr(pipe, "text_encoder") and pipe.text_encoder is not None:
             pipe.text_encoder = pipe.text_encoder.to(self.device)
         if hasattr(pipe, "text_encoder_2") and pipe.text_encoder_2 is not None:
             pipe.text_encoder_2 = pipe.text_encoder_2.to(self.device)
-        logger.debug("[VRAM] Text encoders reloaded to GPU")
+        logger.debug("[VRAM] Text encoders force-reloaded to GPU")
 
     def update_prompt(
         self,

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -1820,6 +1820,7 @@ class StreamDiffusionWrapper:
                         "opt_image_height": self.height,
                         "opt_image_width": self.width,
                         "build_dynamic_shape": False,
+                        "build_static_batch": True,
                     },
                 )
 
@@ -1843,6 +1844,7 @@ class StreamDiffusionWrapper:
                         "opt_image_height": self.height,
                         "opt_image_width": self.width,
                         "build_dynamic_shape": False,
+                        "build_static_batch": True,
                     },
                 )
 
@@ -1858,6 +1860,7 @@ class StreamDiffusionWrapper:
                         "opt_image_height": self.height,
                         "opt_image_width": self.width,
                         "build_dynamic_shape": False,
+                        "build_static_batch": True,
                     }
                     if fp8:
                         from streamdiffusion.acceleration.tensorrt.fp8_quantize import (

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -356,6 +356,10 @@ class StreamDiffusionWrapper:
         self._acceleration = acceleration
         self._engine_dir = engine_dir
 
+        # Prompt change tracking: skip text encoder reload when text is identical
+        self._last_prompt_texts: Optional[List[str]] = None
+        self._last_negative_prompt: Optional[str] = None
+
         if device_ids is not None:
             self.stream.unet = torch.nn.DataParallel(self.stream.unet, device_ids=device_ids)
 
@@ -632,9 +636,26 @@ class StreamDiffusionWrapper:
         safety_checker_threshold : Optional[float]
             The threshold for the safety checker.
         """
-        # Reload text encoders to GPU if a new prompt needs encoding.
-        needs_encoding = prompt_list is not None or negative_prompt is not None
+        # Reload text encoders to GPU only when prompt text actually changed.
+        # OSC sends prompt updates at ~60 Hz even with identical text, so comparing
+        # against the last encoded texts avoids repeated ~1.6 GB CPU↔GPU transfers.
+        _new_prompt_texts = (
+            [p for p, _w in prompt_list] if prompt_list is not None else None
+        )
+        _texts_changed = (
+            _new_prompt_texts is not None
+            and _new_prompt_texts != self._last_prompt_texts
+        )
+        _neg_changed = (
+            negative_prompt is not None
+            and negative_prompt != self._last_negative_prompt
+        )
+        needs_encoding = _texts_changed or _neg_changed
         if needs_encoding:
+            if _new_prompt_texts is not None:
+                self._last_prompt_texts = _new_prompt_texts
+            if negative_prompt is not None:
+                self._last_negative_prompt = negative_prompt
             self._reload_text_encoders()
         try:
             # Handle all parameters via parameter updater (including ControlNet)

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -71,7 +71,7 @@ class StreamDiffusionWrapper:
         model_id_or_path: str,
         t_index_list: List[int],
         min_batch_size: int = 1,
-        max_batch_size: int = 4,
+        max_batch_size: int = 2,
         lora_dict: Optional[Dict[str, float]] = None,
         mode: Literal["img2img", "txt2img"] = "img2img",
         output_type: Literal["pil", "pt", "np", "latent"] = "pil",
@@ -350,6 +350,11 @@ class StreamDiffusionWrapper:
             seed=seed,
         )
 
+        # Offload text encoders to CPU after initial encoding to free ~1.6 GB VRAM (SDXL).
+        # They are reloaded on-demand before each prompt re-encoding call.
+        if acceleration == "tensorrt":
+            self._offload_text_encoders()
+
         # Set wrapper reference on parameter updater so it can access pipeline structure
         self.stream._param_updater.wrapper = self
 
@@ -413,13 +418,17 @@ class StreamDiffusionWrapper:
         # Handle both single prompt and prompt blending
         if isinstance(prompt, str):
             # Single prompt mode (legacy interface)
-            self.stream.prepare(
-                prompt,
-                negative_prompt,
-                num_inference_steps=num_inference_steps,
-                guidance_scale=guidance_scale,
-                delta=delta,
-            )
+            self._reload_text_encoders()
+            try:
+                self.stream.prepare(
+                    prompt,
+                    negative_prompt,
+                    num_inference_steps=num_inference_steps,
+                    guidance_scale=guidance_scale,
+                    delta=delta,
+                )
+            finally:
+                self._offload_text_encoders()
 
             # Apply seed blending if provided
             if seed_list is not None:
@@ -435,15 +444,20 @@ class StreamDiffusionWrapper:
 
             # Prepare with first prompt to initialize the pipeline
             first_prompt = prompt[0][0]
-            self.stream.prepare(
-                first_prompt,
-                negative_prompt,
-                num_inference_steps=num_inference_steps,
-                guidance_scale=guidance_scale,
-                delta=delta,
-            )
+            self._reload_text_encoders()
+            try:
+                self.stream.prepare(
+                    first_prompt,
+                    negative_prompt,
+                    num_inference_steps=num_inference_steps,
+                    guidance_scale=guidance_scale,
+                    delta=delta,
+                )
+            finally:
+                self._offload_text_encoders()
 
             # Then apply prompt blending (and seed blending if provided)
+            # update_stream_params handles its own reload/offload
             self.update_stream_params(
                 prompt_list=prompt,
                 negative_prompt=negative_prompt,
@@ -454,6 +468,31 @@ class StreamDiffusionWrapper:
 
         else:
             raise TypeError(f"prepare: prompt must be str or List[Tuple[str, float]], got {type(prompt)}")
+
+    def _offload_text_encoders(self) -> None:
+        """Move text encoders to CPU to free VRAM (~1.6 GB for SDXL).
+
+        Called automatically after initial prepare() when using TRT acceleration.
+        Text encoders are reloaded to GPU before each prompt re-encoding call.
+        """
+        pipe = self.stream.pipe
+        if hasattr(pipe, "text_encoder") and pipe.text_encoder is not None:
+            if next(pipe.text_encoder.parameters(), None) is not None:
+                pipe.text_encoder = pipe.text_encoder.to("cpu")
+        if hasattr(pipe, "text_encoder_2") and pipe.text_encoder_2 is not None:
+            if next(pipe.text_encoder_2.parameters(), None) is not None:
+                pipe.text_encoder_2 = pipe.text_encoder_2.to("cpu")
+        torch.cuda.empty_cache()
+        logger.debug("[VRAM] Text encoders offloaded to CPU")
+
+    def _reload_text_encoders(self) -> None:
+        """Move text encoders back to GPU before prompt re-encoding."""
+        pipe = self.stream.pipe
+        if hasattr(pipe, "text_encoder") and pipe.text_encoder is not None:
+            pipe.text_encoder = pipe.text_encoder.to(self.device)
+        if hasattr(pipe, "text_encoder_2") and pipe.text_encoder_2 is not None:
+            pipe.text_encoder_2 = pipe.text_encoder_2.to(self.device)
+        logger.debug("[VRAM] Text encoders reloaded to GPU")
 
     def update_prompt(
         self,
@@ -501,8 +540,12 @@ class StreamDiffusionWrapper:
                 # Clear the blending caches to avoid conflicts
                 self.stream._param_updater.clear_caches()
 
-            # Use the legacy single prompt update
-            self.stream.update_prompt(prompt)
+            # Reload text encoders to GPU for re-encoding, then offload when done.
+            self._reload_text_encoders()
+            try:
+                self.stream.update_prompt(prompt)
+            finally:
+                self._offload_text_encoders()
 
         elif isinstance(prompt, list):
             # Prompt blending mode
@@ -513,7 +556,7 @@ class StreamDiffusionWrapper:
             if len(current_prompts) <= 1 and warn_about_conflicts:
                 logger.warning("update_prompt: Switching from single prompt to prompt blending mode.")
 
-            # Apply prompt blending
+            # Apply prompt blending (update_stream_params handles reload/offload internally)
             self.update_stream_params(
                 prompt_list=prompt,
                 negative_prompt=negative_prompt,
@@ -598,29 +641,37 @@ class StreamDiffusionWrapper:
         safety_checker_threshold : Optional[float]
             The threshold for the safety checker.
         """
-        # Handle all parameters via parameter updater (including ControlNet)
-        self.stream._param_updater.update_stream_params(
-            num_inference_steps=num_inference_steps,
-            guidance_scale=guidance_scale,
-            delta=delta,
-            t_index_list=t_index_list,
-            seed=seed,
-            prompt_list=prompt_list,
-            negative_prompt=negative_prompt,
-            prompt_interpolation_method=prompt_interpolation_method,
-            seed_list=seed_list,
-            seed_interpolation_method=seed_interpolation_method,
-            normalize_prompt_weights=normalize_prompt_weights,
-            normalize_seed_weights=normalize_seed_weights,
-            controlnet_config=controlnet_config,
-            ipadapter_config=ipadapter_config,
-            image_preprocessing_config=image_preprocessing_config,
-            image_postprocessing_config=image_postprocessing_config,
-            latent_preprocessing_config=latent_preprocessing_config,
-            latent_postprocessing_config=latent_postprocessing_config,
-            cache_maxframes=cache_maxframes,
-            cache_interval=cache_interval,
-        )
+        # Reload text encoders to GPU if a new prompt needs encoding.
+        needs_encoding = prompt_list is not None or negative_prompt is not None
+        if needs_encoding:
+            self._reload_text_encoders()
+        try:
+            # Handle all parameters via parameter updater (including ControlNet)
+            self.stream._param_updater.update_stream_params(
+                num_inference_steps=num_inference_steps,
+                guidance_scale=guidance_scale,
+                delta=delta,
+                t_index_list=t_index_list,
+                seed=seed,
+                prompt_list=prompt_list,
+                negative_prompt=negative_prompt,
+                prompt_interpolation_method=prompt_interpolation_method,
+                seed_list=seed_list,
+                seed_interpolation_method=seed_interpolation_method,
+                normalize_prompt_weights=normalize_prompt_weights,
+                normalize_seed_weights=normalize_seed_weights,
+                controlnet_config=controlnet_config,
+                ipadapter_config=ipadapter_config,
+                image_preprocessing_config=image_preprocessing_config,
+                image_postprocessing_config=image_postprocessing_config,
+                latent_preprocessing_config=latent_preprocessing_config,
+                latent_postprocessing_config=latent_postprocessing_config,
+                cache_maxframes=cache_maxframes,
+                cache_interval=cache_interval,
+            )
+        finally:
+            if needs_encoding:
+                self._offload_text_encoders()
         if use_safety_checker is not None:
             self.use_safety_checker = use_safety_checker and (self._acceleration == "tensorrt")
         if safety_checker_threshold is not None:

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -1202,7 +1202,15 @@ class StreamDiffusionWrapper:
         self._is_sdxl = is_sdxl
         
         logger.info(f"_load_model: Detected model type: {model_type} (confidence: {confidence:.2f})")
-        
+
+        # Auto-resolve IP-Adapter model/encoder paths for detected architecture.
+        # Runs once here so both pre-TRT and post-TRT installation paths see the resolved cfg.
+        if use_ipadapter and ipadapter_config:
+            from streamdiffusion.modules.ipadapter_module import resolve_ipadapter_paths
+            _ip_cfgs = ipadapter_config if isinstance(ipadapter_config, list) else [ipadapter_config]
+            for _ip_cfg in _ip_cfgs:
+                resolve_ipadapter_paths(_ip_cfg, model_type, is_sdxl)
+
         # DEPRECATED: THIS WILL LOAD LCM_LORA IF USE_LCM_LORA IS TRUE
         # Validate backwards compatibility LCM LoRA selection using proper model detection
         if hasattr(self, 'use_lcm_lora') and self.use_lcm_lora is not None:
@@ -1578,9 +1586,9 @@ class StreamDiffusionWrapper:
                             logger.warning(
                                 f"IP-Adapter weights are incompatible with this model "
                                 f"(UNet cross_attention_dim={unet_cross_attn}). "
-                                f"Checkpoint dimension does not match. "
-                                f"SD-Turbo is SD2.1-based (dim=1024) — use h94/IP-Adapter/models/ip-adapter_sd21.bin "
-                                f"or disable IP-Adapter in td_config.yaml. "
+                                f"Checkpoint dimension does not match — this may be a custom model path "
+                                f"that could not be auto-resolved. "
+                                f"Check ipadapter_model_path in td_config.yaml. "
                                 f"Skipping IP-Adapter and continuing without it."
                             )
                             # Restore original processors — IPAdapter.set_ip_adapter() already replaced

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 torch.set_grad_enabled(False)
 torch.backends.cuda.matmul.allow_tf32 = True
 torch.backends.cudnn.allow_tf32 = True
+torch.backends.cudnn.benchmark = True
 
 
 class StreamDiffusionWrapper:
@@ -1312,7 +1313,7 @@ class StreamDiffusionWrapper:
             kvo_cache, _ = create_kvo_cache(
                 pipe.unet,
                 batch_size=stream.trt_unet_batch_size,
-                cache_maxframes=cache_maxframes,
+                cache_maxframes=max_cache_maxframes,  # Allocate at max to avoid runtime resize race
                 height=self.height,
                 width=self.width,
                 device=self.device,

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -71,7 +71,7 @@ class StreamDiffusionWrapper:
         model_id_or_path: str,
         t_index_list: List[int],
         min_batch_size: int = 1,
-        max_batch_size: int = 2,
+        max_batch_size: int = 4,
         lora_dict: Optional[Dict[str, float]] = None,
         mode: Literal["img2img", "txt2img"] = "img2img",
         output_type: Literal["pil", "pt", "np", "latent"] = "pil",

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -2065,46 +2065,47 @@ class StreamDiffusionWrapper:
                 # Expose for later updates if needed by caller code
                 stream._controlnet_module = cn_module
 
-                try:
-                    compiled_cn_engines = []
-                    for cfg, cn_model in zip(configs, cn_module.controlnets):
-                        if not cfg or not cfg.get("model_id") or cn_model is None:
-                            continue
-                        try:
-                            engine = engine_manager.get_or_load_controlnet_engine(
-                                model_id=cfg["model_id"],
-                                pytorch_model=cn_model,
-                                model_type=model_type,
-                                batch_size=stream.trt_unet_batch_size,
-                                max_batch_size=self.max_batch_size,
-                                min_batch_size=self.min_batch_size,
-                                cuda_stream=cuda_stream,
-                                use_cuda_graph=False,
-                                unet=None,
-                                model_path=cfg["model_id"],
-                                load_engine=load_engine,
-                                conditioning_channels=cfg.get("conditioning_channels", 3),
-                            )
+                if acceleration == "tensorrt":
+                    try:
+                        compiled_cn_engines = []
+                        for cfg, cn_model in zip(configs, cn_module.controlnets):
+                            if not cfg or not cfg.get("model_id") or cn_model is None:
+                                continue
                             try:
-                                setattr(engine, "model_id", cfg["model_id"])
+                                engine = engine_manager.get_or_load_controlnet_engine(
+                                    model_id=cfg["model_id"],
+                                    pytorch_model=cn_model,
+                                    model_type=model_type,
+                                    batch_size=stream.trt_unet_batch_size,
+                                    max_batch_size=self.max_batch_size,
+                                    min_batch_size=self.min_batch_size,
+                                    cuda_stream=cuda_stream,
+                                    use_cuda_graph=False,
+                                    unet=None,
+                                    model_path=cfg["model_id"],
+                                    load_engine=load_engine,
+                                    conditioning_channels=cfg.get("conditioning_channels", 3),
+                                )
+                                try:
+                                    setattr(engine, "model_id", cfg["model_id"])
+                                except Exception:
+                                    pass
+                                compiled_cn_engines.append(engine)
+                            except Exception as e:
+                                logger.warning(f"Failed to compile/load ControlNet engine for {cfg.get('model_id')}: {e}")
+                        if compiled_cn_engines:
+                            setattr(stream, "controlnet_engines", compiled_cn_engines)
+                            try:
+                                logger.info(f"Compiled/loaded {len(compiled_cn_engines)} ControlNet TensorRT engine(s)")
                             except Exception:
                                 pass
-                            compiled_cn_engines.append(engine)
-                        except Exception as e:
-                            logger.warning(f"Failed to compile/load ControlNet engine for {cfg.get('model_id')}: {e}")
-                    if compiled_cn_engines:
-                        setattr(stream, "controlnet_engines", compiled_cn_engines)
-                        try:
-                            logger.info(f"Compiled/loaded {len(compiled_cn_engines)} ControlNet TensorRT engine(s)")
-                        except Exception:
-                            pass
-                except Exception:
-                    import traceback
+                    except Exception:
+                        import traceback
 
-                    traceback.print_exc()
-                    logger.warning(
-                        "ControlNet TensorRT engine build step encountered an issue; continuing with PyTorch ControlNet"
-                    )
+                        traceback.print_exc()
+                        logger.warning(
+                            "ControlNet TensorRT engine build step encountered an issue; continuing with PyTorch ControlNet"
+                        )
             except Exception:
                 import traceback
 

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -2095,6 +2095,8 @@ class StreamDiffusionWrapper:
                                     use_cuda_graph=False,
                                     unet=None,
                                     model_path=cfg["model_id"],
+                                    opt_image_height=self.height,
+                                    opt_image_width=self.width,
                                     load_engine=load_engine,
                                     conditioning_channels=cfg.get("conditioning_channels", 3),
                                 )

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -2092,7 +2092,7 @@ class StreamDiffusionWrapper:
                                     max_batch_size=self.max_batch_size,
                                     min_batch_size=self.min_batch_size,
                                     cuda_stream=cuda_stream,
-                                    use_cuda_graph=False,
+                                    use_cuda_graph=True,
                                     unet=None,
                                     model_path=cfg["model_id"],
                                     opt_image_height=self.height,

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -477,7 +477,10 @@ class StreamDiffusionWrapper:
         if hasattr(pipe, "text_encoder_2") and pipe.text_encoder_2 is not None:
             if next(pipe.text_encoder_2.parameters(), None) is not None:
                 pipe.text_encoder_2 = pipe.text_encoder_2.to("cpu")
-        torch.cuda.empty_cache()
+        # NOTE: torch.cuda.empty_cache() removed — it forces a full CUDA sync
+        # that stalls the GPU pipeline, causing visible stutters during prompt
+        # changes. The freed VRAM stays in PyTorch's allocator cache and gets
+        # reused automatically without the sync penalty.
         logger.debug("[VRAM] Text encoders offloaded to CPU")
 
     def _reload_text_encoders(self) -> None:

--- a/utils/viewer.py
+++ b/utils/viewer.py
@@ -3,10 +3,12 @@ import sys
 import threading
 import time
 import tkinter as tk
-from multiprocessing import  Queue
-from typing import List
+from multiprocessing import Queue
+
 from PIL import Image, ImageTk
+
 from streamdiffusion.image_utils import postprocess_image
+
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
@@ -28,9 +30,8 @@ def update_image(image_data: Image.Image, label: tk.Label) -> None:
     label.configure(image=tk_image, width=width, height=height)
     label.image = tk_image  # keep a reference
 
-def _receive_images(
-    queue: Queue, fps_queue: Queue, label: tk.Label, fps_label: tk.Label
-) -> None:
+
+def _receive_images(queue: Queue, fps_queue: Queue, label: tk.Label, fps_label: tk.Label) -> None:
     """
     Continuously receive images from a queue and update the labels.
 
@@ -85,9 +86,7 @@ def receive_images(queue: Queue, fps_queue: Queue) -> None:
         root.quit()  # stop event loop
         return
 
-    thread = threading.Thread(
-        target=_receive_images, args=(queue, fps_queue, label, fps_label), daemon=True
-    )
+    thread = threading.Thread(target=_receive_images, args=(queue, fps_queue, label, fps_label), daemon=True)
     thread.start()
 
     try:
@@ -95,4 +94,3 @@ def receive_images(queue: Queue, fps_queue: Queue) -> None:
         root.mainloop()
     except KeyboardInterrupt:
         return
-


### PR DESCRIPTION
## Summary

- **Portable batch scripts**: Replaced all hardcoded `D:\Users\alexk\...` paths with `%~dp0` in `Install_StreamDiffusion.bat`, `Install_TensorRT.bat`, and `Start_StreamDiffusion.bat`. Added prerequisite checks (Python 3.11, Git, optional cl.exe warning).
- **Version pin alignment**: Synchronized all version pins across `setup.py`, `sd_installer/installer.py`, `sd_installer/tensorrt.py`, `src/streamdiffusion/tools/install-tensorrt.py`, and `StreamDiffusionTD/install_tensorrt.py` to match verified installed state after deps audit.
- **TensorRT verification**: Added `TENSORRT_CHECKS` to `verifier.py` and wired it into `cli.py` so `install-tensorrt` automatically verifies TRT, cuDNN, and polygraphy after install.
- **Deps audit & safe updates**: Applied 23 safe patch/minor package updates. 7 CVEs in 2 packages (onnx, protobuf) remain blocked by upstream constraints — documented as accepted risk.
- **New `set_env.bat`**: Runtime GPU tuning vars (`PYTORCH_CUDA_ALLOC_CONF`, `CUDA_MODULE_LOADING=LAZY`, L2 persist settings).
- **Installer fixes**: Pinned previously-unpinned `python-osc` to `1.10.2`, fixed `timm` install syntax bug, fixed protobuf phase7 downgrade below `setup.py` minimum.

### Key version changes

| Package | Old Pin | New Pin |
|---------|---------|---------|
| Pillow | >=12.1.1 | >=12.2.0 |
| onnxruntime-gpu | 1.24.3 | 1.24.4 |
| polygraphy | 0.49.24 | 0.49.26 |
| colored | 2.3.1 | 2.3.2 |
| pywin32 | 306 | 311 |
| peft | 0.17.1 | 0.18.1 |
| protobuf | 4.25.3 | 4.25.8 |
| timm | >=1.0.24 (fuzzy) | 1.0.26 (concrete) |
| python-osc | (unpinned) | 1.10.2 |

## Test plan

- [ ] Run `py -3.11 -m sd_installer --base-folder "..." diagnose` — all 14 checks pass (11 core + 3 TensorRT)
- [ ] Run `Install_StreamDiffusion.bat` from a clean directory — verify portable paths resolve correctly
- [ ] Run `Install_TensorRT.bat` — verify TRT install + verification step succeeds
- [ ] Verify `import tensorrt; import polygraphy; import onnxruntime` all succeed in venv
- [ ] Run `/deps-audit` — confirm no new unblocked vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)