### PR TITLE
fix: report the real cause of HuggingFace download failures instead of "model not found"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,9 @@ _deps = [
     # bump, verified 2026-07-15 deps-audit
     "fire==0.7.1",
     "omegaconf==2.3.0",
+    "requests",  # hf_download.py imports this at module scope (wrapper.py imports hf_download
+    # at module scope too), already resolved transitively via huggingface_hub, declared directly
+    # now that it's on the core import path
     "onnx==1.19.1",  # IR 11; modelopt FLOAT4E2M1 (1.18+); 1.21.0 breaks FP8 quant (external-data loading → negative QDQ scale); 6 path-traversal CVEs accepted: require untrusted model loading
     "onnxruntime-gpu==1.24.4",  # TRT EP, supports IR 11; never co-install CPU onnxruntime — shared files conflict
     "onnxoptimizer==0.4.2",
@@ -110,6 +113,7 @@ extras["dev"] = extras["xformers"] + extras["torch"] + extras["tensorrt"] + extr
 install_requires = [
     deps["fire"],
     deps["omegaconf"],
+    deps["requests"],
     deps["diffusers"],
     deps["transformers"],
     deps["accelerate"],

--- a/src/streamdiffusion/modules/controlnet_module.py
+++ b/src/streamdiffusion/modules/controlnet_module.py
@@ -683,20 +683,31 @@ class ControlNetModule(OrchestratorUser):
         self, model_id: str, conditioning_channels: Optional[int] = None
     ) -> ControlNetModel:
         import os
+        import traceback
         from pathlib import Path
+
+        from streamdiffusion.utils.hf_download import (
+            NETWORK_HINT,
+            is_network_error,
+            is_xet_download_error,
+            xet_disabled,
+        )
 
         logger = logging.getLogger(__name__)
 
-        try:
+        # Check if offline mode is enabled via environment variables
+        is_offline = os.environ.get("HF_HUB_OFFLINE", "0") == "1" or os.environ.get("TRANSFORMERS_OFFLINE", "0") == "1"
+
+        def _attempt(force_download: bool = False) -> ControlNetModel:
             # Prepare loading kwargs
             load_kwargs = {"torch_dtype": self.dtype}
             if conditioning_channels is not None:
                 load_kwargs["conditioning_channels"] = conditioning_channels
-
-            # Check if offline mode is enabled via environment variables
-            is_offline = (
-                os.environ.get("HF_HUB_OFFLINE", "0") == "1" or os.environ.get("TRANSFORMERS_OFFLINE", "0") == "1"
-            )
+            if force_download:
+                # A failed Xet transfer can leave a partial `.incomplete` file behind; force a
+                # clean re-download so the plain-HTTPS retry doesn't try to resume a byte offset
+                # written by a different transfer format.
+                load_kwargs["force_download"] = True
 
             if Path(model_id).exists():
                 model_path = Path(model_id)
@@ -735,16 +746,46 @@ class ControlNetModule(OrchestratorUser):
                     controlnet = ControlNetModel.from_pretrained(repo_id, subfolder=subfolder, **load_kwargs)
                 else:
                     controlnet = ControlNetModel.from_pretrained(model_id, **load_kwargs)
-            controlnet = controlnet.to(device=self.device, dtype=self.dtype)
-            # Track model_id for updater diffing
-            try:
-                controlnet.model_id = model_id
-            except Exception as e:
-                logger.debug(f"Failed to set model_id attribute on controlnet: {e}", exc_info=True)
             return controlnet
-        except Exception as e:
-            import traceback
 
-            logger.error(f"ControlNetModule: failed to load model '{model_id}': {e}")
-            logger.error(traceback.format_exc())
-            raise
+        try:
+            controlnet = _attempt()
+        except Exception as e:
+            # A HuggingFace Xet transfer-layer failure surfaces as a generic OSError that
+            # diffusers rewrites into a misleading "can't find the model" message (the real
+            # cause survives only in __cause__). Retry once over plain HTTPS instead of
+            # propagating that misleading message - self-healing for the common case where the
+            # Xet CAS endpoints are blocked (corporate proxy/firewall) but regular HTTPS works.
+            if is_offline or not is_xet_download_error(e):
+                logger.error(f"ControlNetModule: failed to load model '{model_id}': {e}")
+                logger.error(traceback.format_exc())
+                if not is_offline and is_network_error(e):
+                    raise RuntimeError(
+                        f"ControlNetModule: failed to load model '{model_id}': {e}.{NETWORK_HINT}"
+                    ) from e
+                raise
+
+            logger.warning(
+                f"ControlNetModule._load_pytorch_controlnet_model: HuggingFace Xet transfer failed for "
+                f"'{model_id}' ({e}); retrying with Xet disabled (plain HTTPS download)."
+            )
+            try:
+                with xet_disabled():
+                    controlnet = _attempt(force_download=True)
+            except Exception as retry_error:
+                logger.error(
+                    f"ControlNetModule: failed to load model '{model_id}' after Xet-disabled retry: {retry_error}"
+                )
+                logger.error(traceback.format_exc())
+                raise RuntimeError(
+                    f"ControlNetModule: failed to load model '{model_id}' after retrying without Xet: "
+                    f"{retry_error}.{NETWORK_HINT}"
+                ) from retry_error
+
+        controlnet = controlnet.to(device=self.device, dtype=self.dtype)
+        # Track model_id for updater diffing
+        try:
+            controlnet.model_id = model_id
+        except Exception as e:
+            logger.debug(f"Failed to set model_id attribute on controlnet: {e}", exc_info=True)
+        return controlnet

--- a/src/streamdiffusion/utils/hf_download.py
+++ b/src/streamdiffusion/utils/hf_download.py
@@ -1,0 +1,142 @@
+"""Shared classification helpers for HuggingFace Hub download failures.
+
+Both `wrapper.py._load_model` and `controlnet_module.py._load_pytorch_controlnet_model`
+call into `diffusers`/`huggingface_hub` loaders that can fail for two very different
+reasons that look identical at the top level:
+
+1. The model id/path is genuinely wrong (typo, private repo, missing file).
+2. The download itself failed (timeout, connection reset, or a HuggingFace Xet
+   transfer-layer failure) - and `diffusers` rewrites that into a generic
+   `EnvironmentError`/`OSError` that reads exactly like case 1 (see
+   `diffusers/utils/hub_utils.py::_get_model_file`, `except EnvironmentError`).
+
+A real-world example of case 2: a 729 MB ControlNet weight download stalls at
+0 bytes for 33 minutes, then `hf_xet`'s Rust download layer raises
+`OSError: I/O error: I/O error: error decoding response body`. That `OSError`
+*is* an `EnvironmentError` (they're the same type in Python 3), so it is caught
+by the same handler as "this model id doesn't exist" and reported as: "make
+sure '<repo>' is the correct path to a directory containing a file named
+<weights_name>". The real cause survives only in `__cause__`.
+
+This module gives both call sites a single, chain-aware way to detect that
+case and react to it (retry with Xet disabled, or at least report the real
+cause with an actionable hint) instead of independently re-deriving it.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Iterator
+
+import requests
+from huggingface_hub import constants as _hf_constants
+from huggingface_hub.errors import HfHubHTTPError, LocalEntryNotFoundError
+
+# Substrings seen in the wrapped OSError's own message when Xet fails. Kept as a
+# fallback for cases where the traceback frames aren't available (e.g. the
+# exception was reconstructed/pickled across a process boundary).
+_XET_MESSAGE_MARKERS = (
+    "error decoding response body",
+    "cas-server",
+    "xethub",
+)
+
+# Function names that only appear in the hf_xet download path's own traceback
+# frames (huggingface_hub/file_download.py calling into the hf_xet package).
+_XET_FRAME_FUNCTION_NAMES = frozenset({"xet_get", "download_files"})
+
+NETWORK_ERROR_TYPES = (requests.exceptions.RequestException, HfHubHTTPError, LocalEntryNotFoundError)
+
+# Shared hint appended when a download/network failure is about to be reported.
+# NOTE: the substring "huggingface download failure" is asserted verbatim by
+# tests/unit/test_load_model_network_error_reporting.py - do not reword it away.
+NETWORK_HINT = (
+    " Hint: this looks like a HuggingFace download failure (timeout/connection/Xet transfer), not an "
+    "invalid model id. The download resumes from where it stopped, so re-launching is usually enough. "
+    "If this keeps happening, consider `pip install hf_xet` for large-file transfers, set "
+    "HF_HUB_DISABLE_XET=1 to fall back to plain HTTPS downloads, and raise HF_HUB_DOWNLOAD_TIMEOUT if "
+    "this keeps happening on a slow connection."
+)
+
+
+def iter_exception_chain(exc: BaseException) -> Iterator[BaseException]:
+    """Yield `exc`, then each `__cause__`/`__context__` ancestor, deepest last.
+
+    Guards against reference cycles (shouldn't normally happen, but a cycle
+    here would otherwise hang forever).
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
+
+
+def _traceback_mentions_xet(exc: BaseException) -> bool:
+    """Inspect exc's own traceback frames for hf_xet's download call stack."""
+    tb = exc.__traceback__
+    while tb is not None:
+        code = tb.tb_frame.f_code
+        if code.co_name in _XET_FRAME_FUNCTION_NAMES:
+            return True
+        filename = code.co_filename.replace("\\", "/")
+        if "/hf_xet/" in filename or filename.endswith("hf_xet.py"):
+            return True
+        tb = tb.tb_next
+    return False
+
+
+def is_xet_download_error(exc: BaseException) -> bool:
+    """Detect a HuggingFace Xet transfer-layer failure hiding inside `exc`'s chain.
+
+    The exception that reaches call sites is usually the *rewritten* diffusers
+    `EnvironmentError` ("can't find the model..."), not the original `OSError`
+    from `hf_xet`. Matching on the top-level message alone would miss it, so
+    this walks `__cause__`/`__context__` and checks each ancestor's own
+    traceback frames and message.
+    """
+    for ancestor in iter_exception_chain(exc):
+        if not isinstance(ancestor, OSError):
+            continue
+        if _traceback_mentions_xet(ancestor):
+            return True
+        message = str(ancestor).lower()
+        if any(marker in message for marker in _XET_MESSAGE_MARKERS):
+            return True
+    return False
+
+
+def is_network_error(exc: BaseException) -> bool:
+    """Chain-aware check for "this is a download/connection failure, not a bad model id"."""
+    for ancestor in iter_exception_chain(exc):
+        if isinstance(ancestor, NETWORK_ERROR_TYPES):
+            return True
+    return is_xet_download_error(exc)
+
+
+@contextmanager
+def xet_disabled():
+    """Temporarily force `huggingface_hub` to skip the Xet transfer layer.
+
+    `huggingface_hub.constants.HF_HUB_DISABLE_XET` is evaluated from
+    `os.environ` exactly once, at import time (see `constants.py`), so setting
+    the environment variable alone has no effect on an already-imported
+    process. Both call sites that matter (`is_xet_available()` and
+    `file_download.py`'s `xet_get`/`http_get` branch) read the *module
+    attribute* at call time, so patch that directly. The environment variable
+    is set too, for the benefit of any late imports or subprocesses.
+    """
+    original_attr = _hf_constants.HF_HUB_DISABLE_XET
+    original_env = os.environ.get("HF_HUB_DISABLE_XET")
+    _hf_constants.HF_HUB_DISABLE_XET = True
+    os.environ["HF_HUB_DISABLE_XET"] = "1"
+    try:
+        yield
+    finally:
+        _hf_constants.HF_HUB_DISABLE_XET = original_attr
+        if original_env is None:
+            os.environ.pop("HF_HUB_DISABLE_XET", None)
+        else:
+            os.environ["HF_HUB_DISABLE_XET"] = original_env

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -15,6 +15,7 @@ from .pipeline import StreamDiffusion
 from .tools.gpu_profiler import configure as _configure_profiler
 from .tools.gpu_profiler import profiler
 from .utils.diagnostics import write_error_report as _write_error_report_util
+from .utils.hf_download import NETWORK_HINT, is_network_error
 
 logger = logging.getLogger(__name__)
 
@@ -1660,8 +1661,17 @@ class StreamDiffusionWrapper:
                     (StableDiffusionPipeline.from_single_file, "SD from_single_file"),
                     (StableDiffusionXLPipeline.from_single_file, "SDXL from_single_file"),
                 ]
