### PR TITLE
fix: rebuild batch buffers on live t_index resize

### DIFF
--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -1043,7 +1043,11 @@ class StreamDiffusion:
         if self.use_denoising_batch:
             denoised_batch = self.scheduler_step_batch(model_pred, x_t_latent, idx)
 
-            if self.cfg_type == "self" or self.cfg_type == "initialize":
+            # Residual propagation only matters when a next step exists to consume it.
+            # At denoising_steps_num == 1 the write would persist a value the n>1 design
+            # treats as a throwaway (_alpha_next/_beta_next degenerate to 1.0), and
+            # predict_x0_batch reseeds stock_noise from init_noise every frame anyway.
+            if (self.cfg_type == "self" or self.cfg_type == "initialize") and self.denoising_steps_num > 1:
                 scaled_noise = self.beta_prod_t_sqrt * self.stock_noise
                 delta_x = self.scheduler_step_batch(model_pred, scaled_noise, idx)
                 delta_x = self._alpha_next * delta_x
@@ -1140,6 +1144,14 @@ class StreamDiffusion:
                     _sn_dst[1:].copy_(self.stock_noise[:-1])
                     self.stock_noise = _sn_dst
                     self._stock_noise_pong = 1 - self._stock_noise_pong
+                elif self.cfg_type == "self" or self.cfg_type == "initialize":
+                    # denoising_steps_num == 1: no ping-pong slot exists to reseed, and the
+                    # RCFG cross-frame recurrence has growth factor |A| > 1 at typical
+                    # single-step timesteps — without this per-frame reseed stock_noise
+                    # diverges geometrically and guidance > 1 renders black (fp16 Inf→NaN).
+                    # Per paper Eq. 5, the Self-Negative residual at the first (only) step
+                    # is exactly init_noise.
+                    self.stock_noise.copy_(self.init_noise)
                 with profiler.region("unet_step"):
                     x_0_pred_batch, model_pred = self.unet_step(x_t_latent, t_list)
 

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -686,16 +686,23 @@ class StreamDiffusion:
         """Re-create tensors derived from batch_size/scheduler state but NOT rebuilt by
         StreamParameterUpdater._update_timestep_calculations.
 
-        Called by the error-fallback handler in __call__ after
-        _param_updater._update_timestep_calculations() has already refreshed
-        sub_timesteps_tensor, c_skip/c_out, alpha/beta_prod_t_sqrt.
+        Called after _param_updater._update_timestep_calculations() has already
+        refreshed sub_timesteps_tensor, c_skip/c_out, alpha/beta_prod_t_sqrt — by
+        the error-fallback handler in __call__ and by the updater's live
+        t_index_list length-change path (_recalculate_timestep_dependent_params).
         """
-        # init_noise + stock_noise — re-sampled so the fallback frame is coherent
+        # init_noise + stock_noise — re-sampled so the next frame is coherent
         self.init_noise = torch.randn(
             (self.batch_size, 4, self.latent_height, self.latent_width),
             generator=self.generator,
         ).to(device=self.device, dtype=self.dtype)
         self.stock_noise = self.init_noise.clone()
+
+        # Ping-pong buffers for the stock_noise rotation (see prepare()) — batch-sized,
+        # so any batch_size change without this rebuild leaves predict_x0_batch's
+        # copy_ failing every frame with no way to self-heal.
+        self._stock_noise_bufs = [self.stock_noise.clone(), torch.empty_like(self.stock_noise)]
+        self._stock_noise_pong = 0
 
         # Pre-computed shifted tensors (depend on alpha/beta already refreshed above)
         if self.use_denoising_batch and (self.cfg_type == "self" or self.cfg_type == "initialize"):

--- a/src/streamdiffusion/stream_parameter_updater.py
+++ b/src/streamdiffusion/stream_parameter_updater.py
@@ -978,13 +978,18 @@ class StreamParameterUpdater(OrchestratorUser):
         # init_noise every frame (pipeline.py, elif after the ping-pong block) — do not
         # reintroduce logic here that assumes stock_noise persists across frames at n==1.
         # F2: Keep pre-computed shifted tensors in sync with the new alpha/beta values.
