### PR TITLE
fix: eliminate onnxruntime-gpu install churn in Docker TensorRT FP8 step

### DIFF
--- a/src/streamdiffusion/tools/install-tensorrt.py
+++ b/src/streamdiffusion/tools/install-tensorrt.py
@@ -45,10 +45,17 @@ def install(cu: Optional[Literal["11", "12"]] = get_cuda_major()):
         "install onnx==1.19.1 onnxruntime-gpu==1.24.4 onnxoptimizer==0.4.2 onnxslim==0.1.91 onnxscript==0.6.2 --no-cache-dir"
     )
 
-    # FP8 quantization dependencies (CUDA 12 only)
-    # nvidia-modelopt requires cupy; pin cupy 13.x + numpy<2 for mediapipe compat
+    # FP8 quantization dependencies (CUDA 12 only). Pin modelopt==0.43.0 and skip its [onnx] extra:
+    # an unbounded modelopt floats to 0.45.0 (force-upgrades onnx to 1.21.0 -> breaks FP8 quant), and
+    # the [onnx] extra downgrades onnxruntime-gpu off our onnx==1.19.1 / onnxruntime-gpu==1.24.4 pins
+    # (installed just above). Enumerate the extra's remaining deps; onnxslim/onnxscript (above),
+    # onnx-graphsurgeon/polygraphy (above) are already satisfied.
     if cu == "12":
-        run_pip("install nvidia-modelopt[onnx] cupy-cuda12x==13.6.0 numpy==1.26.4 --no-cache-dir")
+        run_pip(
+            "install nvidia-modelopt==0.43.0 "
+            "cppimport lief ml_dtypes onnxconverter-common~=1.16.0 "
+            "cupy-cuda12x==13.6.0 numpy==1.26.4 --no-cache-dir"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `src/streamdiffusion/tools/install-tensorrt.py` (used by the Dockerfiles) requested `nvidia-modelopt[onnx]`, whose `[onnx]` extra hard-pins `onnxruntime-gpu==1.22.0` on Windows and, left unbounded, floats modelopt to a version that force-upgrades `onnx` to 1.21.0 and breaks FP8 quantization.
- Pins `nvidia-modelopt==0.43.0` and drops the `[onnx]` extra, enumerating its remaining deterministic deps explicitly (`cppimport`, `lief`, `ml_dtypes`, `onnxconverter-common~=1.16.0`) so the already-installed `onnx`/`onnxruntime-gpu` pins from the step above are never touched.
- Single focused commit, cherry-picked from `forkni/StreamDiffusion@SDTD_040_beta_release` (internal PR #14).

## Test plan
- [x] Cherry-picked cleanly onto current `SDTD_040_beta_release` tip, no conflicts.
- [x] File-scoped diff (`src/streamdiffusion/tools/install-tensorrt.py`).
- [x] Verified end-to-end via `pip install --dry-run` and a full clean install (companion Windows installer fix, tested locally): no `onnxruntime-gpu` download/uninstall churn in the FP8 step, final state `onnxruntime-gpu==1.24.4`, `onnx==1.19.1`, `nvidia-modelopt==0.43.0`.