+        elif not os.path.exists(model_id_or_path):
+            # A bare HuggingFace repo id (no local path, no .safetensors extension) can only be
+            # loaded via from_pretrained. from_single_file requires an actual file/URL and is
+            # structurally guaranteed to fail here — attempting it anyway just overwrites a real
+            # error (e.g. a network timeout downloading the repo) with a meaningless
+            # "Invalid pretrained_model_name_or_path".
+            loading_methods = [
+                (AutoPipelineForText2Image.from_pretrained, "AutoPipeline from_pretrained"),
+            ]
         else:
-            # For regular model directories or checkpoints, use the original order
+            # Local model directories or single-file checkpoints (e.g. .ckpt) - original order.
             loading_methods = [
                 (AutoPipelineForText2Image.from_pretrained, "AutoPipeline from_pretrained"),
                 (StableDiffusionPipeline.from_single_file, "SD from_single_file"),
@@ -1669,7 +1679,7 @@ class StreamDiffusionWrapper:
             ]
 
         pipe = None
-        last_error = None
+        load_errors = []  # (method_name, exception) for every failed attempt, in order
         for method, method_name in loading_methods:
             try:
                 logger.info(f"_load_model: Attempting to load with {method_name}...")
@@ -1682,7 +1692,18 @@ class StreamDiffusionWrapper:
                     # Try to explicitly load with SDXL pipeline instead
                     try:
                         logger.info("_load_model: Retrying with StableDiffusionXLPipeline...")