-        # _alpha_next / _beta_next / _init_noise_rotated are built only in prepare()
-        # (pipeline.py:595-605) and the error-fallback _refresh_derived_tensors().
-        # Without this sync they go stale when t_index_list is updated at runtime,
-        # causing incorrect stock_noise rotation at guidance > 1.0 (RCFG-self path,
-        # pipeline.py:979-984).  _init_noise_rotated is a rotation of init_noise which
-        # is unchanged by a t_index value-only update, so we re-derive from the live tensor
-        # rather than re-sampling (mirrors the _update_seed precedent at :749-753).
+        # _alpha_next / _beta_next / _init_noise_rotated are built in prepare()
+        # (pipeline.py:595-605) and in _refresh_derived_tensors() (called by the
+        # __call__ error fallback AND by the length-change path of
+        # _recalculate_timestep_dependent_params, which delegates its whole
+        # batch-sized rebuild there). This block covers the remaining live path:
+        # a same-length t_index VALUE update, where batch size is unchanged and
+        # only alpha/beta moved. On the length-change path it runs transiently
+        # against the old-size init_noise and is immediately overwritten by the
+        # delegate — no frame runs in between (updater holds _lock).
+        # _init_noise_rotated is a rotation of init_noise which is unchanged by a
+        # value-only update, so we re-derive from the live tensor rather than
+        # re-sampling (mirrors the _update_seed precedent at :749-753).
         if (
             self.stream.use_denoising_batch
             and (self.stream.cfg_type == "self" or self.stream.cfg_type == "initialize")
@@ -1071,13 +1076,6 @@ class StreamParameterUpdater(OrchestratorUser):
         else:
             self.stream.x_t_latent_buffer = None
 
-        self.stream.init_noise = torch.randn(
-            (self.stream.batch_size, 4, self.stream.latent_height, self.stream.latent_width),
-            generator=self.stream.generator,
-        ).to(device=self.stream.device, dtype=self.stream.dtype)
-
-        # Clone (not zeros) to match prepare()'s stock_noise semantics
-        self.stream.stock_noise = self.stream.init_noise.clone()
         self.stream.prompt_embeds = self.stream.prompt_embeds[0].repeat(self.stream.batch_size, 1, 1)
 
         # Resize kvo_cache tensors if batch size changed
@@ -1112,6 +1110,13 @@ class StreamParameterUpdater(OrchestratorUser):
 
         # Update timestep-dependent calculations (shared with value-only path)
         self._update_timestep_calculations()
+
+        # Rebuild every batch-sized derived tensor — init_noise, stock_noise, the
+        # ping-pong _stock_noise_bufs, _combined_latent_buf, _cfg_latent_buf/_cfg_t_buf,
+        # _alpha_next/_beta_next/_init_noise_rotated — through the single shared
+        # implementation (prepare() parity). Must run after
+        # _update_timestep_calculations(): it consumes the refreshed alpha/beta.
+        self.stream._refresh_derived_tensors()
 
     def _regenerate_resolution_tensors(self) -> None:
         """This method is no longer used - resolution updates now restart the pipeline"""

--- a/src/streamdiffusion/stream_parameter_updater.py
+++ b/src/streamdiffusion/stream_parameter_updater.py
@@ -883,8 +883,10 @@ class StreamParameterUpdater(OrchestratorUser):
             generator=self.stream.generator,
         ).to(device=self.stream.device, dtype=self.stream.dtype)
 
-        # Reset stock_noise to match the new init_noise
-        self.stream.stock_noise = torch.zeros_like(self.stream.init_noise)
+        # Reset stock_noise to match the new init_noise (same semantics as prepare():
+        # a zeros reset makes the RCFG uncond term start from nothing instead of a
+        # coherent residual, visible as a guidance glitch right after a seed change)
+        self.stream.stock_noise = self.stream.init_noise.clone()
 
         # Keep pre-computed rotation in sync with new init_noise
         if self.stream._init_noise_rotated is not None:
@@ -972,6 +974,9 @@ class StreamParameterUpdater(OrchestratorUser):
             dim=0,
         )
 
+        # F3: At denoising_steps_num == 1 predict_x0_batch reseeds stock_noise from
+        # init_noise every frame (pipeline.py, elif after the ping-pong block) — do not
+        # reintroduce logic here that assumes stock_noise persists across frames at n==1.
         # F2: Keep pre-computed shifted tensors in sync with the new alpha/beta values.
         # _alpha_next / _beta_next / _init_noise_rotated are built only in prepare()
         # (pipeline.py:595-605) and the error-fallback _refresh_derived_tensors().
@@ -1071,7 +1076,8 @@ class StreamParameterUpdater(OrchestratorUser):
             generator=self.stream.generator,
         ).to(device=self.stream.device, dtype=self.stream.dtype)
 
-        self.stream.stock_noise = torch.zeros_like(self.stream.init_noise)
+        # Clone (not zeros) to match prepare()'s stock_noise semantics
+        self.stream.stock_noise = self.stream.init_noise.clone()
         self.stream.prompt_embeds = self.stream.prompt_embeds[0].repeat(self.stream.batch_size, 1, 1)
 
         # Resize kvo_cache tensors if batch size changed

