### PR TITLE
fix: install cuda_ipc extra correctly (README + TD installer for v1.12.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Install StreamDiffusion with the extras you need (omit any extras you do not pla
 
 ```bash
 # Latest (recommended)
-pip install "git+https://github.com/daydreamlive/StreamDiffusion.git@main#egg=streamdiffusion[tensorrt,controlnet,ipadapter]"
+pip install "git+https://github.com/daydreamlive/StreamDiffusion.git@main#egg=streamdiffusion[tensorrt,controlnet,ipadapter,cuda_ipc]"
 ```
 
 You can install only the extras you need, e.g. `pip install "git+https://github.com/daydreamlive/StreamDiffusion.git@main#egg=streamdiffusion[tensorrt]"` or `...#egg=streamdiffusion[controlnet]`.
@@ -162,7 +162,7 @@ This script installs the TensorRT runtime and plugins we validate with our demos
 
 ```bash
 # Editable install with optional extras
-pip install -e ".[tensorrt,controlnet,ipadapter]"
+pip install -e ".[tensorrt,controlnet,ipadapter,cuda_ipc]"
 python -m streamdiffusion.tools.install-tensorrt
 ```
 


### PR DESCRIPTION
## Problem

A clean install of this repo pulls **no cuda-link**, even though `setup.py` declares it
under the `cuda_ipc` extra:

- `README.md`'s documented full/dev install commands (`[tensorrt,controlnet,ipadapter]`)
  never listed `cuda_ipc`, so following the README verbatim skips it.
- The StreamDiffusionTD `.tox` installer runs `uv pip install --no-deps -e .[tensorrt]`
  (deliberately `--no-deps`, to avoid re-resolving the whole dependency tree), which means
  `setup.py`'s `cuda_ipc` extra is never consulted there either — TD installs got no
  cuda-link at all, regardless of the README.

## Changes

**This repo (`README.md`):**
- Added `cuda_ipc` to the two documented full-install commands (`pip install
  "...#egg=streamdiffusion[tensorrt,controlnet,ipadapter,cuda_ipc]"` and
  `pip install -e ".[tensorrt,controlnet,ipadapter,cuda_ipc]"`). Left the
  partial-extras example (`[tensorrt]` / `[controlnet]` only) unchanged — it
  illustrates selecting individual extras, not the full/recommended install.
- `setup.py`'s `extras["cuda_ipc"]` (line 105) was already correct — verified only,
  no change needed.

**StreamDiffusionTD side (outside this git tree — ships in the binary `.tox`, not
reviewable in this diff):** patched the `[4/7] StreamDiffusion Installation` step in
the TD emitter to add a dedicated cuda-link install, installing the v1.12.0 prebuilt
wheel directly by URL (no compiler, no git clone of the cuda-link repo needed):

```
uv pip install --no-deps "https://github.com/forkni/cuda-link/releases/download/v1.12.0/cuda_link-1.12.0-cp311-cp311-win_amd64.whl"
```

This targets the `cp311-cp311-win_amd64` wheel matching StreamDiffusionTD's pinned
Python 3.11.9 venv (per cuda-link ADR-0013's "mode 2" scenario).

## Deferred / follow-up (not in this PR)

TD-side "library mode" (`CUDALINK_LIB_PATH`, which lets `CUDALinkBootstrap` import
`cuda_link` directly instead of falling back to the Text DAT mirrors) is **not** wired
up here. It's confirmed optional per cuda-link's own docs (the Text-DAT-mirror fallback
still works), and the correct delivery mechanism is nontrivial: `CUDALinkBootstrap.py`
reads `os.environ` inside **TouchDesigner's own process**, so a subprocess-launch env
var (e.g. in the `Startstream()` launcher) can't reach it — it would need something
like a persisted `setx` var or a TD-side `onStart` hook instead. Revisiting this during
the install-testing pass rather than guessing at a mechanism now.

## Do not merge

Per release process, forkni merges this PR.