-                        pipe = StableDiffusionXLPipeline.from_single_file(model_id_or_path).to(dtype=self.dtype)
+                        # Mirror the same single-file-vs-repo-id test used to build
+                        # loading_methods above: a .safetensors suffix or an existing local
+                        # path is a real file/URL that from_single_file can handle even if it
+                        # doesn't happen to exist yet (e.g. a bad path - that should fail with
+                        # a file-not-found error, not silently be treated as a repo id). Only a
+                        # bare repo id (e.g. one that merely contains "xl") skips
+                        # from_single_file, which requires a local file/URL and would fail
+                        # structurally here.
+                        if model_id_or_path.endswith(".safetensors") or os.path.exists(model_id_or_path):
+                            pipe = StableDiffusionXLPipeline.from_single_file(model_id_or_path).to(dtype=self.dtype)
+                        else:
+                            pipe = StableDiffusionXLPipeline.from_pretrained(model_id_or_path).to(dtype=self.dtype)
                         logger.info("_load_model: Successfully loaded using SDXL pipeline on retry")
                     except Exception as retry_error:
                         # Discard the mismatched-type pipe so a subsequent loading-method
@@ -1696,20 +1717,29 @@ class StreamDiffusionWrapper:
                 break
             except Exception as e:
                 logger.warning(f"_load_model: {method_name} failed: {e}")