--- a/tests/gpu/test_rcfg_self_single_step_e2e.py
+++ b/tests/gpu/test_rcfg_self_single_step_e2e.py
@@ -1,0 +1,64 @@
+"""GPU e2e regression: RCFG 'self' with a single denoising step must not go black.
+
+Locks down the bug fixed in pipeline.py's predict_x0_batch: at
+denoising_steps_num == 1 the ping-pong reseed never runs while unet_step's
+cross-frame recurrence has growth factor |A| > 1, so stock_noise diverged
+geometrically -> fp16 Inf -> NaN in the CFG combine -> black frames within
+seconds whenever guidance_scale > 1. The fix reseeds stock_noise from
+init_noise every frame (per paper Eq. 5 the Self-Negative residual at the
+first step is exactly init_noise).
+
+Pre-fix, divergence hit fp16 Inf within ~5 frames; 120 frames is a wide
+red-capable margin. Uses stabilityai/sd-turbo + taesd (both HF-cached),
+acceleration="none" to avoid TRT engine builds.
+
+Run: venv/Scripts/python.exe -m pytest tests/gpu -v
+"""
+
+import os
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+REPO_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
+INPUT_IMAGE = os.path.join(REPO_ROOT, "images", "inputs", "input.png")
+
+N_FRAMES = 120
+
+
+class TestRcfgSelfSingleStepE2E:
+    def test_single_step_guidance_above_one_stays_visible(self):
+        from streamdiffusion import StreamDiffusionWrapper
+
+        stream = StreamDiffusionWrapper(
+            model_id_or_path="stabilityai/sd-turbo",
+            t_index_list=[16],
+            frame_buffer_size=1,
+            width=512,
+            height=512,
+            warmup=1,
+            acceleration="none",
+            mode="img2img",
+            use_denoising_batch=True,
+            cfg_type="self",
+            output_type="pt",
+            seed=42,
+        )
+        stream.prepare(
+            prompt="a photograph of a cat",
+            negative_prompt="",
+            num_inference_steps=50,
+            guidance_scale=1.4,
+            delta=1.0,
+        )
+
+        image_tensor = stream.preprocess_image(INPUT_IMAGE)
+        for frame in range(N_FRAMES):
+            output = stream(image=image_tensor)
+            assert torch.isfinite(output).all(), f"non-finite output at frame {frame}"
+
+        # Mean luminance over 0-255: a black (NaN-clamped) frame sits at ~0.
+        luminance = output.float().mean().item() * 255.0
+        assert luminance > 10.0, f"output collapsed to black: mean luminance {luminance:.2f}"

