### PR TITLE
fix: validate cached ONNX before reuse to prevent empty-graph TensorRT build crash

### DIFF
--- a/src/streamdiffusion/acceleration/tensorrt/builder.py
+++ b/src/streamdiffusion/acceleration/tensorrt/builder.py
@@ -2,6 +2,7 @@ import gc
 import os
 from typing import *
 
+import onnx
 import torch
 
 from .models import BaseModel
@@ -14,6 +15,29 @@ from .utilities import (
 
 def create_onnx_path(name, onnx_dir, opt=True):
     return os.path.join(onnx_dir, name + (".opt" if opt else "") + ".onnx")
+
+
+def _onnx_cache_valid(path: str) -> bool:
+    """Check a cached source ONNX is usable before reusing it, skipping export.
+
+    A prior run killed mid-export (OOM, crash, manual kill) can leave a
+    syntactically-valid-but-empty protobuf at onnx_path. os.path.exists() alone
+    can't tell that apart from a real export, and a 0-node / opset-less graph
+    makes polygraphy's constant folding blow up downstream with an opaque
+    'NoneType' object has no attribute 'graph' (ORT symbolic shape inference
+    refuses opset < 7 and returns None). Load structure-only (no external
+    weight data) and reject anything that looks truncated.
+    """
+    try:
+        if os.path.getsize(path) == 0:
+            return False
+        model = onnx.load(path, load_external_data=False)
+        if len(model.graph.node) == 0:
+            return False
+        opset = max((o.version for o in model.opset_import), default=0)
+        return opset >= 7
+    except Exception:
+        return False
 
 
 class EngineBuilder:
@@ -47,9 +71,15 @@ class EngineBuilder:
         force_onnx_export: bool = False,
         force_onnx_optimize: bool = False,
     ):
-        if not force_onnx_export and os.path.exists(onnx_path):
+        if not force_onnx_export and os.path.exists(onnx_path) and _onnx_cache_valid(onnx_path):
             print(f"Found cached model: {onnx_path}")
         else:
+            if not force_onnx_export and os.path.exists(onnx_path):
+                print(
+                    f"Cached ONNX at {onnx_path} is empty/corrupt (likely from an "
+                    f"interrupted prior export) -- discarding and re-exporting."
+                )
+                os.remove(onnx_path)
             print(f"Exporting model: {onnx_path}")
             export_onnx(
                 self.network,

--- a/src/streamdiffusion/acceleration/tensorrt/models.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models.py
@@ -46,6 +46,15 @@ class Optimizer:
                 self.graph.outputs[i].name = name
 
     def fold_constants(self, return_onnx=False):
+        if len(self.graph.nodes) == 0:
+            # Catches a corrupt/truncated source ONNX (e.g. left behind by an interrupted
+            # export). CLIP's optimize() override calls fold_constants() directly without
+            # going through BaseModel.optimize(), so the guard has to live here -- the one
+            # call site both paths share -- rather than in optimize() itself.
+            raise RuntimeError(
+                "Optimizer.fold_constants: input ONNX graph has 0 nodes -- the source ONNX is "
+                "empty or corrupt. Delete the cached .onnx file for this model and rebuild."
+            )
         onnx_graph = fold_constants(gs.export_onnx(self.graph), allow_onnxruntime_shape_inference=True)
         self.graph = gs.import_onnx(onnx_graph)
         if return_onnx:


### PR DESCRIPTION
## Summary

A user hit a crash during TensorRT engine build:

```
AttributeError: 'NoneType' object has no attribute 'graph'
  ... polygraphy/backend/onnx/util.py, in get_num_nodes
      return _get_num_graph_nodes(model.graph)
Exception: Acceleration has failed: 'NoneType' object has no attribute 'graph'
```

**Root cause:** a prior build was interrupted mid-`torch.onnx.export()` (OOM, crash, manual
kill). `torch.onnx.export()` writes directly to the final `onnx_path` with no temp-file-then-
rename, so the interrupted run left a syntactically-valid-but-empty (or truncated) protobuf on
disk. `EngineBuilder.build()`'s cache check is existence-only (`os.path.exists(onnx_path)`), so
the next run silently reused the corrupt file instead of re-exporting. That empty/0-node graph
then reached `Optimizer.fold_constants()` → polygraphy's `fold_constants` → ONNX Runtime's
symbolic shape inference, which refuses opset < 7 graphs and returns `None` — crashing
`get_num_nodes(None)` with the opaque `AttributeError` above, several layers away from the
actual cause.

## Fix (two layers, so every model type is covered)

- **`builder.py`**: add `_onnx_cache_valid(path)` — loads the ONNX structure-only (no external
  weight data, so it's cheap even for large models), and rejects it if the file is empty, has
  0 graph nodes, or has no opset ≥ 7. Gate the export cache-hit on this check instead of on
  `os.path.exists()` alone; if a cached file fails validation, delete it and re-export instead
  of silently reusing (or crashing on) garbage.
- **`models.py`**: guard `Optimizer.fold_constants()` itself against a 0-node graph, rather than
  only guarding `BaseModel.optimize()`. `CLIP.optimize()` overrides `BaseModel.optimize()`
  entirely and calls `fold_constants()` directly, so a guard placed only in
  `BaseModel.optimize()` wouldn't catch a corrupt CLIP ONNX. Placing it in `fold_constants()`
  covers CLIP, UNet, VAE encoder, and VAE decoder from the one shared call site.

With this fix, an interrupted-export leftover is detected and transparently re-exported instead
of crashing on the next run.

## Test plan

- [x] `ast.parse()` on both modified files (syntax check in this sandbox)
- [x] Verified this exact fix (validated on our downstream fork forkni/StreamDiffusion,
      merged in forkni/StreamDiffusion#16 and #17) resolves the reported crash
- [ ] End-to-end GPU rebuild (truncate a real cached `.onnx`, rerun build, confirm re-export +
      no crash) — requires a CUDA/TensorRT machine, not runnable in this environment; the
      reporting user's original repro trace is included above as evidence of the failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)