-                last_error = e
+                load_errors.append((method_name, e))
                 continue
 
         if pipe is None:
-            error_msg = (
-                f"_load_model: All loading methods failed for model '{model_id_or_path}'. Last error: {last_error}"
-            )
-            logger.error(error_msg)
-            if last_error:
-                logger.warning("Full traceback of last error:")
-                import traceback
+            # Prefer a network-class error when picking which one to surface: a HF download
+            # timeout/connection/Xet-transfer failure is the actual cause far more often than the
+            # structurally-guaranteed from_single_file failures on a bare repo id (see the
+            # loading_methods construction above), and burying it behind those is exactly what
+            # produced the misleading "Invalid pretrained_model_name_or_path" report.
+            chosen_name, chosen_error = load_errors[0]
+            for name, err in load_errors:
+                if is_network_error(err):
+                    chosen_name, chosen_error = name, err
+                    break
 
-                traceback.print_exc()
-            raise RuntimeError(error_msg)
+            hint = NETWORK_HINT if is_network_error(chosen_error) else ""
+            attempts_summary = "; ".join(f"{name}: {err}" for name, err in load_errors)
+            error_msg = (
+                f"_load_model: All loading methods failed for model '{model_id_or_path}'. "
+                f"Reporting error from {chosen_name}: {chosen_error}.{hint} All attempts: {attempts_summary}"
+            )
+            logger.error(error_msg, exc_info=chosen_error)
+            raise RuntimeError(error_msg) from chosen_error
         else:
             if hasattr(pipe, "text_encoder") and pipe.text_encoder is not None:
                 pipe.text_encoder = pipe.text_encoder.to(device=self.device)