--- a/tests/unit/test_live_t_index_resize_buffers.py
+++ b/tests/unit/test_live_t_index_resize_buffers.py
@@ -1,0 +1,195 @@
+"""
+Regression tests for stale batch-sized buffers after a live t_index_list
+LENGTH change (TD: TIndexBlock numBlocks changed while the stream runs).
+
+Root cause guarded: StreamParameterUpdater._recalculate_timestep_dependent_params
+(length-changed branch) rebuilds batch_size, x_t_latent_buffer, init_noise,
+stock_noise and prompt_embeds — but never `_stock_noise_bufs` / `_stock_noise_pong`
+/ `_combined_latent_buf` / `_cfg_latent_buf` / `_cfg_t_buf`, all allocated only in
+prepare(). predict_x0_batch's n>1 path subscripts `_combined_latent_buf` and runs
+the ping-pong rotation unconditionally, so the next frame after a live resize:
+
+  - 1 -> n>1:  `None[: frame_bff_size]` TypeError (uncaught: __call__'s fallback
+               only catches RuntimeError) — stream dead until restart.
+  - grow n>=2: stale-shape copy_ RuntimeError; the fallback's
+               _refresh_derived_tensors() rebuilt _combined_latent_buf but NOT
+               _stock_noise_bufs, so it failed again every frame (permanent
+               decode(randn) noise loop).
+  - shrink:    copy_ broadcast-succeeds silently, then `stock_noise = _sn_dst`
+               rebinds stock_noise to the stale larger tensor — shape mismatch
+               downstream / silent corruption.
+
+Fix guarded here: _refresh_derived_tensors() also rebuilds the ping-pong buffers,
+and the updater's length-change branch delegates its derived-tensor rebuild to it
+(prepare() parity from one shared implementation).
+
+CPU-only, model-free. Reuses the object.__new__ harnesses from
+test_rcfg_self_single_step_reseed.py (real StreamDiffusion + fake UNet) and
+test_derived_tensor_sync.py (real StreamParameterUpdater shell).
+"""
+
+import torch
+from test_rcfg_self_single_step_reseed import _make_stream, _zero_input
+
+from streamdiffusion.pipeline import StreamDiffusion
+from streamdiffusion.stream_parameter_updater import StreamParameterUpdater
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_resizable_stream(t_index_list, **kwargs):
+    """_make_stream plus the attributes the updater's length-change branch reads
+    (t_list, timesteps, kvo plumbing, instance-assigned scheduler scalings —
+    the object.__new__ LCMScheduler shell has no .config for the real method)."""
+    stream = _make_stream(t_index_list, **kwargs)
+    stream.t_list = list(t_index_list)
+    stream.timesteps = torch.linspace(999, 19, 50).long()
+    stream.sub_timesteps = [int(stream.timesteps[i]) for i in t_index_list]
+    stream._kvo_buckets = None
+    stream._kvo_outputs_by_bucket = None
+
+    def _scalings(timestep):
+        # Same LCM boundary-condition formulas as _make_stream (sigma_data=0.5,
+        # timestep_scaling=10): c_skip ~ 0, c_out ~ 1 at these timesteps
+        t = float(timestep.item() if isinstance(timestep, torch.Tensor) else timestep)
+        st = 10.0 * t
+        return torch.tensor(0.25 / (st**2 + 0.25)), torch.tensor(st / (st**2 + 0.25) ** 0.5)
+
+    stream.scheduler.get_scalings_for_boundary_condition_discrete = _scalings
+    return stream
+
+
+def _make_updater(stream):
+    """Construct StreamParameterUpdater without calling __init__ (avoids deps)."""
+    updater = object.__new__(StreamParameterUpdater)
+    updater.stream = stream
+    updater._lock = __import__("threading").Lock()
+    return updater
+
+
+def _assert_frames_healthy(stream, n_new, num_frames):
+    """Drive predict_x0_batch and assert per-frame batch-shape consistency."""
+    x_in = _zero_input(stream)
+    for frame in range(num_frames):
+        x0 = StreamDiffusion.predict_x0_batch(stream, x_in)
+        assert torch.isfinite(x0).all(), f"frame {frame}: non-finite x0 after resize to n={n_new}"
+        assert stream.stock_noise.shape[0] == n_new, (
+            f"frame {frame}: stock_noise has {stream.stock_noise.shape[0]} rows, expected {n_new} — "
+            "stale ping-pong buffer rebound after live resize"
+        )
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+class TestLiveTIndexResize:
+    """Live length change via updater._recalculate_timestep_dependent_params,
+    then frames through the real predict_x0_batch — no prepare() in between,
+    exactly like the OSC /t_list path in TD."""
+
+    def test_grow_1_to_2(self):
+        stream = _make_resizable_stream([16])
+        updater = _make_updater(stream)
+        _assert_frames_healthy(stream, 1, 2)  # pre-resize baseline works
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        # Pre-fix: TypeError — _combined_latent_buf is still None from n==1
+        _assert_frames_healthy(stream, 2, 4)
+        assert stream._combined_latent_buf.shape[0] == 2
+        for buf in stream._stock_noise_bufs:
+            assert buf.shape[0] == 2
+
+    def test_grow_1_to_2_ping_pong_rotates(self):
+        stream = _make_resizable_stream([16])
+        updater = _make_updater(stream)
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        x_in = _zero_input(stream)
+        expected_pong = stream._stock_noise_pong
+        for frame in range(4):
+            StreamDiffusion.predict_x0_batch(stream, x_in)
+            expected_pong = 1 - expected_pong
+            assert stream._stock_noise_pong == expected_pong, (
+                f"frame {frame}: ping-pong rotation not engaged after live 1->2 resize"
+            )
+
+    def test_grow_2_to_3(self):
+        stream = _make_resizable_stream([16, 32])
+        updater = _make_updater(stream)
+        _assert_frames_healthy(stream, 2, 2)
+
+        updater._recalculate_timestep_dependent_params([8, 24, 40])
+
+        # Pre-fix: RuntimeError — 2-row _combined_latent_buf vs 3-row tensors,
+        # and _stock_noise_bufs stay 2-row even after _refresh_derived_tensors()
+        _assert_frames_healthy(stream, 3, 4)
+        assert stream._combined_latent_buf.shape[0] == 3
+        for buf in stream._stock_noise_bufs:
+            assert buf.shape[0] == 3
+
+    def test_shrink_3_to_2(self):
+        stream = _make_resizable_stream([8, 24, 40])
+        updater = _make_updater(stream)
+        _assert_frames_healthy(stream, 3, 2)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        # Pre-fix: the stale 3-row buffers broadcast-accept the 2-row copies
+        # silently, then stock_noise is rebound to 3 rows (caught per-frame in
+        # _assert_frames_healthy) and unet_step raises on the shape mismatch
+        _assert_frames_healthy(stream, 2, 4)
+        assert stream._combined_latent_buf.shape[0] == 2
+        for buf in stream._stock_noise_bufs:
+            assert buf.shape[0] == 2
+
+    def test_shrink_2_to_1(self):
+        stream = _make_resizable_stream([16, 32])
+        updater = _make_updater(stream)
+        _assert_frames_healthy(stream, 2, 2)
+
+        updater._recalculate_timestep_dependent_params([16])
+
+        # n==1 path uses none of the batch buffers (functional today); the buf
+        # must also be dropped to None for prepare() parity so a later grow
+        # re-allocates instead of reusing a stale tensor
+        x_in = _zero_input(stream)
+        for frame in range(4):
+            x0 = StreamDiffusion.predict_x0_batch(stream, x_in)
+            assert torch.isfinite(x0).all()
+            assert torch.allclose(stream.stock_noise, stream.init_noise), (
+                f"frame {frame}: n==1 per-frame reseed invariant broken after live 2->1 resize"
+            )
+        assert stream._combined_latent_buf is None
+        assert stream.x_t_latent_buffer is None
+
+
+class TestRefreshDerivedTensorsSelfHeal:
+    """_refresh_derived_tensors() is the error-fallback's rebuild hook — it must
+    restore the ping-pong buffers too, or the fallback loops forever."""
+
+    def test_refresh_rebuilds_ping_pong_buffers(self):
+        stream = _make_resizable_stream([16, 32])
+        h = stream.latent_height
+        # Stale the ping-pong state the way a live resize leaves it
+        stream._stock_noise_bufs = [
+            torch.empty(1, 4, h, h, dtype=stream.dtype),
+            torch.empty(1, 4, h, h, dtype=stream.dtype),
+        ]
+        stream._stock_noise_pong = 1
+
+        StreamDiffusion._refresh_derived_tensors(stream)
+
+        assert stream._stock_noise_pong == 0
+        for buf in stream._stock_noise_bufs:
+            assert buf.shape == (stream.batch_size, 4, h, h), (
+                "_refresh_derived_tensors left _stock_noise_bufs stale — the __call__ "
+                "error fallback can never self-heal a live batch-size change"
+            )
+        # The rebuilt bufs must not alias stock_noise (ping-pong precondition)
+        for buf in stream._stock_noise_bufs:
+            assert buf.data_ptr() != stream.stock_noise.data_ptr()

