### PR TITLE
chore: remove temporary [DEBUG-cnprev] per-frame logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,3 +270,4 @@ audit_reports/
 
 # Quality harness run outputs (generated; goldens/ is committed, outputs/ is not)
 tests/quality/outputs/
+logs/

--- a/src/streamdiffusion/modules/controlnet_module.py
+++ b/src/streamdiffusion/modules/controlnet_module.py
@@ -202,13 +202,6 @@ class ControlNetModule(OrchestratorUser):
                 control_image, preprocessors, gate_scales, self._stream.width, self._stream.height, index
             )
             processed = results[index] if results and len(results) > index else None
-            logger.info(  # [DEBUG-cnprev] — remove after preview confirmed
-                "[DEBUG-cnprev] update_control_image_efficient idx=%d scale=%.3f gate=%.3f processed=%s",
-                index,
-                scales[index] if index < len(scales) else -1,
-                gate_scales[index] if index < len(gate_scales) else -1,
-                processed is not None,
-            )
             with self._collections_lock:
                 if processed is not None and index < len(self.controlnet_images):
                     self.controlnet_images[index] = processed

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -1139,10 +1139,6 @@ class StreamDiffusionWrapper:
         This is a display-only path — no health tracking, no return value.
         No-op if cuda_ipc_cn_processed_shm_name was not configured.
         """
-        logger.info(  # [DEBUG-cnprev] — remove after preview confirmed
-            "[DEBUG-cnprev] export_controlnet_preview_ipc called, shm_name=%r",
-            self._cuda_ipc_cn_processed_shm_name,
-        )
         if not self._cuda_ipc_cn_processed_shm_name:
             return
         try:


### PR DESCRIPTION
## Summary
- Remove the `[DEBUG-cnprev]` per-frame `logger.info` calls added to
  `ControlNetModule.update_control_image_efficient` and
  `StreamDiffusionWrapper.export_controlnet_preview_ipc` — they were temporary
  instrumentation to confirm ControlNet preview IPC export was firing correctly,
  and were flooding the log on every frame.
- Add `logs/` to `.gitignore`.

## Test plan
- [x] Validated live prior to removal: SDXL-Turbo + ControlNet streaming at 61 FPS
      with `IPC:ok`, confirming the instrumented path worked as intended.
- [x] Change is logging-removal only — no functional/behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)