--- a/tests/unit/test_controlnet_network_error_reporting.py
+++ b/tests/unit/test_controlnet_network_error_reporting.py
@@ -1,0 +1,222 @@
+"""
+Regression tests for the ControlNet loader's Xet-download-failure handling.
+
+A laptop failed at startup with:
+
+    OSError: Can't load the model for 'thibaud/controlnet-sd21-scribble-diffusers'.
+    ... make sure '...' is the correct path to a directory containing a file
+    named diffusion_pytorch_model.bin
+
+That message is wrong. The real cause was a HuggingFace Xet transfer-layer
+failure (`hf_xet`'s Rust download layer raising `OSError: I/O error: I/O
+error: error decoding response body` after 33 minutes at 0 bytes transferred).
+`diffusers`' `_get_model_file` catches any `EnvironmentError` (== `OSError` in
+Python 3) and rewrites it into the "can't find the model" message above,
+discarding the real cause into `__cause__`.
+
+This is the same bug class already fixed for the base model load path (see
+`test_load_model_network_error_reporting.py`), now fixed for
+`ControlNetModule._load_pytorch_controlnet_model`: detect a Xet transfer
+failure, retry once with Xet disabled (plain HTTPS) and `force_download=True`,
+and if it still fails, report the real cause with an actionable hint instead
+of the misleading message.
+
+Follows the `patch.object(module.Symbol, "method", staticmethod(fake))`
+pattern established in test_load_model_network_error_reporting.py. Unlike
+that file, `ControlNetModule.__init__(device, dtype)` is trivial, so no
+`object.__new__` shell is needed, and `ControlNetModel` is imported at module
+level in controlnet_module.py, so the patch target is
+`controlnet_module.ControlNetModel`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import torch
+from huggingface_hub import constants as hf_constants
+
+from streamdiffusion.modules import controlnet_module as controlnet_module_mod
+from streamdiffusion.modules.controlnet_module import ControlNetModule
+from streamdiffusion.utils.hf_download import is_xet_download_error
+
+
+def _make_xet_error() -> OSError:
+    """Build a synthetic exception chain mirroring the real one from the log:
+    an inner OSError raised from a function literally named `xet_get` (so it
+    carries a genuine traceback frame matching the detection signature),
+    wrapped by an outer OSError with the misleading diffusers-style message.
+    """
+
+    def download_files():
+        raise OSError("I/O error: I/O error: error decoding response body")
+
+    def xet_get():
+        download_files()
+
+    try:
+        xet_get()
+    except OSError as inner:
+        try:
+            raise OSError(
+                "Can't load the model for 'thibaud/controlnet-sd21-scribble-diffusers'. ... make "
+                "sure '...' is the correct path to a directory containing a file named "
+                "diffusion_pytorch_model.bin"
+            ) from inner
+        except OSError as outer:
+            return outer
+    raise AssertionError("unreachable")
+
+
+class _FakeControlNet:
+    """Stand-in for a loaded ControlNetModel."""
+
+    model_id: str | None = None
+
+    def to(self, *args, **kwargs):
+        return self
+
+
+class TestXetDownloadErrorDetection:
+    def test_detects_xet_error_chain(self):
+        assert is_xet_download_error(_make_xet_error()) is True
+
+    def test_does_not_flag_ordinary_oserror(self):
+        assert is_xet_download_error(OSError("permission denied")) is False
+
+    def test_does_not_flag_genuine_missing_file(self):
+        err = OSError(
+            "Can't load the model for 'some/typo-repo'. ... make sure 'some/typo-repo' is the "
+            "correct path to a directory containing a file named diffusion_pytorch_model.bin"
+        )
+        assert is_xet_download_error(err) is False
+
+
+class TestXetRetrySucceeds:
+    def test_retries_with_xet_disabled_and_force_download(self):
+        calls = []
+
+        def fake_from_pretrained(model_id, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise _make_xet_error()
+            return _FakeControlNet()
+
+        module = ControlNetModule(device="cpu", dtype=torch.float32)
+
+        with patch.object(
+            controlnet_module_mod.ControlNetModel,
+            "from_pretrained",
+            staticmethod(fake_from_pretrained),
+        ):
+            result = module._load_pytorch_controlnet_model("thibaud/controlnet-sd21-scribble-diffusers")
+
+        assert isinstance(result, _FakeControlNet)
+        assert len(calls) == 2, "expected exactly one retry after the Xet failure"
+        assert calls[0].get("force_download") is not True
+        assert calls[1].get("force_download") is True
+        assert result.model_id == "thibaud/controlnet-sd21-scribble-diffusers"
+
+
+class TestXetDisableStateRestored:
+    def test_restored_after_successful_retry(self):
+        original = hf_constants.HF_HUB_DISABLE_XET
+        seen_during_retry = {}
+        calls = []
+
+        def fake_from_pretrained(model_id, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise _make_xet_error()
+            seen_during_retry["value"] = hf_constants.HF_HUB_DISABLE_XET
+            return _FakeControlNet()
+
+        module = ControlNetModule(device="cpu", dtype=torch.float32)
+
+        try:
+            with patch.object(
+                controlnet_module_mod.ControlNetModel,
+                "from_pretrained",
+                staticmethod(fake_from_pretrained),
+            ):
+                module._load_pytorch_controlnet_model("thibaud/controlnet-sd21-scribble-diffusers")
+        finally:
+            assert original == hf_constants.HF_HUB_DISABLE_XET
+
+        assert seen_during_retry["value"] is True
+
+    def test_restored_after_failed_retry(self):
+        original = hf_constants.HF_HUB_DISABLE_XET
+
+        def fake_from_pretrained(model_id, **kwargs):
+            raise _make_xet_error()
+
+        module = ControlNetModule(device="cpu", dtype=torch.float32)
+
+        try:
+            with patch.object(
+                controlnet_module_mod.ControlNetModel,
+                "from_pretrained",
+                staticmethod(fake_from_pretrained),
+            ):
+                with pytest.raises(RuntimeError):
+                    module._load_pytorch_controlnet_model("thibaud/controlnet-sd21-scribble-diffusers")
+        finally:
+            assert original == hf_constants.HF_HUB_DISABLE_XET
+
+
+class TestPermanentFailureMessage:
+    def test_message_reports_real_cause_with_hint(self):
+        xet_error = _make_xet_error()
+
+        def fake_from_pretrained(model_id, **kwargs):
+            raise xet_error
+
+        module = ControlNetModule(device="cpu", dtype=torch.float32)
+
+        with patch.object(
+            controlnet_module_mod.ControlNetModel,
+            "from_pretrained",
+            staticmethod(fake_from_pretrained),
+        ):
+            with pytest.raises(Exception) as exc_info:
+                module._load_pytorch_controlnet_model("thibaud/controlnet-sd21-scribble-diffusers")
+
+        message = str(exc_info.value).lower()
+        assert "huggingface download failure" in message
+        # Unlike the original bug report (bare diffusers text, no explanation at all),
+        # the final message must make clear a Xet-disabled retry was attempted.
+        assert "retrying without xet" in message
+        # The real cause must be preserved in the exception chain, not discarded.
+        cause_chain = []
+        cur = exc_info.value
+        while cur is not None:
+            cause_chain.append(cur)
+            cur = cur.__cause__
+        assert xet_error in cause_chain
+
+
+class TestOfflineModeSkipsRetry:
+    def test_offline_mode_does_not_retry(self, monkeypatch):
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+        calls = []
+
+        def fake_from_pretrained(model_id, **kwargs):
+            calls.append(kwargs)
+            raise _make_xet_error()
+
+        module = ControlNetModule(device="cpu", dtype=torch.float32)
+
+        with patch.object(
+            controlnet_module_mod.ControlNetModel,
+            "from_pretrained",
+            staticmethod(fake_from_pretrained),
+        ):
+            # Offline mode's permanent-failure path is a bare `raise` (preserves the original
+            # exception unchanged) rather than the RuntimeError wrapping used elsewhere - it never
+            # reaches the "retry failed" or "non-offline network error" branches that wrap.
+            with pytest.raises(OSError):
+                module._load_pytorch_controlnet_model("thibaud/controlnet-sd21-scribble-diffusers")
+
+        assert len(calls) == 1, "offline mode must not retry a Xet failure"

--- a/tests/unit/test_load_model_network_error_reporting.py
+++ b/tests/unit/test_load_model_network_error_reporting.py
@@ -1,0 +1,164 @@
+"""
+Regression tests for the `_load_model` error-masking fix.
+
+A clean install's first run failed after a 56-minute HuggingFace download
+timeout with a misleading `RuntimeError: ... Invalid pretrained_model_name_or_path
+provided`. The real cause (a network timeout downloading a bare HF repo id) was
+overwritten by two structurally-guaranteed-to-fail `from_single_file` attempts
+that ran afterward, whose own failure became the reported error.
+
+Covers three independent pieces of that fix in `StreamDiffusionWrapper._load_model`:
+
+1. A bare HF repo id (no local path, no `.safetensors` suffix) builds a
+   single-entry `loading_methods` list — `from_single_file` requires an actual
+   file/URL and can never succeed on a bare repo id, so it must not be tried.
+2. When the sole attempt fails with a network-class error, that error (not a
+   masked "Invalid pretrained_model_name_or_path") is what `_load_model` raises,
+   with the network exception preserved as `__cause__`.
+3. A bare repo id that merely contains the substring "xl" routes the inner
+   SDXL pipeline-mismatch retry through `StableDiffusionXLPipeline.from_pretrained`,
+   not `.from_single_file`, for the same structural reason as (1).
+
+Follows the object.__new__ shell + patch.object(wrapper_module.*, ...) pattern
+established in test_wrapper_exception_hygiene.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import requests
+import torch
+
+from streamdiffusion import wrapper as wrapper_module
+from streamdiffusion.wrapper import StreamDiffusionWrapper
+
+
+def _make_wrapper_shell() -> StreamDiffusionWrapper:
+    """Construct a minimal StreamDiffusionWrapper without model loading."""
+    w = object.__new__(StreamDiffusionWrapper)
+    w.device = torch.device("cpu")
+    w.dtype = torch.float32
+    w.cleanup_gpu_memory = lambda: None
+    return w
+
+
+class _FakeWrongTypePipe:
+    """Stand-in for a successfully-loaded but non-SDXL pipeline object."""
+
+    def to(self, *args, **kwargs):
+        return self
+
+
+class TestBareRepoIdLoadingMethods:
+    def test_from_single_file_variants_are_never_attempted(self):
+        sd_single_file_calls = []
+        xl_single_file_calls = []
+
+        def fake_auto_from_pretrained(path, *args, **kwargs):
+            raise RuntimeError("AutoPipeline boom")
+
+        def fake_sd_from_single_file(path, *args, **kwargs):
+            sd_single_file_calls.append(path)
+            raise RuntimeError("should never be reached")
+
+        def fake_xl_from_single_file(path, *args, **kwargs):
+            xl_single_file_calls.append(path)
+            raise RuntimeError("should never be reached")
+
+        w = _make_wrapper_shell()
+
+        with (
+            patch.object(
+                wrapper_module.AutoPipelineForText2Image,
+                "from_pretrained",
+                staticmethod(fake_auto_from_pretrained),
+            ),
+            patch.object(
+                wrapper_module.StableDiffusionPipeline,
+                "from_single_file",
+                staticmethod(fake_sd_from_single_file),
+            ),
+            patch.object(
+                wrapper_module.StableDiffusionXLPipeline,
+                "from_single_file",
+                staticmethod(fake_xl_from_single_file),
+            ),
+        ):
+            with pytest.raises(RuntimeError):
+                w._load_model("stabilityai/sd-turbo", t_index_list=[0])
+
+        assert sd_single_file_calls == [], "SD from_single_file must not be attempted for a bare repo id"
+        assert xl_single_file_calls == [], "SDXL from_single_file must not be attempted for a bare repo id"
+
+
+class TestNetworkErrorNotMasked:
+    def test_read_timeout_is_reported_not_masked(self):
+        """The regression test for the reported bug: a HF download timeout must
+        surface as itself, not as 'Invalid pretrained_model_name_or_path'."""
+        timeout_error = requests.exceptions.ReadTimeout("Read timed out. (read timeout=10)")
+
+        def fake_auto_from_pretrained(path, *args, **kwargs):
+            raise timeout_error
+
+        w = _make_wrapper_shell()
+
+        with patch.object(
+            wrapper_module.AutoPipelineForText2Image,
+            "from_pretrained",
+            staticmethod(fake_auto_from_pretrained),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                w._load_model("stabilityai/sd-turbo", t_index_list=[0])
+
+        message = str(exc_info.value).lower()
+        assert "invalid `pretrained_model_name_or_path`" not in message
+        assert "read timed out" in message
+        assert "huggingface download failure" in message
+        assert exc_info.value.__cause__ is timeout_error
+
+
+class TestXlNamedBareRepoIdRetry:
+    def test_inner_retry_uses_from_pretrained_not_from_single_file(self):
+        """A bare repo id containing 'xl' (matching the SDXL-indicator substring
+        check) is not a local file - the inner SDXL pipeline-mismatch retry must
+        use from_pretrained, not from_single_file."""
+        xl_from_pretrained_calls = []
+        xl_from_single_file_calls = []
+
+        def fake_auto_from_pretrained(path, *args, **kwargs):
+            return _FakeWrongTypePipe()
+
+        def fake_xl_from_pretrained(path, *args, **kwargs):
+            xl_from_pretrained_calls.append(path)
+            raise RuntimeError("retry boom")
+
+        def fake_xl_from_single_file(path, *args, **kwargs):
+            xl_from_single_file_calls.append(path)
+            raise RuntimeError("should never be reached")
+
+        w = _make_wrapper_shell()
+
+        with (
+            patch.object(
+                wrapper_module.AutoPipelineForText2Image,
+                "from_pretrained",
+                staticmethod(fake_auto_from_pretrained),
+            ),
+            patch.object(
+                wrapper_module.StableDiffusionXLPipeline,
+                "from_pretrained",
+                staticmethod(fake_xl_from_pretrained),
+            ),
+            patch.object(
+                wrapper_module.StableDiffusionXLPipeline,
+                "from_single_file",
+                staticmethod(fake_xl_from_single_file),
+            ),
+        ):
+            with pytest.raises(RuntimeError):
+                w._load_model("some-xl-model", t_index_list=[0])
+
+        assert xl_from_pretrained_calls == ["some-xl-model"]
+        assert xl_from_single_file_calls == [], "from_single_file must not be attempted on a bare repo id retry"


### PR DESCRIPTION
## What

A laptop failed at startup with:

```
OSError: Can't load the model for 'thibaud/controlnet-sd21-scribble-diffusers'.
... make sure '...' is the correct path to a directory containing a file
named diffusion_pytorch_model.bin
```

That message is wrong. The real cause was a HuggingFace Xet transfer-layer failure (`hf_xet`'s
Rust download layer raising `OSError: I/O error: I/O error: error decoding response body` after
33 minutes at 0 bytes transferred). `diffusers`' `_get_model_file` catches any `EnvironmentError`
(== `OSError` in Python 3) and rewrites it into the misleading "can't find the model" message
above, discarding the real cause into `__cause__`. A second field report hit the same class of bug
via a 56-minute plain network timeout on the base model load path.

## How

New `src/streamdiffusion/utils/hf_download.py`:
- `is_xet_download_error` / `is_network_error` — detect a Xet-transfer-layer or generic network
  failure by walking the exception's `__cause__`/`__context__` chain and inspecting tracebacks for
  Xet-specific frames.
- `xet_disabled()` — a context manager that mutates `huggingface_hub.constants.HF_HUB_DISABLE_XET`
  directly, not just the env var. The constant is evaluated once at import time, so setting the
  env var alone has no effect on an already-imported `huggingface_hub`.

**Two call sites, and they are not symmetric:**

- **`controlnet_module.py`'s `_load_pytorch_controlnet_model`** — detection **+ retry**. On a Xet
  failure (and not offline), retries once with Xet disabled (plain HTTPS) and
  `force_download=True` (a failed Xet transfer can leave a partial `.incomplete` file that a
  plain-HTTPS resume would misinterpret). Reports the real cause with an actionable hint if the
  retry also fails.
- **`wrapper.py`'s `_load_model`** — reporting only, **no retry**. Prefers a network-class error
  when choosing which of several failed loading-method attempts to surface (instead of whichever
  happened to run last), and appends the same hint. Also fixes a related bug found while working
  on this: the SDXL bare-repo-id retry unconditionally called
  `StableDiffusionXLPipeline.from_single_file`, which requires a local file/URL and fails
  structurally on a bare repo id — burying the real error behind a second, meaningless one. It now
  checks for a local file/URL first and falls back to `from_pretrained` otherwise.

`setup.py`: declares `requests` in `install_requires`. `hf_download.py` imports it at module scope,
and `wrapper.py` imports `hf_download` at module scope, so this PR is what puts `requests` on the
core import path. It already resolved transitively via `huggingface_hub`; this makes it explicit.

## Testing

`tests/unit/test_load_model_network_error_reporting.py` and
`tests/unit/test_controlnet_network_error_reporting.py` (new, 8 tests) cover detection, the retry
sequence, Xet-disabled-state restoration (success and failure paths), the permanent-failure
message format, and that offline mode (`HF_HUB_OFFLINE=1`) skips the retry entirely.

`tests/unit/test_wrapper_exception_hygiene.py` (pre-existing, unchanged) asserts on the substring
`"all loading methods failed"` — verified this still passes against the rewritten message.

Ran all three locally against this branch: **18 passed**.

```
pip install -e .
pytest tests/unit/test_load_model_network_error_reporting.py \
       tests/unit/test_controlnet_network_error_reporting.py \
       tests/unit/test_wrapper_exception_hygiene.py -q
```

Note: there's no `conftest.py` or pytest config in the repo, and the only CI workflow
(`release.yml`) is tag-triggered, so these won't run in CI automatically — the run command above
is the way to exercise them.