--- a/tests/unit/test_rcfg_self_single_step_reseed.py
+++ b/tests/unit/test_rcfg_self_single_step_reseed.py
@@ -1,0 +1,252 @@
+"""
+Regression tests for the R-CFG single-step divergence bug (black output at
+guidance_scale > 1 with a 1-element t_index_list).
+
+Root cause guarded: with cfg_type='self' and denoising_steps_num == 1, the
+per-frame stock_noise reseed (predict_x0_batch ping-pong rotation) is gated
+behind `denoising_steps_num > 1` and never runs, while unet_step's R-CFG
+recurrence `stock_noise = _init_noise_rotated + delta_x` still executes with
+degenerate coefficients (_alpha_next = _beta_next = 1.0). The resulting
+cross-frame linear recurrence has growth factor |A| > 1 at typical single-step
+timesteps, so stock_noise diverges geometrically (~x100/frame), overflows fp16
+to Inf, and Inf - Inf = NaN in the CFG combine renders black frames.
+
+Correct behavior per StreamDiffusion paper Eq. 5: at the first (and only)
+denoising step, the Self-Negative virtual residual equals init_noise exactly,
+so stock_noise must be reseeded from init_noise every frame when n == 1.
+
+CPU-only, model-free. Builds a real StreamDiffusion instance via object.__new__
+(same idiom as test_derived_tensor_sync.py) with a deterministic fake UNet and
+drives the actual predict_x0_batch / unet_step code paths.
+"""
+
+import torch
+from diffusers import LCMScheduler
+
+from streamdiffusion.pipeline import StreamDiffusion
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_unet(sample, timestep, encoder_hidden_states=None, kvo_cache=None, return_dict=False, **kwargs):
+    """Deterministic stand-in for the UNet (SD1.5 calling convention)."""
+    return (0.05 * sample,)
+
+
+def _make_stream(
+    t_index_list,
+    cfg_type="self",
+    guidance_scale=1.4,
+    delta=1.0,
+    dtype=torch.float32,
+    latent_hw=8,
+    seed=1234,
+):
+    """Real StreamDiffusion instance (no __init__) wired with exactly the
+    attributes predict_x0_batch / unet_step read, mirroring prepare()'s
+    formulas. frame_bff_size fixed at 1 (the TD configuration)."""
+    stream = object.__new__(StreamDiffusion)
+    n = len(t_index_list)
+    frame_bff_size = 1
+    batch_size = n * frame_bff_size
+    h = w = latent_hw
+
+    stream.device = "cpu"
+    stream.dtype = dtype
+    stream.latent_height = h
+    stream.latent_width = w
+    stream.frame_bff_size = frame_bff_size
+    stream.denoising_steps_num = n
+    stream.batch_size = batch_size
+    stream.cfg_type = cfg_type
+    stream.use_denoising_batch = True
+    stream.guidance_scale = guidance_scale
+    stream.delta = delta
+    stream.do_add_noise = True
+    stream.generator = torch.Generator(device="cpu").manual_seed(seed)
+
+    # UNet plumbing: SD1.5 branch, hooks/caches disabled
+    stream.is_sdxl = False
+    stream.unet_hooks = []
+    stream.kvo_cache = []
+    stream.fio_cache = []
+    stream.use_feature_injection = False
+    stream._fi_strength_tensor = None
+    stream._fi_threshold_tensor = None
+    stream._is_unet_tensorrt = None
+    stream._unet_kwargs = {"return_dict": False}
+    stream._sdxl_conditioning_cache = {}
+    stream._cached_batch_size = None
+    stream._cached_cfg_type = None
+    stream._cached_guidance_scale = None
+    stream.unet = _fake_unet
+    stream.update_kvo_cache = lambda *a, **k: None
+    stream.prompt_embeds = torch.zeros(batch_size, 77, 8, dtype=dtype)
+
+    # Scheduler shell with a real cumulative-alpha schedule (matches
+    # test_derived_tensor_sync.py's mock; isinstance(LCMScheduler) must hold)
+    sched = object.__new__(LCMScheduler)
+    betas = torch.linspace(0.0001, 0.02, 1000)
+    alphas_cumprod = torch.cumprod(1.0 - betas, dim=0)
+    sched.alphas_cumprod = alphas_cumprod
+    stream.scheduler = sched
+
+    timesteps_raw = torch.linspace(999, 19, 50).long()
+    sub_timesteps = [int(timesteps_raw[i]) for i in t_index_list]
+    stream.sub_timesteps_tensor = torch.tensor(sub_timesteps, dtype=torch.long)
+
+    stream.alpha_prod_t_sqrt = (
+        torch.stack([alphas_cumprod[t].sqrt() for t in sub_timesteps]).view(n, 1, 1, 1).to(dtype)
+    )
+    stream.beta_prod_t_sqrt = (
+        torch.stack([(1 - alphas_cumprod[t]).sqrt() for t in sub_timesteps]).view(n, 1, 1, 1).to(dtype)
+    )
+
+    # LCM boundary-condition scalings (diffusers formulas, sigma_data=0.5,
+    # timestep_scaling=10): c_skip ~ 0, c_out ~ 1 at these timesteps
+    c_skip_l, c_out_l = [], []
+    for t in sub_timesteps:
+        st = 10.0 * t
+        c_skip_l.append(0.25 / (st**2 + 0.25))
+        c_out_l.append(st / (st**2 + 0.25) ** 0.5)
+    stream.c_skip = torch.tensor(c_skip_l, dtype=dtype).view(n, 1, 1, 1)
+    stream.c_out = torch.tensor(c_out_l, dtype=dtype).view(n, 1, 1, 1)
+
+    # Noise state + ping-pong buffers, exactly as prepare() builds them
+    stream.init_noise = torch.randn((batch_size, 4, h, w), dtype=dtype, generator=stream.generator)
+    stream.stock_noise = stream.init_noise.clone()
+    stream._stock_noise_bufs = [stream.stock_noise.clone(), torch.empty_like(stream.stock_noise)]
+    stream._stock_noise_pong = 0
+
+    # Derived shifted tensors (degenerate ones-padding at n == 1)
+    if cfg_type in ("self", "initialize"):
+        stream._alpha_next = torch.cat(
+            [stream.alpha_prod_t_sqrt[1:], torch.ones_like(stream.alpha_prod_t_sqrt[0:1])], dim=0
+        )
+        stream._beta_next = torch.cat(
+            [stream.beta_prod_t_sqrt[1:], torch.ones_like(stream.beta_prod_t_sqrt[0:1])], dim=0
+        )
+        stream._init_noise_rotated = torch.cat([stream.init_noise[1:], stream.init_noise[0:1]], dim=0)
+    else:
+        stream._alpha_next = None
+        stream._beta_next = None
+        stream._init_noise_rotated = None
+
+    # Latent buffers
+    stream.x_t_latent_buffer = None if n == 1 else torch.zeros((n - 1) * frame_bff_size, 4, h, w, dtype=dtype)
+    stream._combined_latent_buf = None if n == 1 else torch.empty(batch_size, 4, h, w, dtype=dtype)
+
+    # CFG expansion buffers (only allocated for the cfg types that use them)
+    if guidance_scale > 1.0 and cfg_type in ("initialize", "full"):
+        cfg_batch = (1 + batch_size) if cfg_type == "initialize" else (2 * batch_size)
+        stream._cfg_latent_buf = torch.empty(cfg_batch, 4, h, w, dtype=dtype)
+        stream._cfg_t_buf = torch.empty(cfg_batch, dtype=stream.sub_timesteps_tensor.dtype)
+    else:
+        stream._cfg_latent_buf = None
+        stream._cfg_t_buf = None
+
+    return stream
+
+
+def _zero_input(stream):
+    return torch.zeros(stream.frame_bff_size, 4, stream.latent_height, stream.latent_width, dtype=stream.dtype)
+
+
+def _run_frames(stream, num_frames):
+    """Drive predict_x0_batch with a constant zero input latent; returns the
+    per-frame x0 outputs. NOTE: runs all frames up front — use an inline loop
+    instead when asserting per-frame stream state."""
+    x_in = _zero_input(stream)
+    return [StreamDiffusion.predict_x0_batch(stream, x_in) for _ in range(num_frames)]
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+class TestSingleStepReseedFixesDivergence:
+    """n == 1, cfg_type='self', guidance > 1: stock_noise must be pinned to
+    init_noise every frame and stay bounded/finite. FAILS on unpatched code
+    (observed geometric blow-up ~x100/frame); PASSES once predict_x0_batch's
+    n == 1 reseed and the unet_step recurrence gate land."""
+
+    def test_stock_noise_pinned_to_init_noise_every_frame(self):
+        stream = _make_stream([16], cfg_type="self", guidance_scale=1.4)
+        x_in = _zero_input(stream)
+        for frame in range(8):
+            x0 = StreamDiffusion.predict_x0_batch(stream, x_in)
+            max_abs = stream.stock_noise.abs().max().item()
+            assert torch.allclose(stream.stock_noise, stream.init_noise), (
+                f"frame {frame}: stock_noise diverged from init_noise (max_abs={max_abs:.3e}) — "
+                "n==1 per-frame reseed missing"
+            )
+            # copy_, not alias: init_noise must never be corrupted through stock_noise
+            assert stream.stock_noise.data_ptr() != stream.init_noise.data_ptr()
+            assert max_abs < 100.0, f"frame {frame}: stock_noise unbounded (max_abs={max_abs:.3e})"
+            assert torch.isfinite(x0).all(), f"frame {frame}: non-finite x0 output"
+
+    def test_divergence_gone_even_at_guidance_1(self):
+        """The recurrence ran (and silently diverged) even at guidance 1.0 —
+        raising guidance later merely exposed the already-corrupt buffer."""
+        stream = _make_stream([16], cfg_type="self", guidance_scale=1.0)
+        x_in = _zero_input(stream)
+        for frame in range(8):
+            x0 = StreamDiffusion.predict_x0_batch(stream, x_in)
+            max_abs = stream.stock_noise.abs().max().item()
+            assert max_abs < 100.0, (
+                f"frame {frame}: stock_noise diverging in background at guidance 1.0 (max_abs={max_abs:.3e})"
+            )
+            assert torch.isfinite(x0).all()
+
+    def test_initialize_cfg_type_bounded(self):
+        """'initialize' self-heals at n==1 (real uncond overwrites the single
+        slot each frame) — must stay bounded before and after the fix."""
+        stream = _make_stream([16], cfg_type="initialize", guidance_scale=1.4)
+        x_in = _zero_input(stream)
+        for frame in range(8):
+            x0 = StreamDiffusion.predict_x0_batch(stream, x_in)
+            max_abs = stream.stock_noise.abs().max().item()
+            assert max_abs < 100.0, f"frame {frame}: stock_noise unbounded (max_abs={max_abs:.3e})"
+            assert torch.isfinite(x0).all()
+
+    def test_full_and_none_cfg_types_unaffected(self):
+        """'full'/'none' never synthesize uncond from stock_noise — just assert
+        the n==1 path runs clean and finite."""
+        for cfg_type in ("full", "none"):
+            stream = _make_stream([16], cfg_type=cfg_type, guidance_scale=1.4)
+            for x0 in _run_frames(stream, 4):
+                assert torch.isfinite(x0).all(), f"cfg_type={cfg_type}: non-finite x0"
+
+
+class TestMultiStepPathUnaffectedByReseed:
+    """n == 2 ping-pong path must be untouched by the n == 1 fix (the new code
+    sits in an elif only reachable when denoising_steps_num == 1)."""
+
+    def test_ping_pong_still_engages_and_stays_stable(self):
+        stream = _make_stream([16, 32], cfg_type="self", guidance_scale=1.4)
+        x_in = _zero_input(stream)
+        expected_pong = 0
+        for frame in range(6):
+            x0 = StreamDiffusion.predict_x0_batch(stream, x_in)
+            expected_pong = 1 - expected_pong
+            assert stream._stock_noise_pong == expected_pong, (
+                f"frame {frame}: ping-pong rotation did not run (n==1 branch leaked into n==2?)"
+            )
+            assert stream.x_t_latent_buffer is not None
+            # The n==1 invariant (stock_noise pinned to init_noise) must NOT leak here
+            assert not torch.allclose(stream.stock_noise, stream.init_noise)
+            max_abs = stream.stock_noise.abs().max().item()
+            assert max_abs < 10_000.0, f"frame {frame}: n==2 stock_noise unstable (max_abs={max_abs:.3e})"
+            assert torch.isfinite(x0).all()
+
+    def test_multi_step_outputs_deterministic_and_finite(self):
+        """Seeded n==2 run is reproducible — used with capture_reference.py-style
+        pre/post-fix diffing to pin the multi-step path bit-identical."""
+        outs_a = _run_frames(_make_stream([16, 32], cfg_type="self", guidance_scale=1.4, seed=77), 6)
+        outs_b = _run_frames(_make_stream([16, 32], cfg_type="self", guidance_scale=1.4, seed=77), 6)
+        for a, b in zip(outs_a, outs_b):
+            assert torch.equal(a, b), "seeded n==2 run not deterministic"
+            assert torch.isfinite(a).all()

