### PR TITLE
trt: fail fast on 0-node ONNX graph in Optimizer.fold_constants

### DIFF
--- a/src/streamdiffusion/acceleration/tensorrt/models/models.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/models.py
@@ -60,6 +60,15 @@ class Optimizer:
         # quantize), so is_fp8 is always False here for the UNet/ControlNet path. Gate on size
         # too (same >2GB threshold Optimizer.infer_shapes uses below) so the doomed ORT attempt
         # is skipped for any large graph. Small fp16/CLIP/VAE graphs keep the faster ORT path.
+        if len(self.graph.nodes) == 0:
+            # Catches a corrupt/truncated source ONNX (e.g. left behind by an interrupted
+            # export) here too -- CLIP's optimize() override (below) calls fold_constants()
+            # directly without going through BaseModel.optimize()'s equivalent guard, so that
+            # check alone doesn't cover every caller.
+            raise RuntimeError(
+                "Optimizer.fold_constants: input ONNX graph has 0 nodes -- the source ONNX is "
+                "empty or corrupt. Delete the cached .onnx file for this engine and rebuild."
+            )
         onnx_graph = gs.export_onnx(self.graph)
         is_fp8 = any(n.op in ("QuantizeLinear", "DequantizeLinear") for n in self.graph.nodes)
         is_large = onnx_graph.ByteSize() > 2147483648


### PR DESCRIPTION
## What

Adds a 0-node guard directly in `Optimizer.fold_constants` (`models.py`), mirroring the guard
`BaseModel.optimize` already has, so every caller is covered regardless of override.

## Why

Follow-up to d11bfa60 (already merged) — that fix guarded `BaseModel.optimize` against a
corrupt/truncated source ONNX (0 nodes), which previously surfaced as an opaque polygraphy
`'NoneType' object has no attribute 'graph'` once ORT shape inference bailed on the missing/invalid
opset.

`CLIP.optimize` is a full override — it never calls `super().optimize()`. It builds its own
`Optimizer` and calls `fold_constants()` directly, so a corrupt CLIP ONNX still reaches
`fold_constants` completely unguarded today. This adds the guard at the one shared choke point
(`fold_constants` itself) instead of duplicating it in every override.

**Why raise here instead of auto-deleting the corrupt cache**, the way `builder.py`'s pre-export
check does (`os.remove(onnx_path)` when `_onnx_cache_valid` fails): that recovery only fires on the
pre-export cache check. The `Optimizer` layer runs later and doesn't own the cache path — CLIP's
override reaches it from a different call site — so the right behavior here is a clear, actionable
error rather than silent deletion of a file this layer doesn't manage.

## Testing

Manual: constructed a truncated/corrupt ONNX proto (0 nodes) and confirmed `Optimizer.fold_constants`
now raises the new `RuntimeError` immediately instead of the previous opaque
`'NoneType' object has no attribute 'graph'` failure inside polygraphy's shape inference.
