### PR TITLE
fix: TRT static-batch engine cache keys, load validation, runtime step-change guard

### DIFF
--- a/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
+++ b/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
@@ -116,6 +116,7 @@ class EngineManager:
         resolution: Optional[tuple] = None,
         builder_optimization_level: Optional[int] = None,
         build_static_batch: Optional[bool] = None,
+        static_batch_size: Optional[int] = None,
     ) -> Path:
         """
         Generate engine path using wrapper.py's current logic.
@@ -180,6 +181,13 @@ class EngineManager:
                 # because the loaded engine has a symbolic batch dim.
                 if build_static_batch is not None:
                     prefix += f"--sbatch{int(build_static_batch)}"
+                # A static-batch engine only accepts the exact batch it was built
+                # with (= steps x frame_buffer x cfg factor), so that value must be
+                # part of the cache key: without it a 1-step config resolves to an
+                # engine frozen at batch 2 and fails set_input_shape on the first
+                # frame. min_batch/max_batch above are only the capacity range.
+                if build_static_batch and static_batch_size is not None:
+                    prefix += f"--batch-{static_batch_size}"
 
             prefix += optlvl_suffix
 

--- a/src/streamdiffusion/acceleration/tensorrt/utilities.py
+++ b/src/streamdiffusion/acceleration/tensorrt/utilities.py
@@ -924,6 +924,19 @@ class Engine:
         logger.info(f"Loading TensorRT engine: {self.engine_path}")
         self.engine = engine_from_bytes(bytes_from_path(self.engine_path))
 
+    def get_input_profile_bounds(self, name: str):
+        """Return (min, opt, max) shapes of input `name` from optimization profile 0,
+        or None if the engine is not loaded / the tensor does not exist. Lets callers
+        validate a requested shape (e.g. UNet batch = steps * frame_buffer) against
+        what the serialized engine actually supports, instead of failing inside
+        set_input_shape mid-stream."""
+        if self.engine is None:
+            return None
+        try:
+            return self.engine.get_tensor_profile_shape(name, 0)
+        except Exception:
+            return None
+
     def activate(self, reuse_device_memory=None):
         if reuse_device_memory:
             self.context = self.engine.create_execution_context_without_device_memory()
@@ -981,7 +994,15 @@ class Engine:
 
             if mode == trt.TensorIOMode.INPUT:
                 if not self.context.set_input_shape(name, shape):
-                    raise RuntimeError(f"TensorRT: set_input_shape failed for '{name}' with shape {shape}")
+                    bounds = self.get_input_profile_bounds(name)
+                    hint = ""
+                    if bounds is not None:
+                        hint = (
+                            f" Engine profile for '{name}': min={tuple(bounds[0])} opt={tuple(bounds[1])} "
+                            f"max={tuple(bounds[-1])}. The engine was built for a fixed shape range — "
+                            f"revert the parameter change or rebuild the engine for the new shape."
+                        )
+                    raise RuntimeError(f"TensorRT: set_input_shape failed for '{name}' with shape {shape}.{hint}")
 
             tensor = torch.empty(tuple(shape), dtype=torch_dtype).to(device=device)
             self.tensors[name] = tensor

--- a/src/streamdiffusion/stream_parameter_updater.py
+++ b/src/streamdiffusion/stream_parameter_updater.py
@@ -240,6 +240,30 @@ class StreamParameterUpdater(OrchestratorUser):
                 new_cache[cache_idx - 1] = cache_data
         return new_cache
 
+    def _trt_unet_batch_bounds(self) -> Optional[Tuple[int, int]]:
+        """(min, max) batch the loaded TRT UNet engine accepts, or None when the
+        UNet is not a TRT engine (PyTorch fallback -> no batch restriction)."""
+        engine = getattr(getattr(self.stream, "unet", None), "engine", None)
+        get_bounds = getattr(engine, "get_input_profile_bounds", None)
+        if get_bounds is None:
+            return None
+        bounds = get_bounds("sample")
+        if bounds is None:
+            return None
+        return int(bounds[0][0]), int(bounds[-1][0])
+
+    def _prospective_unet_batch(self, num_steps: int) -> int:
+        """UNet batch a step count would need — mirrors pipeline.py's
+        trt_unet_batch_size computation (cfg factor + denoising batch)."""
+        s = self.stream
+        if not getattr(s, "use_denoising_batch", False):
+            return s.frame_bff_size
+        if s.cfg_type == "initialize":
+            return (num_steps + 1) * s.frame_bff_size
+        if s.cfg_type == "full":
+            return 2 * num_steps * s.frame_bff_size
+        return num_steps * s.frame_bff_size
+
     @torch.inference_mode()
     def update_stream_params(
         self,
@@ -270,6 +294,29 @@ class StreamParameterUpdater(OrchestratorUser):
         """Update streaming parameters efficiently in a single call."""
 
         with self._update_lock:
+            # Guard: changing the number of t_index entries changes the UNet batch
+            # (steps x frame_buffer x cfg factor). A TRT engine only accepts batches
+            # inside its built profile (static engines: exactly one). Reject the
+            # change here with a warning instead of letting set_input_shape kill the
+            # streaming loop; all other parameter updates in this call still apply.
+            if t_index_list is not None:
+                cur_len = len(self.stream.t_list) if self.stream.t_list else len(t_index_list)
+                if len(t_index_list) != cur_len:
+                    bounds = self._trt_unet_batch_bounds()
+                    if bounds is not None:
+                        new_batch = self._prospective_unet_batch(len(t_index_list))
+                        if not (bounds[0] <= new_batch <= bounds[1]):
+                            logger.warning(
+                                f"update_stream_params: step count change {cur_len} -> "
+                                f"{len(t_index_list)} needs UNet batch {new_batch}, but the "
+                                f"loaded TRT engine supports batch {bounds[0]}"
+                                + (f"-{bounds[1]}" if bounds[1] != bounds[0] else " only")
+                                + ". Ignoring the step change — restart the stream with the "
+                                "new step count to build/load a matching engine "
+                                "(or use the Flexible TRT profile for runtime step changes)."
+                            )
+                            t_index_list = None
+
             # First, update num_inference_steps if needed (this changes the timesteps array size)
             if num_inference_steps is not None:
                 # Safety check: Ensure num_inference_steps is at least as large as max t_index value

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -1893,9 +1893,11 @@ class StreamDiffusionWrapper:
                     fp8=fp8,
                     resolution=(self.height, self.width),
                     builder_optimization_level=self.builder_optimization_level,
-                    # Must match the hardcoded build_static_batch value below so the cache
-                    # key reflects the actual TRT profile policy (static vs dynamic batch).
-                    build_static_batch=True,
+                    # Must match the build_static_batch value in _unet_build_opts below so
+                    # the cache key reflects the actual TRT profile policy. Static engines
+                    # additionally encode the exact batch they are frozen at.
+                    build_static_batch=self.static_shapes,
+                    static_batch_size=stream.trt_unet_batch_size if self.static_shapes else None,
                 )
                 # Effective VAE optlvl: per-engine override first, then global fallback.
                 _vae_optlvl = (
@@ -2269,19 +2271,21 @@ class StreamDiffusionWrapper:
                 vae_dtype = stream.vae.dtype
 
                 try:
-                    # Note: the UNet always builds with build_static_batch=True /
-                    # build_dynamic_shape=False regardless of self.static_shapes.
-                    # static_shapes only controls the VAE enc/dec build flags.
+                    # The UNet honors self.static_shapes for the batch dimension
+                    # (TRT profile 'flexible' -> dynamic batch, step count changeable at
+                    # runtime; static profiles -> batch frozen at trt_unet_batch_size for
+                    # speed). Resolution is always fixed (build_dynamic_shape=False) —
+                    # the engine dir name carries --res-WxH either way.
                     logger.warning(
                         f"[TRT] UNet engine: fp8={fp8}, "
-                        f"build_static_batch=True, build_dynamic_shape=False, "
-                        f"engine_path={unet_path}"
+                        f"build_static_batch={self.static_shapes}, build_dynamic_shape=False, "
+                        f"batch={stream.trt_unet_batch_size}, engine_path={unet_path}"
                     )
                     _unet_build_opts = {
                         "opt_image_height": self.height,
                         "opt_image_width": self.width,
                         "build_dynamic_shape": False,
-                        "build_static_batch": True,
+                        "build_static_batch": self.static_shapes,
                     }
                     if self.builder_optimization_level is not None:
                         _unet_build_opts["builder_optimization_level"] = self.builder_optimization_level
@@ -2323,6 +2327,22 @@ class StreamDiffusionWrapper:
                     )
                     if load_engine:
                         logger.info("TensorRT UNet engine loaded successfully")
+                        # Guard: a cached engine may not cover the requested batch
+                        # (engine dirs from before the --batch-N cache-key suffix, or
+                        # hand-copied engines). Fail here with a readable message
+                        # instead of set_input_shape blowing up on the first frame.
+                        _bounds = stream.unet.engine.get_input_profile_bounds("sample")
+                        if _bounds is not None:
+                            _min_b, _max_b = int(_bounds[0][0]), int(_bounds[-1][0])
+                            _req = stream.trt_unet_batch_size
+                            if not (_min_b <= _req <= _max_b):
+                                raise RuntimeError(
+                                    f"UNet engine batch mismatch: engine supports batch {_min_b}"
+                                    + (f"-{_max_b}" if _max_b != _min_b else " only")
+                                    + f", config needs {_req} (steps x frame_buffer x cfg factor). "
+                                    f"Change the step count to match the engine, or delete the "
+                                    f"engine dir to rebuild for the new batch: {Path(unet_path).parent}"
+                                )
 
                 except Exception as e:
                     error_msg = str(e).lower()


### PR DESCRIPTION
## Credit

This is a straight cherry-pick of **dotsimulate's** commit `e52841e` from
`origin/fix/trt-static-batch-guards` (which itself is PR #24's branch + this one extra
commit). Cherry-picked with authorship preserved — dotsimulate remains the commit author;
I'm only the one landing it as its own PR against `SDTD_032_dev` now that PR #24 is
merged. dotsimulate may prefer to land this one himself instead — flagging that option
rather than assuming.

## What it fixes

`SDTD_032_dev` hardcoded `build_static_batch=True` for the TRT UNet, which silently
regressed the Flexible profile back to a static-batch build (losing 0.3.1's runtime
`t_index_list`-length step-change behavior) and didn't fold the built batch size into the
engine cache key — so a 1-step config could cache-hit an engine actually built for batch
2, surfacing as a first-frame `set_input_shape` crash instead of a clear error.

- `engine_manager.py`: static-batch UNet engine dirs now encode the exact built batch
  (`--batch-N`), so a stale/mismatched engine can't silently cache-hit.
- `wrapper.py`: UNet now honors `static_shapes` instead of the hardcoded
  `build_static_batch=True` — Flexible profile builds a dynamic-batch UNet again (0.3.1
  behavior); static profiles keep the fixed-batch speedup. Also validates the loaded
  engine's batch profile against the running config at load time, with a clear
  built-vs-requested-batch error instead of the previous first-frame crash.
- `stream_parameter_updater.py`: rejects a mid-stream step-count change the loaded engine
  can't satisfy (logs a warning, stream keeps running) — other params in the same update
  still apply.
- `utilities.py`: adds `Engine.get_input_profile_bounds()`; `set_input_shape` errors now
  include the engine's min/opt/max profile.

Zero overlap with PR #24's changed regions (confirmed before cherry-picking).

## Do not merge

Per release process, forkni merges this PR (or defers to dotsimulate, per the credit note
above).