--- a/tests/unit/test_unet_call_backend_gate.py
+++ b/tests/unit/test_unet_call_backend_gate.py
@@ -112,6 +112,7 @@ def _make_pipeline(unet, *, prompt_tokens: int = 4) -> StreamDiffusion:
 
     sd.guidance_scale = 1.0  # skip CFG latent-doubling branch entirely
     sd.cfg_type = "none"
+    sd.denoising_steps_num = 1  # read by the RCFG recurrence gate in unet_step
 
     sd.prompt_embeds = torch.randn(1, prompt_tokens, 8)
     sd.kvo_cache: List[torch.Tensor] = []
@@ -161,8 +162,7 @@ class TestSd15Sd21UnetCallBackendGate:
         assert "kvo_cache" in recording_unet.last_kwargs
         for key in ("fio_cache", "fi_strength", "fi_threshold"):
             assert key not in recording_unet.last_kwargs, (
-                f"non-TRT UNet call must not receive {key!r}; got kwargs="
-                f"{sorted(recording_unet.last_kwargs)}"
+                f"non-TRT UNet call must not receive {key!r}; got kwargs={sorted(recording_unet.last_kwargs)}"
             )
 
     def test_tensorrt_engine_still_receives_feature_injection_kwargs(self):
@@ -176,6 +176,5 @@ class TestSd15Sd21UnetCallBackendGate:
 
         for key in ("kvo_cache", "fio_cache", "fi_strength", "fi_threshold"):
             assert key in fake_engine.last_kwargs, (
-                f"TRT engine call must still receive {key!r}; got kwargs="
-                f"{sorted(fake_engine.last_kwargs)}"
+                f"TRT engine call must still receive {key!r}; got kwargs={sorted(fake_engine.last_kwargs)}"
             )


