### PR TITLE
deps: pin cuda-link to the published wheel instead of the VCS tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ _deps = [
     f"cuda-python{get_cuda_constraint()}",
     "xformers==0.0.30",
     "diffusers @ git+https://github.com/varshith15/diffusers.git@3e3b72f557e91546894340edabc845e894f00922",
-    "cuda-link @ git+https://github.com/forkni/cuda-link@v1.12.1",
+    "cuda-link @ https://github.com/forkni/cuda-link/releases/download/v1.12.1/cuda_link-1.12.1-cp311-cp311-win_amd64.whl ; sys_platform == 'win32' and python_version == \"3.11\"",
     "transformers==4.56.0",
     "accelerate==1.13.0",
     "huggingface_hub==0.35.0",


### PR DESCRIPTION
## What

Changes the `cuda-link` dependency in `setup.py` from a VCS pin
(`cuda-link @ git+https://github.com/forkni/cuda-link@v1.12.1`) to the wheel the same tag already
publishes, gated by a platform/version marker:

```
cuda-link @ https://github.com/forkni/cuda-link/releases/download/v1.12.1/cuda_link-1.12.1-cp311-cp311-win_amd64.whl ; sys_platform == 'win32' and python_version == "3.11"
```

## Why

`cuda-link` builds via `scikit_build_core.build` (it compiles `_native_waiter.cpp`), so the VCS
pin makes `pip` clone the repo and build it from source — requiring MSVC on Windows — even though
release `v1.12.1` already publishes a prebuilt `cp311-cp311-win_amd64` wheel.

The marker is required, not optional: `extras["dev"]` includes `cuda_ipc`
(`deps_list("cuda-link")`), so an unmarked hard pin to a `win_amd64`-only wheel would make
`pip install -e .[dev]` fail to resolve on Linux/macOS and on Python 3.10 — which is what this
repo's own `release.yml` builds on. With the marker, `cuda-link` is simply skipped as a requirement
on non-matching platforms instead of failing.

Precedent for the marker pattern already exists one line away, for `pywin32`:
`"pywin32==311;sys_platform == 'win32'"`.

## Testing

`deps_list`'s parsing regex (`re.findall(r"^(([^!=<>~ @]+)(?:[!=<>~ @].*)?$)", x)`) splits on
`[^!=<>~ @]+`, so the dict key stays `cuda-link` with the marker appended intact — verified by
running the regex against the new string directly. Also ran `python setup.py --version`, which
parses `_deps`/`deps`/`extras` and returns `0.1.1` without raising.