### PR DESCRIPTION
## Summary

A live `t_index_list` **length** change (TouchDesigner: `TIndexBlock` numBlocks while
streaming; OSC `/t_list` → `update_stream_params` →
`_recalculate_timestep_dependent_params`) rebuilt `batch_size`, `x_t_latent_buffer`,
`init_noise`, `stock_noise` and `prompt_embeds`, but never the five batch-sized buffers
that are otherwise only allocated in `prepare()`: `_stock_noise_bufs`,
`_stock_noise_pong`, `_combined_latent_buf`, `_cfg_latent_buf`, `_cfg_t_buf`.

Consequences on the next frame after a live length change:
- 1→n grow died on an uncaught `TypeError` (`None` `_combined_latent_buf`; `__call__`'s
  fallback only catches `RuntimeError`).
- n≥2 grow hit a `copy_` shape mismatch whose fallback loop never healed (decoded
  `randn` noise every frame) because `_refresh_derived_tensors` skipped the ping-pong
  buffers.
- Shrink broadcast-succeeded silently, then rebound `stock_noise` to the stale larger
  tensor.

Fix: `_refresh_derived_tensors()` now also rebuilds `_stock_noise_bufs` /
`_stock_noise_pong` (heals the fallback loop), and the updater's length-change branch
delegates its whole derived-tensor rebuild to it — removing a third hand-copied rebuild
site (same drift class the existing `test_derived_tensor_sync.py` guards).

**Stacked on #38.** This branch is built on top of `pr/rcfg-single-step-reseed`
(#38) because both PRs touch `pipeline.py` / `stream_parameter_updater.py`, and this
fix's own diff only applies cleanly with #38's reseed content already present.
GitHub cross-repo PRs can't target another fork branch as base, so this PR is opened
directly against `SDTD_040_beta_release` — until #38 merges, its commit list/diff will
include both commits; only `816eba3` ("fix: rebuild batch buffers on live t_index
resize") is this PR's own content. The diff will automatically narrow to just that
commit once #38 merges into `SDTD_040_beta_release`. Please land #38 first.

## Test plan

- [x] `tests/unit/test_live_t_index_resize_buffers.py` (new) — red-first regression
      tests covering grow 1→2, 2→3, shrink 3→2, 2→1, and the refresh self-heal.
- [x] All pass locally against this branch's own `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
