### PR TITLE
fix: repair cfg_type none/full gaps from RCFG reseed + resize fixes

### DIFF
--- a/src/streamdiffusion/param_schema.py
+++ b/src/streamdiffusion/param_schema.py
@@ -37,6 +37,12 @@ from typing import Any, Dict, List, Literal, Tuple
 PromptInterpolationMethod = Literal["linear", "slerp", "cosine_weighted"]
 SeedInterpolationMethod = Literal["linear", "slerp"]
 
+# The four cfg_type values StreamDiffusion.__init__ accepts (pipeline.py's single
+# assignment choke point, :85). cfg_type is construction-time only — it is not in
+# PARAM_NAMES/UPDATER_PARAM_NAMES, so there is no live-update validation path to
+# also guard; this constant is consumed once, at __init__.
+VALID_CFG_TYPES: Tuple[str, ...] = ("none", "full", "self", "initialize")
+
 
 @dataclass(frozen=True)
 class ParamSpec:

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -1043,7 +1043,11 @@ class StreamDiffusion:
         if self.use_denoising_batch:
             denoised_batch = self.scheduler_step_batch(model_pred, x_t_latent, idx)
 
-            if self.cfg_type == "self" or self.cfg_type == "initialize":
+            # Residual propagation only matters when a next step exists to consume it.
+            # At denoising_steps_num == 1 the write would persist a value the n>1 design
+            # treats as a throwaway (_alpha_next/_beta_next degenerate to 1.0), and
+            # predict_x0_batch reseeds stock_noise from init_noise every frame anyway.
+            if (self.cfg_type == "self" or self.cfg_type == "initialize") and self.denoising_steps_num > 1:
                 scaled_noise = self.beta_prod_t_sqrt * self.stock_noise
                 delta_x = self.scheduler_step_batch(model_pred, scaled_noise, idx)
                 delta_x = self._alpha_next * delta_x
@@ -1140,6 +1144,14 @@ class StreamDiffusion:
                     _sn_dst[1:].copy_(self.stock_noise[:-1])
                     self.stock_noise = _sn_dst
                     self._stock_noise_pong = 1 - self._stock_noise_pong
+                elif self.cfg_type == "self" or self.cfg_type == "initialize":
+                    # denoising_steps_num == 1: no ping-pong slot exists to reseed, and the
+                    # RCFG cross-frame recurrence has growth factor |A| > 1 at typical
+                    # single-step timesteps — without this per-frame reseed stock_noise
+                    # diverges geometrically and guidance > 1 renders black (fp16 Inf→NaN).
+                    # Per paper Eq. 5, the Self-Negative residual at the first (only) step
+                    # is exactly init_noise.
+                    self.stock_noise.copy_(self.init_noise)
                 with profiler.region("unet_step"):
                     x_0_pred_batch, model_pred = self.unet_step(x_t_latent, t_list)
 

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -24,6 +24,7 @@ from streamdiffusion.hooks import (
 )
 from streamdiffusion.image_filter import SimilarImageFilter
 from streamdiffusion.model_detection import detect_model
+from streamdiffusion.param_schema import VALID_CFG_TYPES
 from streamdiffusion.stream_parameter_updater import StreamParameterUpdater
 from streamdiffusion.tools.gpu_profiler import profiler
 
@@ -81,6 +82,12 @@ class StreamDiffusion:
         self.frame_bff_size = frame_buffer_size
         self.denoising_steps_num = len(t_index_list)
 
+        # G6: cfg_type is Literal-hinted but that's not enforced at runtime — a typo
+        # previously behaved like "none" until the guidance combine, then raised an
+        # opaque UnboundLocalError. Validate here, the one choke point every
+        # construction path (direct + wrapper.py) flows through.
+        if cfg_type not in VALID_CFG_TYPES:
+            raise ValueError(f"cfg_type must be one of {VALID_CFG_TYPES}, got {cfg_type!r}")
         self.cfg_type = cfg_type
         self.scheduler_type = scheduler
         self.sampler_type = sampler
@@ -444,6 +451,19 @@ class StreamDiffusion:
         if self.guidance_scale > 1.0:
             do_classifier_free_guidance = True
 
+        # G5 (not fixed — see plan): cfg_type="full" has been broken at baseline since
+        # _apply_prompt_blending's live-update path builds batch_size//2 uncond+cond rows
+        # (stream_parameter_updater.py, batch_size == frame_bff_size collapses that to 0
+        # at denoising_steps_num == 1) while unet_step doubles the latent to 2*batch_size.
+        # No shipped config uses cfg_type="full", so this has never been observed in
+        # practice. Warn loudly rather than silently producing garbage/shape-error output.
+        if self.cfg_type == "full" and self.guidance_scale > 1.0:
+            logger.warning(
+                "prepare: cfg_type='full' is known-broken (embeds row count vs. UNet batch "
+                "mismatch after the first prompt update) — not repaired by this change; "
+                "use cfg_type='self' or 'initialize' instead."
+            )
+
         # Handle SDXL vs SD1.5/SD2.1 text encoding differently
         if self.is_sdxl:
             # SDXL encode_prompt returns 4 values:
@@ -473,12 +493,26 @@ class StreamDiffusion:
                 base_prompt_embeds = prompt_embeds.repeat(self.batch_size, 1, 1)
 
                 # Handle CFG for prompt embeddings
+                # G4: uncond_prompt_embeds is only assigned under specific
+                # use_denoising_batch/cfg_type combos but consumed unconditionally below
+                # whenever guidance_scale>1 and cfg_type is initialize/full. TCD forces
+                # use_denoising_batch=False, so {scheduler: tcd, cfg_type: full} left this
+                # unbound. Initialize it and turn the unreachable-combo case into a legible
+                # error instead of UnboundLocalError.
+                uncond_prompt_embeds = None
                 if self.use_denoising_batch and self.cfg_type == "full":
                     uncond_prompt_embeds = negative_prompt_embeds.repeat(self.batch_size, 1, 1)
                 elif self.cfg_type == "initialize":
                     uncond_prompt_embeds = negative_prompt_embeds.repeat(self.frame_bff_size, 1, 1)
 
                 if self.guidance_scale > 1.0 and (self.cfg_type == "initialize" or self.cfg_type == "full"):
+                    if uncond_prompt_embeds is None:
+                        raise ValueError(
+                            f"prepare: cfg_type={self.cfg_type!r} with guidance_scale>1.0 requires "
+                            f"use_denoising_batch=True (got {self.use_denoising_batch}); cfg_type='full' "
+                            "is not supported with use_denoising_batch=False (e.g. the TCD scheduler, "
+                            "which forces it off)."
+                        )
                     base_prompt_embeds = torch.cat([uncond_prompt_embeds, base_prompt_embeds], dim=0)
 
                 # Set up SDXL-specific conditioning (added_cond_kwargs)
@@ -521,12 +555,21 @@ class StreamDiffusion:
             )
             base_prompt_embeds = encoder_output[0].repeat(self.batch_size, 1, 1)
 
+            # G4 (see the SDXL branch above for the full explanation).
+            uncond_prompt_embeds = None
             if self.use_denoising_batch and self.cfg_type == "full":
                 uncond_prompt_embeds = encoder_output[1].repeat(self.batch_size, 1, 1)
             elif self.cfg_type == "initialize":
                 uncond_prompt_embeds = encoder_output[1].repeat(self.frame_bff_size, 1, 1)
 
             if self.guidance_scale > 1.0 and (self.cfg_type == "initialize" or self.cfg_type == "full"):
+                if uncond_prompt_embeds is None:
+                    raise ValueError(
+                        f"prepare: cfg_type={self.cfg_type!r} with guidance_scale>1.0 requires "
+                        f"use_denoising_batch=True (got {self.use_denoising_batch}); cfg_type='full' "
+                        "is not supported with use_denoising_batch=False (e.g. the TCD scheduler, "
+                        "which forces it off)."
+                    )
                 base_prompt_embeds = torch.cat([uncond_prompt_embeds, base_prompt_embeds], dim=0)
 
             # Run embedding hooks (no-op unless modules register)
@@ -631,16 +674,8 @@ class StreamDiffusion:
         self.c_skip = self.c_skip.to(self.device)
         self.c_out = self.c_out.to(self.device)
 
-        # Precompute per-step expanded timestep tensors for the TCD / non-batched sequential loop.
-        # Avoids per-step t.view(1).repeat(frame_bff_size) tensor allocations inside predict_x0_batch.
-        # Only valid when sub_timesteps_tensor is a 1-D sequence (not the collapsed-scalar LCM path).
-        _use_seq_loop = not (self.use_denoising_batch and isinstance(self.scheduler, LCMScheduler))
-        if _use_seq_loop and self.sub_timesteps_tensor.dim() >= 1:
-            self._sub_timesteps_expanded = (
-                self.sub_timesteps_tensor.view(-1).unsqueeze(1).expand(-1, self.frame_bff_size).contiguous()
-            )  # shape [loop_steps, frame_bff_size]
-        else:
-            self._sub_timesteps_expanded = None
+        # Precompute per-step expanded timestep tensors for the TCD / non-batched sequential loop (G1).
+        self._rebuild_sub_timesteps_expanded()
 
         # Pre-compute shifted alpha/beta/init_noise (eliminates 5 mallocs + 8 kernel launches per frame)
         if self.use_denoising_batch and (self.cfg_type == "self" or self.cfg_type == "initialize"):
@@ -682,6 +717,26 @@ class StreamDiffusion:
         # Seed _unet_kwargs with the constant key so per-frame code only updates values
         self._unet_kwargs = {"return_dict": False}
 
+    def _rebuild_sub_timesteps_expanded(self) -> None:
+        """(Re)build the per-step expanded timestep table consumed by the TCD /
+        non-batched sequential loop in predict_x0_batch. Avoids per-step
+        t.view(1).repeat(frame_bff_size) tensor allocations. Only valid when
+        sub_timesteps_tensor is a 1-D sequence (not the collapsed-scalar LCM path).
+
+        Called from prepare() and from _refresh_derived_tensors() (G1) — a live
+        t_index_list length change previously left this table at its old length,
+        raising IndexError on the sequential path (predict_x0_batch indexes it by
+        loop position) rather than the RuntimeError __call__'s fallback catches.
+        Idempotent, so the extra call from that fallback is harmless.
+        """
+        _use_seq_loop = not (self.use_denoising_batch and isinstance(self.scheduler, LCMScheduler))
+        if _use_seq_loop and self.sub_timesteps_tensor.dim() >= 1:
+            self._sub_timesteps_expanded = (
+                self.sub_timesteps_tensor.view(-1).unsqueeze(1).expand(-1, self.frame_bff_size).contiguous()
+            )  # shape [loop_steps, frame_bff_size]
+        else:
+            self._sub_timesteps_expanded = None
+
     def _refresh_derived_tensors(self) -> None:
         """Re-create tensors derived from batch_size/scheduler state but NOT rebuilt by
         StreamParameterUpdater._update_timestep_calculations.
@@ -691,6 +746,10 @@ class StreamDiffusion:
         the error-fallback handler in __call__ and by the updater's live
         t_index_list length-change path (_recalculate_timestep_dependent_params).
         """
+        # G1: keep the sequential-loop timestep table in sync with the just-refreshed
+        # sub_timesteps_tensor (its own length may have just changed).
+        self._rebuild_sub_timesteps_expanded()
+
         # init_noise + stock_noise — re-sampled so the next frame is coherent
         self.init_noise = torch.randn(
             (self.batch_size, 4, self.latent_height, self.latent_width),

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -686,16 +686,23 @@ class StreamDiffusion:
         """Re-create tensors derived from batch_size/scheduler state but NOT rebuilt by
         StreamParameterUpdater._update_timestep_calculations.
 
-        Called by the error-fallback handler in __call__ after
-        _param_updater._update_timestep_calculations() has already refreshed
-        sub_timesteps_tensor, c_skip/c_out, alpha/beta_prod_t_sqrt.
+        Called after _param_updater._update_timestep_calculations() has already
+        refreshed sub_timesteps_tensor, c_skip/c_out, alpha/beta_prod_t_sqrt — by
+        the error-fallback handler in __call__ and by the updater's live
+        t_index_list length-change path (_recalculate_timestep_dependent_params).
         """
-        # init_noise + stock_noise — re-sampled so the fallback frame is coherent
+        # init_noise + stock_noise — re-sampled so the next frame is coherent
         self.init_noise = torch.randn(
             (self.batch_size, 4, self.latent_height, self.latent_width),
             generator=self.generator,
         ).to(device=self.device, dtype=self.dtype)
         self.stock_noise = self.init_noise.clone()
+
+        # Ping-pong buffers for the stock_noise rotation (see prepare()) — batch-sized,
+        # so any batch_size change without this rebuild leaves predict_x0_batch's
+        # copy_ failing every frame with no way to self-heal.
+        self._stock_noise_bufs = [self.stock_noise.clone(), torch.empty_like(self.stock_noise)]
+        self._stock_noise_pong = 0
 
         # Pre-computed shifted tensors (depend on alpha/beta already refreshed above)
         if self.use_denoising_batch and (self.cfg_type == "self" or self.cfg_type == "initialize"):

--- a/src/streamdiffusion/stream_parameter_updater.py
+++ b/src/streamdiffusion/stream_parameter_updater.py
@@ -373,7 +373,21 @@ class StreamParameterUpdater(OrchestratorUser):
                     logger.warning(
                         "update_stream_params: Warning: guidance_scale > 1.0 with cfg_type='none' will have no effect"
                     )
+                _old_gs_gt1 = self.stream.guidance_scale > 1.0
                 self.stream.guidance_scale = guidance_scale
+                # G3: for cfg_type in (initialize, full), _cfg_latent_buf/_cfg_t_buf
+                # (pipeline.py _refresh_derived_tensors) and prompt_embeds's [uncond|cond]
+                # layout both exist only when guidance_scale > 1.0. A live crossing of that
+                # boundary left them stale (None -> TypeError in unet_step, or a shape from
+                # the old regime) until the next batch-size-changing call happened to reach
+                # _refresh_derived_tensors. Rebuild in step instead.
+                if (self.stream.guidance_scale > 1.0) != _old_gs_gt1 and self.stream.cfg_type in (
+                    "initialize",
+                    "full",
+                ):
+                    self.stream._refresh_derived_tensors()
+                    if self._current_prompt_list:
+                        self._apply_prompt_blending(self._last_prompt_interpolation_method)
 
             if delta is not None:
                 self.stream.delta = delta
@@ -581,9 +595,6 @@ class StreamParameterUpdater(OrchestratorUser):
 
         # Handle CFG properly - need to set both conditional and unconditional if using CFG
         if self.stream.cfg_type in ["full", "initialize"] and self.stream.guidance_scale > 1.0:
-            # For CFG, prompt_embeds contains [uncond, cond] concatenated
-            batch_size = self.stream.batch_size // 2 if self.stream.cfg_type == "full" else self.stream.batch_size
-
             # Get unconditional embeddings (empty prompt)
             uncond_output = self.stream.pipe.encode_prompt(
                 prompt="",
@@ -592,10 +603,26 @@ class StreamParameterUpdater(OrchestratorUser):
                 do_classifier_free_guidance=False,
                 negative_prompt=self._current_negative_prompt,
             )
-            uncond_embeds = uncond_output[0].repeat(batch_size, 1, 1)
 
-            # Combine with conditional embeddings
-            cond_embeds = combined_embeds.repeat(batch_size, 1, 1)
+            # G2 (extends the original row-[0]-repeat fix): row counts must match what
+            # prepare() built (pipeline.py's [uncond|cond] cat) and what unet_step's
+            # _cfg_latent_buf actually holds, or the encoder_hidden_states batch dim
+            # mismatches the UNet's latent batch dim.
+            if self.stream.cfg_type == "initialize":
+                # prepare() shares ONE uncond block per frame_bff_size slot (:518) —
+                # _cfg_latent_buf is (frame_bff_size + batch_size) rows (pipeline.py
+                # :902-908), not 2*batch_size. Previously this branch repeated uncond
+                # by the full batch_size, silently wrong for denoising_steps_num > 1
+                # (only masked at n==1, where frame_bff_size == batch_size).
+                uncond_embeds = uncond_output[0].repeat(self.stream.frame_bff_size, 1, 1)
+                cond_embeds = combined_embeds.repeat(self.stream.batch_size, 1, 1)
+            else:
+                # "full" (G5 — not fixed): reproduces the existing baseline batch_size//2
+                # + batch_size//2 shape verbatim, not the 2*batch_size unet_step expects.
+                half = self.stream.batch_size // 2
+                uncond_embeds = uncond_output[0].repeat(half, 1, 1)
+                cond_embeds = combined_embeds.repeat(half, 1, 1)
+
             final_prompt_embeds = torch.cat([uncond_embeds, cond_embeds], dim=0)
             final_negative_embeds = None  # CFG mode combines everything into prompt_embeds
         else:
@@ -1029,11 +1056,50 @@ class StreamParameterUpdater(OrchestratorUser):
                     _BLEED_THRESHOLD,
                 )
 
+        # G1: _sub_timesteps_expanded (pipeline.py's precomputed per-step timestep
+        # table for the TCD / non-batched sequential loop) derives from
+        # sub_timesteps_tensor, just refreshed above, but was previously rebuilt
+        # only in prepare() — a live t_index_list VALUE change (same length, the
+        # _update_timestep_values_only path below, which calls this method and
+        # returns without ever reaching _refresh_derived_tensors()) left it
+        # silently stale. This method is the one funnel shared by that path, the
+        # length-changed path, and __call__'s error fallback, so rebuilding here
+        # covers all three; the length-changed path's separate call inside
+        # _refresh_derived_tensors() (a few lines below its own call to this
+        # method) makes this redundant there but idempotent, not harmful.
+        self.stream._rebuild_sub_timesteps_expanded()
+
     def _update_timestep_values_only(self, t_index_list: List[int]) -> None:
         """Update only timestep-dependent values when t_index_list values change but length stays same.
         This preserves the working branch behavior for value-only changes."""
         self.stream.t_list = t_index_list
         self._update_timestep_calculations()
+
+    def _resize_cache_tensors(self, cache_list: List[torch.Tensor], old_b: int, new_b: int, batch_dim: int) -> None:
+        """Resize every tensor in ``cache_list`` in place along ``batch_dim`` to
+        ``new_b``, zero-padding on growth and truncating on shrink while preserving
+        as much of the old cached content as possible.
+
+        Shared by the kvo_cache and fio_cache resize paths (G7/G8), which have
+        different tensor ranks and batch-dimension positions — ``batch_dim`` is
+        NOT cosmetic. Per-layer shapes (see create_kvo_cache / create_fi_cache in
+        acceleration/tensorrt/models/utils.py):
+          - kvo_cache: (2, cache_maxframes, batch_size, seq_len, hidden_dim) — 5-D,
+            the leading 2 is K+V; batch at dim 2.
+          - fio_cache: (cache_maxframes, batch_size, seq_len, hidden_dim) — 4-D,
+            output only, no K/V dim; batch at dim 1.
+        Reusing one cache's hardcoded slicing on the other's rank would resize the
+        wrong axis (or index out of range).
+        """
+        min_batch = min(old_b, new_b)
+        for i, cache_tensor in enumerate(cache_list):
+            new_shape = list(cache_tensor.shape)
+            new_shape[batch_dim] = new_b
+            new_cache_tensor = torch.zeros(tuple(new_shape), dtype=cache_tensor.dtype, device=cache_tensor.device)
+            old_slice = [slice(None)] * cache_tensor.dim()
+            old_slice[batch_dim] = slice(0, min_batch)
+            new_cache_tensor[tuple(old_slice)] = cache_tensor[tuple(old_slice)]
+            cache_list[i] = new_cache_tensor
 
     def _recalculate_timestep_dependent_params(self, t_index_list: List[int]) -> None:
         """Recalculate all parameters that depend on t_index_list."""
@@ -1048,7 +1114,11 @@ class StreamParameterUpdater(OrchestratorUser):
         self.stream.t_list = t_index_list
         self.stream.denoising_steps_num = len(self.stream.t_list)
 
-        old_batch_size = self.stream.batch_size
+        # G7/G8: the caches are allocated against trt_unet_batch_size (wrapper.py's
+        # create_kvo_cache/create_fi_cache), which differs from batch_size exactly when
+        # cfg_type is "initialize" ((n+1)*f) or "full" (2*n*f) — track it separately so
+        # the resize below is driven by what was actually allocated.
+        old_trt_batch_size = self.stream.trt_unet_batch_size
 
         if self.stream.use_denoising_batch:
             self.stream.batch_size = self.stream.denoising_steps_num * self.stream.frame_bff_size
@@ -1076,37 +1146,57 @@ class StreamParameterUpdater(OrchestratorUser):
         else:
             self.stream.x_t_latent_buffer = None
 
-        self.stream.prompt_embeds = self.stream.prompt_embeds[0].repeat(self.stream.batch_size, 1, 1)
+        # G2: row [0] is the *uncond* row for cfg_type in (initialize, full) — see
+        # prepare()'s [uncond|cond] cat — so repeating it silently turned every row
+        # into uncond (wrong content, and for "full" also the wrong count vs. the
+        # 2*batch_size UNet expects). Re-run the one function that already knows
+        # every cfg layout instead of hand-rolling the shape here; it reads from
+        # _prompt_cache so the positive prompt is not re-encoded. Falls back to the
+        # old row-0 repeat only when there's no cached prompt yet to re-blend from.
+        if self._current_prompt_list:
+            self._apply_prompt_blending(self._last_prompt_interpolation_method)
+        else:
+            self.stream.prompt_embeds = self.stream.prompt_embeds[0].repeat(self.stream.batch_size, 1, 1)
 
-        # Resize kvo_cache tensors if batch size changed
-        if self.stream.kvo_cache and old_batch_size != self.stream.batch_size:
-            logger.info(
-                f"_recalculate_timestep_dependent_params: Resizing kvo_cache tensors from batch_size {old_batch_size} to {self.stream.batch_size}"
-            )
-            for i, cache_tensor in enumerate(self.stream.kvo_cache):
-                # KVO cache shape: (2, cache_maxframes, batch_size, seq_length, hidden_dim)
-                current_shape = cache_tensor.shape
-                new_shape = (
-                    current_shape[0],
-                    current_shape[1],
-                    self.stream.batch_size,
-                    current_shape[3],
-                    current_shape[4],
+        # G7/G8: resize kvo_cache / fio_cache if the TensorRT UNet batch size changed.
+        # Driven by trt_unet_batch_size (what wrapper.py's create_kvo_cache/create_fi_cache
+        # actually allocated with), NOT batch_size — the two differ exactly when cfg_type
+        # is "initialize" or "full" (see old_trt_batch_size comment above). Previously only
+        # kvo_cache was resized, keyed on batch_size, and fio_cache was never touched at
+        # all — stale on every live t_index change, including the shipped cfg_type="self"
+        # path.
+        if old_trt_batch_size != self.stream.trt_unet_batch_size:
+            if self.stream.kvo_cache:
+                logger.info(
+                    "_recalculate_timestep_dependent_params: Resizing kvo_cache tensors from "
+                    f"trt_unet_batch_size {old_trt_batch_size} to {self.stream.trt_unet_batch_size}"
                 )
-                new_cache_tensor = torch.zeros(new_shape, dtype=cache_tensor.dtype, device=cache_tensor.device)
-
-                # Copy over as much data as possible from old cache
-                min_batch = min(old_batch_size, self.stream.batch_size)
-                new_cache_tensor[:, :, :min_batch, :, :] = cache_tensor[:, :, :min_batch, :, :]
-
-                self.stream.kvo_cache[i] = new_cache_tensor
-            # Drop bucketed storage refs so update_kvo_cache falls back to
-            # per-layer writes against the new tensors.
-            self.stream._kvo_buckets = None
-            self.stream._kvo_outputs_by_bucket = None
-            logger.info(
-                f"_recalculate_timestep_dependent_params: KVO cache tensors resized to new batch_size {self.stream.batch_size}"
-            )
+                self._resize_cache_tensors(
+                    self.stream.kvo_cache, old_trt_batch_size, self.stream.trt_unet_batch_size, batch_dim=2
+                )
+                # Drop bucketed storage refs so update_kvo_cache falls back to per-layer
+                # writes against the new tensors. fio_cache has no equivalent bucket
+                # storage — wrapper.py discards create_fi_cache's bucket returns at
+                # allocation (fio_cache, _, _, _ = create_fi_cache(...)) — so no
+                # invalidation is needed there.
+                self.stream._kvo_buckets = None
+                self.stream._kvo_outputs_by_bucket = None
+                logger.info(
+                    "_recalculate_timestep_dependent_params: KVO cache tensors resized to new "
+                    f"trt_unet_batch_size {self.stream.trt_unet_batch_size}"
+                )
+            if self.stream.fio_cache:
+                logger.info(
+                    "_recalculate_timestep_dependent_params: Resizing fio_cache tensors from "
+                    f"trt_unet_batch_size {old_trt_batch_size} to {self.stream.trt_unet_batch_size}"
+                )
+                self._resize_cache_tensors(
+                    self.stream.fio_cache, old_trt_batch_size, self.stream.trt_unet_batch_size, batch_dim=1
+                )
+                logger.info(
+                    "_recalculate_timestep_dependent_params: fio_cache tensors resized to new "
+                    f"trt_unet_batch_size {self.stream.trt_unet_batch_size}"
+                )
 
         # Update timestep-dependent calculations (shared with value-only path)
         self._update_timestep_calculations()

--- a/src/streamdiffusion/stream_parameter_updater.py
+++ b/src/streamdiffusion/stream_parameter_updater.py
@@ -978,13 +978,18 @@ class StreamParameterUpdater(OrchestratorUser):
         # init_noise every frame (pipeline.py, elif after the ping-pong block) — do not
         # reintroduce logic here that assumes stock_noise persists across frames at n==1.
         # F2: Keep pre-computed shifted tensors in sync with the new alpha/beta values.
-        # _alpha_next / _beta_next / _init_noise_rotated are built only in prepare()
-        # (pipeline.py:595-605) and the error-fallback _refresh_derived_tensors().
-        # Without this sync they go stale when t_index_list is updated at runtime,
-        # causing incorrect stock_noise rotation at guidance > 1.0 (RCFG-self path,
-        # pipeline.py:979-984).  _init_noise_rotated is a rotation of init_noise which
-        # is unchanged by a t_index value-only update, so we re-derive from the live tensor
-        # rather than re-sampling (mirrors the _update_seed precedent at :749-753).
+        # _alpha_next / _beta_next / _init_noise_rotated are built in prepare()
+        # (pipeline.py:595-605) and in _refresh_derived_tensors() (called by the
+        # __call__ error fallback AND by the length-change path of
+        # _recalculate_timestep_dependent_params, which delegates its whole
+        # batch-sized rebuild there). This block covers the remaining live path:
+        # a same-length t_index VALUE update, where batch size is unchanged and
+        # only alpha/beta moved. On the length-change path it runs transiently
+        # against the old-size init_noise and is immediately overwritten by the
+        # delegate — no frame runs in between (updater holds _lock).
+        # _init_noise_rotated is a rotation of init_noise which is unchanged by a
+        # value-only update, so we re-derive from the live tensor rather than
+        # re-sampling (mirrors the _update_seed precedent at :749-753).
         if (
             self.stream.use_denoising_batch
             and (self.stream.cfg_type == "self" or self.stream.cfg_type == "initialize")
@@ -1071,13 +1076,6 @@ class StreamParameterUpdater(OrchestratorUser):
         else:
             self.stream.x_t_latent_buffer = None
 
-        self.stream.init_noise = torch.randn(
-            (self.stream.batch_size, 4, self.stream.latent_height, self.stream.latent_width),
-            generator=self.stream.generator,
-        ).to(device=self.stream.device, dtype=self.stream.dtype)
-
-        # Clone (not zeros) to match prepare()'s stock_noise semantics
-        self.stream.stock_noise = self.stream.init_noise.clone()
         self.stream.prompt_embeds = self.stream.prompt_embeds[0].repeat(self.stream.batch_size, 1, 1)
 
         # Resize kvo_cache tensors if batch size changed
@@ -1112,6 +1110,13 @@ class StreamParameterUpdater(OrchestratorUser):
 
         # Update timestep-dependent calculations (shared with value-only path)
         self._update_timestep_calculations()
+
+        # Rebuild every batch-sized derived tensor — init_noise, stock_noise, the
+        # ping-pong _stock_noise_bufs, _combined_latent_buf, _cfg_latent_buf/_cfg_t_buf,
+        # _alpha_next/_beta_next/_init_noise_rotated — through the single shared
+        # implementation (prepare() parity). Must run after
+        # _update_timestep_calculations(): it consumes the refreshed alpha/beta.
+        self.stream._refresh_derived_tensors()
 
     def _regenerate_resolution_tensors(self) -> None:
         """This method is no longer used - resolution updates now restart the pipeline"""

--- a/src/streamdiffusion/stream_parameter_updater.py
+++ b/src/streamdiffusion/stream_parameter_updater.py
@@ -883,8 +883,10 @@ class StreamParameterUpdater(OrchestratorUser):
             generator=self.stream.generator,
         ).to(device=self.stream.device, dtype=self.stream.dtype)
 
-        # Reset stock_noise to match the new init_noise
-        self.stream.stock_noise = torch.zeros_like(self.stream.init_noise)
+        # Reset stock_noise to match the new init_noise (same semantics as prepare():
+        # a zeros reset makes the RCFG uncond term start from nothing instead of a
+        # coherent residual, visible as a guidance glitch right after a seed change)
+        self.stream.stock_noise = self.stream.init_noise.clone()
 
         # Keep pre-computed rotation in sync with new init_noise
         if self.stream._init_noise_rotated is not None:
@@ -972,6 +974,9 @@ class StreamParameterUpdater(OrchestratorUser):
             dim=0,
         )
 
+        # F3: At denoising_steps_num == 1 predict_x0_batch reseeds stock_noise from
+        # init_noise every frame (pipeline.py, elif after the ping-pong block) — do not
+        # reintroduce logic here that assumes stock_noise persists across frames at n==1.
         # F2: Keep pre-computed shifted tensors in sync with the new alpha/beta values.
         # _alpha_next / _beta_next / _init_noise_rotated are built only in prepare()
         # (pipeline.py:595-605) and the error-fallback _refresh_derived_tensors().
@@ -1071,7 +1076,8 @@ class StreamParameterUpdater(OrchestratorUser):
             generator=self.stream.generator,
         ).to(device=self.stream.device, dtype=self.stream.dtype)
 
-        self.stream.stock_noise = torch.zeros_like(self.stream.init_noise)
+        # Clone (not zeros) to match prepare()'s stock_noise semantics
+        self.stream.stock_noise = self.stream.init_noise.clone()
         self.stream.prompt_embeds = self.stream.prompt_embeds[0].repeat(self.stream.batch_size, 1, 1)
 
         # Resize kvo_cache tensors if batch size changed

--- a/tests/gpu/test_rcfg_self_single_step_e2e.py
+++ b/tests/gpu/test_rcfg_self_single_step_e2e.py
@@ -1,0 +1,64 @@
+"""GPU e2e regression: RCFG 'self' with a single denoising step must not go black.
+
+Locks down the bug fixed in pipeline.py's predict_x0_batch: at
+denoising_steps_num == 1 the ping-pong reseed never runs while unet_step's
+cross-frame recurrence has growth factor |A| > 1, so stock_noise diverged
+geometrically -> fp16 Inf -> NaN in the CFG combine -> black frames within
+seconds whenever guidance_scale > 1. The fix reseeds stock_noise from
+init_noise every frame (per paper Eq. 5 the Self-Negative residual at the
+first step is exactly init_noise).
+
+Pre-fix, divergence hit fp16 Inf within ~5 frames; 120 frames is a wide
+red-capable margin. Uses stabilityai/sd-turbo + taesd (both HF-cached),
+acceleration="none" to avoid TRT engine builds.
+
+Run: venv/Scripts/python.exe -m pytest tests/gpu -v
+"""
+
+import os
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+REPO_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
+INPUT_IMAGE = os.path.join(REPO_ROOT, "images", "inputs", "input.png")
+
+N_FRAMES = 120
+
+
+class TestRcfgSelfSingleStepE2E:
+    def test_single_step_guidance_above_one_stays_visible(self):
+        from streamdiffusion import StreamDiffusionWrapper
+
+        stream = StreamDiffusionWrapper(
+            model_id_or_path="stabilityai/sd-turbo",
+            t_index_list=[16],
+            frame_buffer_size=1,
+            width=512,
+            height=512,
+            warmup=1,
+            acceleration="none",
+            mode="img2img",
+            use_denoising_batch=True,
+            cfg_type="self",
+            output_type="pt",
+            seed=42,
+        )
+        stream.prepare(
+            prompt="a photograph of a cat",
+            negative_prompt="",
+            num_inference_steps=50,
+            guidance_scale=1.4,
+            delta=1.0,
+        )
+
+        image_tensor = stream.preprocess_image(INPUT_IMAGE)
+        for frame in range(N_FRAMES):
+            output = stream(image=image_tensor)
+            assert torch.isfinite(output).all(), f"non-finite output at frame {frame}"
+
+        # Mean luminance over 0-255: a black (NaN-clamped) frame sits at ~0.
+        luminance = output.float().mean().item() * 255.0
+        assert luminance > 10.0, f"output collapsed to black: mean luminance {luminance:.2f}"

--- a/tests/unit/test_cache_resize_trt_batch.py
+++ b/tests/unit/test_cache_resize_trt_batch.py
@@ -1,0 +1,263 @@
+"""
+Regression tests for G7 + G8: kvo_cache / fio_cache staleness after a live
+t_index_list LENGTH change, specifically for cfg_type modes where
+trt_unet_batch_size != batch_size.
+
+G7 root cause guarded: kvo_cache is *allocated* with stream.trt_unet_batch_size
+(wrapper.py's create_kvo_cache) but was *resized* on a live t_index change
+against stream.batch_size (stream_parameter_updater.py). Those two diverge
+exactly when cfg_type is "initialize" ((n+1)*f) or "full" (2*n*f) -- for
+"self"/"none" they're equal, which is why this went unnoticed (no shipped
+config uses initialize/full). Fix: track old_trt_batch_size separately and
+drive the resize off trt_unet_batch_size, matching what was actually
+allocated.
+
+G8 root cause guarded: fio_cache (also allocated with trt_unet_batch_size,
+wrapper.py's create_fi_cache) was never resized *at all* on a live t_index
+change -- no reference to it anywhere in the updater, for any cfg_type,
+including the shipped "self" path. Fix: resize it alongside kvo_cache through
+a shared _resize_cache_tensors helper.
+
+The two caches have different rank and batch-dim position (see
+create_kvo_cache / create_fi_cache, acceleration/tensorrt/models/utils.py):
+  - kvo_cache: (2, cache_maxframes, batch, seq_len, hidden) -- 5-D, batch at dim 2
+    (leading 2 is K+V).
+  - fio_cache: (cache_maxframes, batch, seq_len, hidden) -- 4-D, output only,
+    batch at dim 1.
+Reusing one cache's slicing on the other's rank would resize the wrong axis
+(or index out of range) -- that asymmetry is the easiest thing to get wrong
+here and is what most of these tests are pinned on.
+
+CPU-only, model-free. Reuses _make_resizable_stream / _make_updater from
+test_live_t_index_resize_buffers.py.
+"""
+
+import torch
+from test_live_t_index_resize_buffers import _make_resizable_stream, _make_updater
+
+CACHE_MAXFRAMES = 1
+SEQ_LEN = 4
+HIDDEN_DIM = 8
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_kvo_layer(batch, fill=0.0):
+    t = torch.full((2, CACHE_MAXFRAMES, batch, SEQ_LEN, HIDDEN_DIM), fill)
+    return t
+
+
+def _make_fio_layer(batch, fill=0.0):
+    return torch.full((CACHE_MAXFRAMES, batch, SEQ_LEN, HIDDEN_DIM), fill)
+
+
+def _make_cache_stream(t_index_list, cfg_type, n_kvo_layers=2, n_fio_layers=2, **kwargs):
+    """_make_resizable_stream plus real kvo_cache / fio_cache tensors sized to
+    the stream's initial trt_unet_batch_size (as wrapper.py's allocators
+    would), each layer filled with its layer index so content preservation
+    is checkable post-resize."""
+    stream = _make_resizable_stream(t_index_list, cfg_type=cfg_type, **kwargs)
+    old_trt = stream.trt_unet_batch_size
+    stream.kvo_cache = [_make_kvo_layer(old_trt, fill=float(i)) for i in range(n_kvo_layers)]
+    stream.fio_cache = [_make_fio_layer(old_trt, fill=float(i)) for i in range(n_fio_layers)]
+    return stream
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+class TestG7KvoCacheResizesToTrtBatchSize:
+    def test_grow_resizes_kvo_cache_to_new_trt_batch_size_not_batch_size(self):
+        """cfg_type='initialize': trt_unet_batch_size = (n+1)*f, batch_size = n*f
+        -- they diverge, so this is the case that catches a resize keyed on
+        the wrong one."""
+        stream = _make_cache_stream([16], cfg_type="initialize")
+        assert stream.trt_unet_batch_size == 2  # (1+1)*1
+        assert stream.batch_size == 1  # 1*1
+        updater = _make_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        assert stream.trt_unet_batch_size == 3  # (2+1)*1
+        assert stream.batch_size == 2  # 2*1
+        for layer in stream.kvo_cache:
+            assert layer.shape[2] == stream.trt_unet_batch_size, (
+                f"kvo_cache batch dim {layer.shape[2]} != trt_unet_batch_size "
+                f"{stream.trt_unet_batch_size} (resized against batch_size instead?)"
+            )
+
+    def test_shrink_resizes_kvo_cache_to_new_trt_batch_size(self):
+        stream = _make_cache_stream([8, 24, 40], cfg_type="initialize")
+        assert stream.trt_unet_batch_size == 4  # (3+1)*1
+        updater = _make_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        assert stream.trt_unet_batch_size == 3  # (2+1)*1
+        for layer in stream.kvo_cache:
+            assert layer.shape[2] == 3
+
+    def test_full_cfg_type_also_driven_by_trt_batch_size(self):
+        """cfg_type='full': trt_unet_batch_size = 2*n*f, further from batch_size
+        than 'initialize' -- an independent check on the same divergence."""
+        stream = _make_cache_stream([16], cfg_type="full")
+        assert stream.trt_unet_batch_size == 2  # 2*1*1
+        updater = _make_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        assert stream.trt_unet_batch_size == 4  # 2*2*1
+        for layer in stream.kvo_cache:
+            assert layer.shape[2] == 4
+
+    def test_self_cfg_type_kvo_cache_still_resizes(self):
+        """Non-regression: 'self' has trt_unet_batch_size == batch_size, so this
+        exercises the ordinary (pre-existing, already-working) path stays intact."""
+        stream = _make_cache_stream([16], cfg_type="self")
+        assert stream.trt_unet_batch_size == stream.batch_size == 1
+        updater = _make_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        assert stream.trt_unet_batch_size == stream.batch_size == 2
+        for layer in stream.kvo_cache:
+            assert layer.shape[2] == 2
+
+    def test_kvo_bucket_state_invalidated_after_resize(self):
+        stream = _make_cache_stream([16], cfg_type="initialize")
+        stream._kvo_buckets = {"stale": True}
+        stream._kvo_outputs_by_bucket = {"stale": True}
+        updater = _make_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        assert stream._kvo_buckets is None, "stale kvo bucket refs survived a resize"
+        assert stream._kvo_outputs_by_bucket is None
+
+    def test_kvo_cache_content_preserved_up_to_min_batch_on_grow(self):
+        stream = _make_cache_stream([16], cfg_type="initialize", n_kvo_layers=1)
+        old_batch = stream.trt_unet_batch_size  # 2
+        original = stream.kvo_cache[0].clone()
+        updater = _make_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        resized = stream.kvo_cache[0]
+        assert torch.equal(resized[:, :, :old_batch, :, :], original), (
+            "kvo_cache lost its old content across a grow resize"
+        )
+        assert torch.equal(resized[:, :, old_batch:, :, :], torch.zeros_like(resized[:, :, old_batch:, :, :])), (
+            "kvo_cache's newly grown rows should be zero-padded, not garbage"
+        )
+
+    def test_empty_kvo_cache_list_is_skipped_without_error(self):
+        """kvo_cache=[] (never allocated -- no TRT engine / feature disabled)
+        must not raise even when trt_unet_batch_size changes."""
+        stream = _make_cache_stream([16], cfg_type="initialize", n_kvo_layers=0)
+        assert stream.kvo_cache == []
+        updater = _make_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])  # must not raise
+
+        assert stream.kvo_cache == []
+
+
+class TestG8FioCacheResizesAtDim1:
+    def test_grow_resizes_fio_cache_at_dim_1_not_dim_2(self):
+        """The rank/batch-dim asymmetry vs. kvo_cache is the easiest thing to
+        get wrong here: fio_cache is 4-D with batch at dim 1, not 5-D at dim 2."""
+        stream = _make_cache_stream([16], cfg_type="initialize")
+        old_trt = stream.trt_unet_batch_size  # 2
+        updater = _make_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        for layer in stream.fio_cache:
+            assert layer.dim() == 4, "fio_cache layer rank changed -- should stay 4-D"
+            assert layer.shape[1] == stream.trt_unet_batch_size == 3, (
+                f"fio_cache batch dim (dim 1) is {layer.shape[1]}, expected trt_unet_batch_size=3"
+            )
+            # the other three dims (maxframes, seq_len, hidden) must be untouched
+            assert layer.shape[0] == CACHE_MAXFRAMES
+            assert layer.shape[2] == SEQ_LEN
+            assert layer.shape[3] == HIDDEN_DIM
+        assert old_trt != stream.trt_unet_batch_size  # sanity: this resize actually happened
+
+    def test_shrink_resizes_fio_cache_at_dim_1(self):
+        stream = _make_cache_stream([8, 24, 40], cfg_type="full")
+        assert stream.trt_unet_batch_size == 6  # 2*3*1
+        updater = _make_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        assert stream.trt_unet_batch_size == 4  # 2*2*1
+        for layer in stream.fio_cache:
+            assert layer.shape[1] == 4
+
+    def test_self_cfg_type_fio_cache_now_resizes_too(self):
+        """The shipped path: cfg_type='self' previously left fio_cache stale on
+        every live t_index change (G8's headline symptom) -- must now resize
+        just like kvo_cache does."""
+        stream = _make_cache_stream([16], cfg_type="self")
+        updater = _make_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        for layer in stream.fio_cache:
+            assert layer.shape[1] == stream.trt_unet_batch_size == 2
+
+    def test_fio_cache_content_preserved_up_to_min_batch_on_grow(self):
+        stream = _make_cache_stream([16], cfg_type="initialize", n_fio_layers=1)
+        old_batch = stream.trt_unet_batch_size  # 2
+        original = stream.fio_cache[0].clone()
+        updater = _make_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        resized = stream.fio_cache[0]
+        assert torch.equal(resized[:, :old_batch, :, :], original), (
+            "fio_cache lost its old content across a grow resize"
+        )
+
+    def test_empty_fio_cache_list_is_skipped_without_error(self):
+        stream = _make_cache_stream([16], cfg_type="initialize", n_fio_layers=0)
+        assert stream.fio_cache == []
+        updater = _make_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])  # must not raise
+
+        assert stream.fio_cache == []
+
+
+class TestG7G8NoResizeWhenTrtBatchSizeUnchanged:
+    def test_kvo_and_fio_caches_untouched_when_trt_batch_size_does_not_change(self):
+        """Two different t_index lengths can still land on the same
+        trt_unet_batch_size (e.g. 'full' collapses (n, f) pairs less densely
+        than 'self') -- the resize must be skipped (same object, not just same
+        shape) rather than paying for a no-op reallocation every time."""
+        # cfg_type='full', frame_bff_size=1: trt = 2*n*f. Force n unchanged in
+        # count but exercise the "length changed" branch by holding f steady
+        # and changing t_index length while keeping the *value* of 2*n*f fixed
+        # is not reachable via a single length change with f=1, so instead
+        # assert directly on the guard: call the resize helper's caller twice
+        # with identical old/new to confirm identity is preserved.
+        stream = _make_cache_stream([16], cfg_type="self")
+        updater = _make_updater(stream)
+        kvo_before = list(stream.kvo_cache)
+        fio_before = list(stream.fio_cache)
+
+        # Same length -> value-only path, which never touches trt_unet_batch_size
+        # or the caches at all (confirms the resize is gated on an actual change).
+        updater._recalculate_timestep_dependent_params([32])
+
+        assert len(stream.kvo_cache) == len(kvo_before)
+        assert len(stream.fio_cache) == len(fio_before)
+        for a, b in zip(stream.kvo_cache, kvo_before):
+            assert a.data_ptr() == b.data_ptr()
+        for a, b in zip(stream.fio_cache, fio_before):
+            assert a.data_ptr() == b.data_ptr()

--- a/tests/unit/test_cfg_type_validation.py
+++ b/tests/unit/test_cfg_type_validation.py
@@ -1,0 +1,185 @@
+"""
+Regression tests for G4 + G6: unvalidated / partially-handled cfg_type values.
+
+G6 root cause guarded: cfg_type is Literal-hinted in StreamDiffusion.__init__'s
+signature but that's a static-analysis hint only -- nothing enforced it at
+runtime. A typo (or a caller passing an arbitrary string) sailed through
+construction and behaved like "none" until the guidance combine in
+unet_step, then raised an opaque UnboundLocalError with no indication of
+what was actually wrong. Fix: validate at pipeline.py's single choke point
+(the one assignment to self.cfg_type, :85-91) against VALID_CFG_TYPES.
+
+G4 root cause guarded: prepare()'s prompt-embedding setup only assigns
+uncond_prompt_embeds under `use_denoising_batch and cfg_type == "full"` (or
+unconditionally for "initialize"), but consumes it unconditionally whenever
+guidance_scale > 1.0 and cfg_type is "initialize"/"full". The TCD scheduler
+forces use_denoising_batch=False (pipeline.py:104-109), so {scheduler: tcd,
+cfg_type: full} left uncond_prompt_embeds unbound -> UnboundLocalError deep
+inside torch.cat. Fix: initialize uncond_prompt_embeds = None ahead of the
+branches (both the SDXL and SD1.5/2.1 copies of this logic) and raise a
+ValueError naming the unsupported combination at the consumption site,
+instead of letting Python raise UnboundLocalError.
+
+CPU-only, model-free. G6 is tested through the real StreamDiffusion.__init__
+with a minimal fake pipe (only .vae_scale_factor is read before the cfg_type
+check fires; detect_model() -- the next thing __init__ touches -- is never
+reached in the rejection case). G4 is tested through the real prepare(), via
+an object.__new__ stub wired with only the attributes prepare() reads before
+its CFG-embeds block, plus a sentinel scheduler whose set_timesteps() raises
+a marker exception -- this bounds each test to exactly the block under test
+without needing to stand up the rest of prepare()'s scheduler machinery.
+"""
+
+import types
+
+import pytest
+import torch
+
+from streamdiffusion.param_schema import VALID_CFG_TYPES
+from streamdiffusion.pipeline import StreamDiffusion
+
+TOKENS = 77
+HIDDEN = 8
+
+
+# ---------------------------------------------------------------------------
+# G6 helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_pipe_for_init():
+    """Only .vae_scale_factor is read before the G6 cfg_type check (:79-80);
+    detect_model(pipe.unet, pipe) is the next thing __init__ touches, and it
+    isn't reached when cfg_type is rejected."""
+    return types.SimpleNamespace(vae_scale_factor=8)
+
+
+# ---------------------------------------------------------------------------
+# G4 helpers
+# ---------------------------------------------------------------------------
+
+
+class _StopHere(Exception):
+    """Marks 'prepare() got past the CFG-embeds block cleanly' -- raised by
+    the sentinel scheduler's set_timesteps(), the next thing prepare() calls
+    after the block under test."""
+
+
+class _SentinelScheduler:
+    def set_timesteps(self, *a, **k):
+        raise _StopHere()
+
+
+def _fake_sd15_encode_prompt(**kwargs):
+    return (torch.zeros(1, TOKENS, HIDDEN), torch.zeros(1, TOKENS, HIDDEN))
+
+
+def _fake_sdxl_encode_prompt(**kwargs):
+    return (
+        torch.zeros(1, TOKENS, HIDDEN),
+        torch.zeros(1, TOKENS, HIDDEN),
+        torch.zeros(1, HIDDEN),
+        torch.zeros(1, HIDDEN),
+    )
+
+
+def _make_prepare_stub(
+    cfg_type,
+    use_denoising_batch,
+    is_sdxl=False,
+    guidance_scale=1.4,
+    batch_size=2,
+    frame_bff_size=1,
+    denoising_steps_num=2,
+):
+    """object.__new__ stub wired with exactly what prepare() reads up to (and
+    including) the CFG-embeds block -- not the full prepare() surface."""
+    stream = object.__new__(StreamDiffusion)
+    stream.height = 512
+    stream.width = 512
+    stream.dtype = torch.float32
+    stream.device = "cpu"
+    stream.denoising_steps_num = denoising_steps_num
+    stream.frame_bff_size = frame_bff_size
+    stream.latent_height = 64
+    stream.latent_width = 64
+    stream.cfg_type = cfg_type
+    stream.is_sdxl = is_sdxl
+    stream.use_denoising_batch = use_denoising_batch
+    stream.batch_size = batch_size
+    stream.embedding_hooks = []
+    stream.scheduler = _SentinelScheduler()
+    stream.pipe = types.SimpleNamespace(
+        encode_prompt=_fake_sdxl_encode_prompt if is_sdxl else _fake_sd15_encode_prompt
+    )
+    return stream
+
+
+# ---------------------------------------------------------------------------
+# G6 tests
+# ---------------------------------------------------------------------------
+
+
+class TestG6CfgTypeValidation:
+    def test_unknown_cfg_type_raises_listing_valid_values(self):
+        with pytest.raises(ValueError, match="cfg_type must be one of"):
+            StreamDiffusion(pipe=_fake_pipe_for_init(), t_index_list=[16], device="cpu", cfg_type="bogus")
+
+    def test_all_valid_cfg_types_pass_the_gate(self):
+        """Must not raise G6's ValueError for any real cfg_type -- construction
+        is expected to fail later (AttributeError on the fake pipe's missing
+        .unet, inside detect_model) for reasons unrelated to this check."""
+        for cfg_type in VALID_CFG_TYPES:
+            try:
+                StreamDiffusion(pipe=_fake_pipe_for_init(), t_index_list=[16], device="cpu", cfg_type=cfg_type)
+            except ValueError as e:
+                if "cfg_type must be one of" in str(e):
+                    pytest.fail(f"valid cfg_type {cfg_type!r} rejected by the G6 gate")
+                raise
+            except AttributeError:
+                pass  # expected: detect_model(pipe.unet, ...) -- fake pipe has no .unet
+
+
+# ---------------------------------------------------------------------------
+# G4 tests
+# ---------------------------------------------------------------------------
+
+
+class TestG4UncondPromptEmbedsUnboundLocal:
+    def test_tcd_full_raises_legible_value_error_sd15(self):
+        """The actual regression: {scheduler: tcd (-> use_denoising_batch=False),
+        cfg_type: full} at guidance_scale > 1.0 must raise a ValueError naming
+        the unsupported combination, not UnboundLocalError."""
+        stream = _make_prepare_stub(cfg_type="full", use_denoising_batch=False, guidance_scale=1.4)
+        with pytest.raises(ValueError, match="requires use_denoising_batch=True"):
+            stream.prepare("a cat")
+
+    def test_tcd_full_raises_legible_value_error_sdxl(self):
+        """Same regression, SDXL branch (pipeline.py duplicates this logic)."""
+        stream = _make_prepare_stub(cfg_type="full", use_denoising_batch=False, is_sdxl=True, guidance_scale=1.4)
+        with pytest.raises(ValueError, match="requires use_denoising_batch=True"):
+            stream.prepare("a cat")
+
+    def test_lcm_full_reaches_scheduler_setup_without_valueerror(self):
+        """Non-regression: {scheduler: lcm (-> use_denoising_batch=True),
+        cfg_type: full} is the reachable, working combination -- must NOT
+        raise G4's ValueError. Reaching the sentinel scheduler proves the
+        CFG-embeds block (including the torch.cat) completed successfully."""
+        stream = _make_prepare_stub(cfg_type="full", use_denoising_batch=True, guidance_scale=1.4)
+        with pytest.raises(_StopHere):
+            stream.prepare("a cat")
+
+    def test_tcd_initialize_does_not_raise(self):
+        """cfg_type='initialize' assigns uncond_prompt_embeds unconditionally
+        (pipeline.py's elif has no use_denoising_batch guard) -- G4 does not
+        affect this mode even under TCD. Non-regression guard."""
+        stream = _make_prepare_stub(cfg_type="initialize", use_denoising_batch=False, guidance_scale=1.4)
+        with pytest.raises(_StopHere):
+            stream.prepare("a cat")
+
+    def test_none_cfg_type_never_touches_uncond_branch(self):
+        """cfg_type='none' never satisfies the guidance_scale>1.0-and-cfg-mode
+        gate, so uncond_prompt_embeds staying None is never consumed."""
+        stream = _make_prepare_stub(cfg_type="none", use_denoising_batch=False, guidance_scale=1.4)
+        with pytest.raises(_StopHere):
+            stream.prepare("a cat")

--- a/tests/unit/test_derived_tensor_sync.py
+++ b/tests/unit/test_derived_tensor_sync.py
@@ -80,6 +80,12 @@ def _make_stream_shell(
     stream.t_list = t_index_list
     stream.sub_timesteps = [int(timesteps_raw[i]) for i in t_index_list]
     stream.sub_timesteps_tensor = torch.tensor(stream.sub_timesteps, dtype=torch.long)
+    # G1: _update_timestep_calculations() now unconditionally calls
+    # stream._rebuild_sub_timesteps_expanded() (see test_sub_timesteps_expanded_refresh.py).
+    # This shell is a bare SimpleNamespace, not a real StreamDiffusion, and this
+    # file doesn't exercise that table -- stub it out rather than reimplementing
+    # pipeline.py's logic here.
+    stream._rebuild_sub_timesteps_expanded = lambda: None
 
     # Build initial alpha/beta matching the logic in _update_timestep_calculations
     a_list, b_list = [], []

--- a/tests/unit/test_live_t_index_resize_buffers.py
+++ b/tests/unit/test_live_t_index_resize_buffers.py
@@ -1,0 +1,195 @@
+"""
+Regression tests for stale batch-sized buffers after a live t_index_list
+LENGTH change (TD: TIndexBlock numBlocks changed while the stream runs).
+
+Root cause guarded: StreamParameterUpdater._recalculate_timestep_dependent_params
+(length-changed branch) rebuilds batch_size, x_t_latent_buffer, init_noise,
+stock_noise and prompt_embeds — but never `_stock_noise_bufs` / `_stock_noise_pong`
+/ `_combined_latent_buf` / `_cfg_latent_buf` / `_cfg_t_buf`, all allocated only in
+prepare(). predict_x0_batch's n>1 path subscripts `_combined_latent_buf` and runs
+the ping-pong rotation unconditionally, so the next frame after a live resize:
+
+  - 1 -> n>1:  `None[: frame_bff_size]` TypeError (uncaught: __call__'s fallback
+               only catches RuntimeError) — stream dead until restart.
+  - grow n>=2: stale-shape copy_ RuntimeError; the fallback's
+               _refresh_derived_tensors() rebuilt _combined_latent_buf but NOT
+               _stock_noise_bufs, so it failed again every frame (permanent
+               decode(randn) noise loop).
+  - shrink:    copy_ broadcast-succeeds silently, then `stock_noise = _sn_dst`
+               rebinds stock_noise to the stale larger tensor — shape mismatch
+               downstream / silent corruption.
+
+Fix guarded here: _refresh_derived_tensors() also rebuilds the ping-pong buffers,
+and the updater's length-change branch delegates its derived-tensor rebuild to it
+(prepare() parity from one shared implementation).
+
+CPU-only, model-free. Reuses the object.__new__ harnesses from
+test_rcfg_self_single_step_reseed.py (real StreamDiffusion + fake UNet) and
+test_derived_tensor_sync.py (real StreamParameterUpdater shell).
+"""
+
+import torch
+from test_rcfg_self_single_step_reseed import _make_stream, _zero_input
+
+from streamdiffusion.pipeline import StreamDiffusion
+from streamdiffusion.stream_parameter_updater import StreamParameterUpdater
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_resizable_stream(t_index_list, **kwargs):
+    """_make_stream plus the attributes the updater's length-change branch reads
+    (t_list, timesteps, kvo plumbing, instance-assigned scheduler scalings —
+    the object.__new__ LCMScheduler shell has no .config for the real method)."""
+    stream = _make_stream(t_index_list, **kwargs)
+    stream.t_list = list(t_index_list)
+    stream.timesteps = torch.linspace(999, 19, 50).long()
+    stream.sub_timesteps = [int(stream.timesteps[i]) for i in t_index_list]
+    stream._kvo_buckets = None
+    stream._kvo_outputs_by_bucket = None
+
+    def _scalings(timestep):
+        # Same LCM boundary-condition formulas as _make_stream (sigma_data=0.5,
+        # timestep_scaling=10): c_skip ~ 0, c_out ~ 1 at these timesteps
+        t = float(timestep.item() if isinstance(timestep, torch.Tensor) else timestep)
+        st = 10.0 * t
+        return torch.tensor(0.25 / (st**2 + 0.25)), torch.tensor(st / (st**2 + 0.25) ** 0.5)
+
+    stream.scheduler.get_scalings_for_boundary_condition_discrete = _scalings
+    return stream
+
+
+def _make_updater(stream):
+    """Construct StreamParameterUpdater without calling __init__ (avoids deps)."""
+    updater = object.__new__(StreamParameterUpdater)
+    updater.stream = stream
+    updater._lock = __import__("threading").Lock()
+    return updater
+
+
+def _assert_frames_healthy(stream, n_new, num_frames):
+    """Drive predict_x0_batch and assert per-frame batch-shape consistency."""
+    x_in = _zero_input(stream)
+    for frame in range(num_frames):
+        x0 = StreamDiffusion.predict_x0_batch(stream, x_in)
+        assert torch.isfinite(x0).all(), f"frame {frame}: non-finite x0 after resize to n={n_new}"
+        assert stream.stock_noise.shape[0] == n_new, (
+            f"frame {frame}: stock_noise has {stream.stock_noise.shape[0]} rows, expected {n_new} — "
+            "stale ping-pong buffer rebound after live resize"
+        )
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+class TestLiveTIndexResize:
+    """Live length change via updater._recalculate_timestep_dependent_params,
+    then frames through the real predict_x0_batch — no prepare() in between,
+    exactly like the OSC /t_list path in TD."""
+
+    def test_grow_1_to_2(self):
+        stream = _make_resizable_stream([16])
+        updater = _make_updater(stream)
+        _assert_frames_healthy(stream, 1, 2)  # pre-resize baseline works
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        # Pre-fix: TypeError — _combined_latent_buf is still None from n==1
+        _assert_frames_healthy(stream, 2, 4)
+        assert stream._combined_latent_buf.shape[0] == 2
+        for buf in stream._stock_noise_bufs:
+            assert buf.shape[0] == 2
+
+    def test_grow_1_to_2_ping_pong_rotates(self):
+        stream = _make_resizable_stream([16])
+        updater = _make_updater(stream)
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        x_in = _zero_input(stream)
+        expected_pong = stream._stock_noise_pong
+        for frame in range(4):
+            StreamDiffusion.predict_x0_batch(stream, x_in)
+            expected_pong = 1 - expected_pong
+            assert stream._stock_noise_pong == expected_pong, (
+                f"frame {frame}: ping-pong rotation not engaged after live 1->2 resize"
+            )
+
+    def test_grow_2_to_3(self):
+        stream = _make_resizable_stream([16, 32])
+        updater = _make_updater(stream)
+        _assert_frames_healthy(stream, 2, 2)
+
+        updater._recalculate_timestep_dependent_params([8, 24, 40])
+
+        # Pre-fix: RuntimeError — 2-row _combined_latent_buf vs 3-row tensors,
+        # and _stock_noise_bufs stay 2-row even after _refresh_derived_tensors()
+        _assert_frames_healthy(stream, 3, 4)
+        assert stream._combined_latent_buf.shape[0] == 3
+        for buf in stream._stock_noise_bufs:
+            assert buf.shape[0] == 3
+
+    def test_shrink_3_to_2(self):
+        stream = _make_resizable_stream([8, 24, 40])
+        updater = _make_updater(stream)
+        _assert_frames_healthy(stream, 3, 2)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        # Pre-fix: the stale 3-row buffers broadcast-accept the 2-row copies
+        # silently, then stock_noise is rebound to 3 rows (caught per-frame in
+        # _assert_frames_healthy) and unet_step raises on the shape mismatch
+        _assert_frames_healthy(stream, 2, 4)
+        assert stream._combined_latent_buf.shape[0] == 2
+        for buf in stream._stock_noise_bufs:
+            assert buf.shape[0] == 2
+
+    def test_shrink_2_to_1(self):
+        stream = _make_resizable_stream([16, 32])
+        updater = _make_updater(stream)
+        _assert_frames_healthy(stream, 2, 2)
+
+        updater._recalculate_timestep_dependent_params([16])
+
+        # n==1 path uses none of the batch buffers (functional today); the buf
+        # must also be dropped to None for prepare() parity so a later grow
+        # re-allocates instead of reusing a stale tensor
+        x_in = _zero_input(stream)
+        for frame in range(4):
+            x0 = StreamDiffusion.predict_x0_batch(stream, x_in)
+            assert torch.isfinite(x0).all()
+            assert torch.allclose(stream.stock_noise, stream.init_noise), (
+                f"frame {frame}: n==1 per-frame reseed invariant broken after live 2->1 resize"
+            )
+        assert stream._combined_latent_buf is None
+        assert stream.x_t_latent_buffer is None
+
+
+class TestRefreshDerivedTensorsSelfHeal:
+    """_refresh_derived_tensors() is the error-fallback's rebuild hook — it must
+    restore the ping-pong buffers too, or the fallback loops forever."""
+
+    def test_refresh_rebuilds_ping_pong_buffers(self):
+        stream = _make_resizable_stream([16, 32])
+        h = stream.latent_height
+        # Stale the ping-pong state the way a live resize leaves it
+        stream._stock_noise_bufs = [
+            torch.empty(1, 4, h, h, dtype=stream.dtype),
+            torch.empty(1, 4, h, h, dtype=stream.dtype),
+        ]
+        stream._stock_noise_pong = 1
+
+        StreamDiffusion._refresh_derived_tensors(stream)
+
+        assert stream._stock_noise_pong == 0
+        for buf in stream._stock_noise_bufs:
+            assert buf.shape == (stream.batch_size, 4, h, h), (
+                "_refresh_derived_tensors left _stock_noise_bufs stale — the __call__ "
+                "error fallback can never self-heal a live batch-size change"
+            )
+        # The rebuilt bufs must not alias stock_noise (ping-pong precondition)
+        for buf in stream._stock_noise_bufs:
+            assert buf.data_ptr() != stream.stock_noise.data_ptr()

--- a/tests/unit/test_live_t_index_resize_buffers.py
+++ b/tests/unit/test_live_t_index_resize_buffers.py
@@ -66,6 +66,12 @@ def _make_updater(stream):
     updater = object.__new__(StreamParameterUpdater)
     updater.stream = stream
     updater._lock = __import__("threading").Lock()
+    # G2/G3 (_recalculate_timestep_dependent_params, update_stream_params) read
+    # these unconditionally -- real __init__ always sets them; the object.__new__
+    # stub must too, or the resize path raises AttributeError before it ever
+    # reaches the buffer-rebuild logic this file actually tests.
+    updater._current_prompt_list = []
+    updater._last_prompt_interpolation_method = "linear"
     return updater
 
 

--- a/tests/unit/test_prompt_embeds_cfg_resize.py
+++ b/tests/unit/test_prompt_embeds_cfg_resize.py
@@ -1,0 +1,189 @@
+"""
+Regression tests for G2 + G3: prompt_embeds / CFG buffer staleness across a
+live t_index_list resize and a live guidance_scale crossing of 1.0.
+
+G2 root cause guarded: _recalculate_timestep_dependent_params's length-changed
+branch rebuilt prompt_embeds as prompt_embeds[0].repeat(batch_size, 1, 1) with
+no cfg guard. Row [0] is the *uncond* row for cfg_type in (initialize, full)
+(see prepare()'s [uncond|cond] cat) — repeating it turned every row into
+uncond: wrong content, and (for cfg_type == "initialize" with
+denoising_steps_num > 1) also the wrong row count, since _apply_prompt_blending's
+own CFG branch was *also* repeating uncond by the full batch_size instead of
+frame_bff_size — only masked at denoising_steps_num == 1, where the two are
+equal. Fix: the resize path re-runs _apply_prompt_blending (the one function
+that already knows every cfg layout) instead of hand-rolling the shape, and
+_apply_prompt_blending's "initialize" branch itself was corrected to repeat
+uncond by frame_bff_size, matching prepare() and unet_step's _cfg_latent_buf.
+
+G3 root cause guarded: a live guidance_scale update crossing 1.0 (either
+direction) left _cfg_latent_buf/_cfg_t_buf (pipeline.py's CFG expansion
+buffers, allocated only when guidance_scale > 1.0) stale — None if it had
+never crossed above 1.0 before, or sized for the OLD cfg regime otherwise —
+until some unrelated batch-size-changing call happened to reach
+_refresh_derived_tensors(). Fix: update_stream_params now detects the
+crossing and rebuilds them (plus re-blends prompt_embeds) in step.
+
+CPU-only, model-free. Builds a real StreamDiffusion instance via the
+_make_stream / _make_resizable_stream harnesses (test_rcfg_self_single_step_reseed.py
+/ test_live_t_index_resize_buffers.py), plus a minimal stream.pipe.encode_prompt
+stand-in so _apply_prompt_blending's CFG branch can run without a real text encoder.
+"""
+
+import threading
+import types
+
+import torch
+from test_live_t_index_resize_buffers import _make_resizable_stream, _make_updater
+
+UNCOND_VALUE = -1.0
+COND_VALUE = 2.0
+TOKENS = 77
+HIDDEN = 8
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_encode_prompt(**kwargs):
+    """Deterministic uncond embedding, distinguishable from the cached cond embed."""
+    return (torch.full((1, TOKENS, HIDDEN), UNCOND_VALUE),)
+
+
+def _make_cfg_stream(t_index_list, **kwargs):
+    stream = _make_resizable_stream(t_index_list, **kwargs)
+    stream.embedding_hooks = []
+    stream.pipe = types.SimpleNamespace(encode_prompt=_fake_encode_prompt)
+    return stream
+
+
+def _make_cfg_updater(stream, prompt="cat"):
+    """_make_updater plus a populated prompt cache (so _apply_prompt_blending
+    has something to re-blend) and the lock/warn-once flags
+    update_stream_params reads unconditionally."""
+    updater = _make_updater(stream)
+    updater._prompt_cache = {0: {"embed": torch.full((1, TOKENS, HIDDEN), COND_VALUE), "text": prompt}}
+    updater._current_prompt_list = [(prompt, 1.0)]
+    updater._current_negative_prompt = ""
+    updater._last_prompt_interpolation_method = "linear"
+    updater.normalize_prompt_weights = True
+    updater._update_lock = threading.RLock()
+    updater._warned_delta_above_ceiling = False
+    updater._warned_delta_out_of_range = False
+    return updater
+
+
+# ---------------------------------------------------------------------------
+# G2 tests
+# ---------------------------------------------------------------------------
+
+
+class TestG2PromptEmbedsCfgResize:
+    def test_initialize_resize_uncond_cond_content_and_row_count(self):
+        stream = _make_cfg_stream([16], cfg_type="initialize", guidance_scale=1.4)
+        updater = _make_cfg_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        f = stream.frame_bff_size
+        n = stream.batch_size
+        assert stream.prompt_embeds.shape[0] == f + n, (
+            f"initialize prompt_embeds row count {stream.prompt_embeds.shape[0]} != "
+            f"frame_bff_size({f}) + batch_size({n}) — mismatches _cfg_latent_buf/UNet batch"
+        )
+        uncond_rows = stream.prompt_embeds[:f]
+        cond_rows = stream.prompt_embeds[f:]
+        assert torch.allclose(uncond_rows, torch.full_like(uncond_rows, UNCOND_VALUE)), (
+            "uncond rows are not real uncond content after resize"
+        )
+        assert torch.allclose(cond_rows, torch.full_like(cond_rows, COND_VALUE)), (
+            "cond rows corrupted — pre-fix bug made every row uncond (row[0].repeat)"
+        )
+
+    def test_self_resize_all_rows_are_cond(self):
+        """cfg_type='self' has no uncond block in prompt_embeds at all — every
+        row must be the real cond content post-resize (not silently zeroed or
+        left partially stale)."""
+        stream = _make_cfg_stream([16], cfg_type="self", guidance_scale=1.4)
+        updater = _make_cfg_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        assert stream.prompt_embeds.shape[0] == stream.batch_size
+        assert torch.allclose(stream.prompt_embeds, torch.full_like(stream.prompt_embeds, COND_VALUE))
+
+    def test_resize_falls_back_to_row0_repeat_when_no_cached_prompt(self):
+        """No cfg guard needed for the fallback branch either — must survive
+        the case where there's nothing cached yet to re-blend from (fresh
+        construction before the first update_prompt call)."""
+        stream = _make_cfg_stream([16], cfg_type="self", guidance_scale=1.4)
+        updater = _make_updater(stream)  # no _prompt_cache / _current_prompt_list entries
+        old_row0 = stream.prompt_embeds[0].clone()
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        assert stream.prompt_embeds.shape[0] == stream.batch_size
+        assert torch.allclose(stream.prompt_embeds, old_row0.repeat(stream.batch_size, 1, 1))
+
+
+# ---------------------------------------------------------------------------
+# G3 tests
+# ---------------------------------------------------------------------------
+
+
+class TestG3GuidanceScaleCrossing:
+    def test_crossing_above_1_allocates_cfg_buffers(self):
+        stream = _make_cfg_stream([16, 32], cfg_type="initialize", guidance_scale=1.0)
+        assert stream._cfg_latent_buf is None  # baseline: guidance <= 1.0, never allocated
+        updater = _make_cfg_updater(stream)
+
+        updater.update_stream_params(guidance_scale=1.4)
+
+        assert stream._cfg_latent_buf is not None, (
+            "_cfg_latent_buf still None after guidance_scale crossed above 1.0 — "
+            "unet_step would TypeError on the next frame"
+        )
+        assert stream._cfg_t_buf is not None
+        assert stream._cfg_latent_buf.shape[0] == stream.frame_bff_size + stream.batch_size
+
+    def test_crossing_below_1_drops_cfg_buffers(self):
+        stream = _make_cfg_stream([16, 32], cfg_type="initialize", guidance_scale=1.4)
+        assert stream._cfg_latent_buf is not None
+        updater = _make_cfg_updater(stream)
+
+        updater.update_stream_params(guidance_scale=1.0)
+
+        assert stream._cfg_latent_buf is None
+        assert stream._cfg_t_buf is None
+
+    def test_non_crossing_change_leaves_cfg_buffers_untouched(self):
+        """A guidance_scale change that stays on the same side of 1.0 must not
+        pay for a rebuild — same buffer object, not just an equal-shaped one."""
+        stream = _make_cfg_stream([16, 32], cfg_type="initialize", guidance_scale=1.4)
+        updater = _make_cfg_updater(stream)
+        buf_before = stream._cfg_latent_buf
+
+        updater.update_stream_params(guidance_scale=1.6)
+
+        assert stream._cfg_latent_buf is buf_before
+
+    def test_full_cfg_type_also_covered(self):
+        stream = _make_cfg_stream([16, 32], cfg_type="full", guidance_scale=1.0)
+        updater = _make_cfg_updater(stream)
+
+        updater.update_stream_params(guidance_scale=1.4)
+
+        assert stream._cfg_latent_buf is not None
+        assert stream._cfg_latent_buf.shape[0] == 2 * stream.batch_size
+
+    def test_none_and_self_cfg_types_unaffected(self):
+        """'none'/'self' never allocate these buffers regardless of guidance —
+        crossing must not spuriously allocate them."""
+        for cfg_type in ("none", "self"):
+            stream = _make_cfg_stream([16, 32], cfg_type=cfg_type, guidance_scale=1.0)
+            updater = _make_cfg_updater(stream)
+
+            updater.update_stream_params(guidance_scale=1.4)
+
+            assert stream._cfg_latent_buf is None
+            assert stream._cfg_t_buf is None

--- a/tests/unit/test_rcfg_self_single_step_reseed.py
+++ b/tests/unit/test_rcfg_self_single_step_reseed.py
@@ -62,6 +62,17 @@ def _make_stream(
     stream.batch_size = batch_size
     stream.cfg_type = cfg_type
     stream.use_denoising_batch = True
+    # G7/G8: _recalculate_timestep_dependent_params reads trt_unet_batch_size
+    # unconditionally (it differs from batch_size for "initialize"/"full" --
+    # see pipeline.py's __init__ formula, :113-118) -- the object.__new__ stub
+    # must set it too, or the resize path raises AttributeError before ever
+    # reaching the buffer-rebuild logic downstream tests exercise.
+    if cfg_type == "initialize":
+        stream.trt_unet_batch_size = (n + 1) * frame_bff_size
+    elif cfg_type == "full":
+        stream.trt_unet_batch_size = 2 * n * frame_bff_size
+    else:
+        stream.trt_unet_batch_size = n * frame_bff_size
     stream.guidance_scale = guidance_scale
     stream.delta = delta
     stream.do_add_noise = True

--- a/tests/unit/test_rcfg_self_single_step_reseed.py
+++ b/tests/unit/test_rcfg_self_single_step_reseed.py
@@ -1,0 +1,252 @@
+"""
+Regression tests for the R-CFG single-step divergence bug (black output at
+guidance_scale > 1 with a 1-element t_index_list).
+
+Root cause guarded: with cfg_type='self' and denoising_steps_num == 1, the
+per-frame stock_noise reseed (predict_x0_batch ping-pong rotation) is gated
+behind `denoising_steps_num > 1` and never runs, while unet_step's R-CFG
+recurrence `stock_noise = _init_noise_rotated + delta_x` still executes with
+degenerate coefficients (_alpha_next = _beta_next = 1.0). The resulting
+cross-frame linear recurrence has growth factor |A| > 1 at typical single-step
+timesteps, so stock_noise diverges geometrically (~x100/frame), overflows fp16
+to Inf, and Inf - Inf = NaN in the CFG combine renders black frames.
+
+Correct behavior per StreamDiffusion paper Eq. 5: at the first (and only)
+denoising step, the Self-Negative virtual residual equals init_noise exactly,
+so stock_noise must be reseeded from init_noise every frame when n == 1.
+
+CPU-only, model-free. Builds a real StreamDiffusion instance via object.__new__
+(same idiom as test_derived_tensor_sync.py) with a deterministic fake UNet and
+drives the actual predict_x0_batch / unet_step code paths.
+"""
+
+import torch
+from diffusers import LCMScheduler
+
+from streamdiffusion.pipeline import StreamDiffusion
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_unet(sample, timestep, encoder_hidden_states=None, kvo_cache=None, return_dict=False, **kwargs):
+    """Deterministic stand-in for the UNet (SD1.5 calling convention)."""
+    return (0.05 * sample,)
+
+
+def _make_stream(
+    t_index_list,
+    cfg_type="self",
+    guidance_scale=1.4,
+    delta=1.0,
+    dtype=torch.float32,
+    latent_hw=8,
+    seed=1234,
+):
+    """Real StreamDiffusion instance (no __init__) wired with exactly the
+    attributes predict_x0_batch / unet_step read, mirroring prepare()'s
+    formulas. frame_bff_size fixed at 1 (the TD configuration)."""
+    stream = object.__new__(StreamDiffusion)
+    n = len(t_index_list)
+    frame_bff_size = 1
+    batch_size = n * frame_bff_size
+    h = w = latent_hw
+
+    stream.device = "cpu"
+    stream.dtype = dtype
+    stream.latent_height = h
+    stream.latent_width = w
+    stream.frame_bff_size = frame_bff_size
+    stream.denoising_steps_num = n
+    stream.batch_size = batch_size
+    stream.cfg_type = cfg_type
+    stream.use_denoising_batch = True
+    stream.guidance_scale = guidance_scale
+    stream.delta = delta
+    stream.do_add_noise = True
+    stream.generator = torch.Generator(device="cpu").manual_seed(seed)
+
+    # UNet plumbing: SD1.5 branch, hooks/caches disabled
+    stream.is_sdxl = False
+    stream.unet_hooks = []
+    stream.kvo_cache = []
+    stream.fio_cache = []
+    stream.use_feature_injection = False
+    stream._fi_strength_tensor = None
+    stream._fi_threshold_tensor = None
+    stream._is_unet_tensorrt = None
+    stream._unet_kwargs = {"return_dict": False}
+    stream._sdxl_conditioning_cache = {}
+    stream._cached_batch_size = None
+    stream._cached_cfg_type = None
+    stream._cached_guidance_scale = None
+    stream.unet = _fake_unet
+    stream.update_kvo_cache = lambda *a, **k: None
+    stream.prompt_embeds = torch.zeros(batch_size, 77, 8, dtype=dtype)
+
+    # Scheduler shell with a real cumulative-alpha schedule (matches
+    # test_derived_tensor_sync.py's mock; isinstance(LCMScheduler) must hold)
+    sched = object.__new__(LCMScheduler)
+    betas = torch.linspace(0.0001, 0.02, 1000)
+    alphas_cumprod = torch.cumprod(1.0 - betas, dim=0)
+    sched.alphas_cumprod = alphas_cumprod
+    stream.scheduler = sched
+
+    timesteps_raw = torch.linspace(999, 19, 50).long()
+    sub_timesteps = [int(timesteps_raw[i]) for i in t_index_list]
+    stream.sub_timesteps_tensor = torch.tensor(sub_timesteps, dtype=torch.long)
+
+    stream.alpha_prod_t_sqrt = (
+        torch.stack([alphas_cumprod[t].sqrt() for t in sub_timesteps]).view(n, 1, 1, 1).to(dtype)
+    )
+    stream.beta_prod_t_sqrt = (
+        torch.stack([(1 - alphas_cumprod[t]).sqrt() for t in sub_timesteps]).view(n, 1, 1, 1).to(dtype)
+    )
+
+    # LCM boundary-condition scalings (diffusers formulas, sigma_data=0.5,
+    # timestep_scaling=10): c_skip ~ 0, c_out ~ 1 at these timesteps
+    c_skip_l, c_out_l = [], []
+    for t in sub_timesteps:
+        st = 10.0 * t
+        c_skip_l.append(0.25 / (st**2 + 0.25))
+        c_out_l.append(st / (st**2 + 0.25) ** 0.5)
+    stream.c_skip = torch.tensor(c_skip_l, dtype=dtype).view(n, 1, 1, 1)
+    stream.c_out = torch.tensor(c_out_l, dtype=dtype).view(n, 1, 1, 1)
+
+    # Noise state + ping-pong buffers, exactly as prepare() builds them
+    stream.init_noise = torch.randn((batch_size, 4, h, w), dtype=dtype, generator=stream.generator)
+    stream.stock_noise = stream.init_noise.clone()
+    stream._stock_noise_bufs = [stream.stock_noise.clone(), torch.empty_like(stream.stock_noise)]
+    stream._stock_noise_pong = 0
+
+    # Derived shifted tensors (degenerate ones-padding at n == 1)
+    if cfg_type in ("self", "initialize"):
+        stream._alpha_next = torch.cat(
+            [stream.alpha_prod_t_sqrt[1:], torch.ones_like(stream.alpha_prod_t_sqrt[0:1])], dim=0
+        )
+        stream._beta_next = torch.cat(
+            [stream.beta_prod_t_sqrt[1:], torch.ones_like(stream.beta_prod_t_sqrt[0:1])], dim=0
+        )
+        stream._init_noise_rotated = torch.cat([stream.init_noise[1:], stream.init_noise[0:1]], dim=0)
+    else:
+        stream._alpha_next = None
+        stream._beta_next = None
+        stream._init_noise_rotated = None
+
+    # Latent buffers
+    stream.x_t_latent_buffer = None if n == 1 else torch.zeros((n - 1) * frame_bff_size, 4, h, w, dtype=dtype)
+    stream._combined_latent_buf = None if n == 1 else torch.empty(batch_size, 4, h, w, dtype=dtype)
+
+    # CFG expansion buffers (only allocated for the cfg types that use them)
+    if guidance_scale > 1.0 and cfg_type in ("initialize", "full"):
+        cfg_batch = (1 + batch_size) if cfg_type == "initialize" else (2 * batch_size)
+        stream._cfg_latent_buf = torch.empty(cfg_batch, 4, h, w, dtype=dtype)
+        stream._cfg_t_buf = torch.empty(cfg_batch, dtype=stream.sub_timesteps_tensor.dtype)
+    else:
+        stream._cfg_latent_buf = None
+        stream._cfg_t_buf = None
+
+    return stream
+
+
+def _zero_input(stream):
+    return torch.zeros(stream.frame_bff_size, 4, stream.latent_height, stream.latent_width, dtype=stream.dtype)
+
+
+def _run_frames(stream, num_frames):
+    """Drive predict_x0_batch with a constant zero input latent; returns the
+    per-frame x0 outputs. NOTE: runs all frames up front — use an inline loop
+    instead when asserting per-frame stream state."""
+    x_in = _zero_input(stream)
+    return [StreamDiffusion.predict_x0_batch(stream, x_in) for _ in range(num_frames)]
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+class TestSingleStepReseedFixesDivergence:
+    """n == 1, cfg_type='self', guidance > 1: stock_noise must be pinned to
+    init_noise every frame and stay bounded/finite. FAILS on unpatched code
+    (observed geometric blow-up ~x100/frame); PASSES once predict_x0_batch's
+    n == 1 reseed and the unet_step recurrence gate land."""
+
+    def test_stock_noise_pinned_to_init_noise_every_frame(self):
+        stream = _make_stream([16], cfg_type="self", guidance_scale=1.4)
+        x_in = _zero_input(stream)
+        for frame in range(8):
+            x0 = StreamDiffusion.predict_x0_batch(stream, x_in)
+            max_abs = stream.stock_noise.abs().max().item()
+            assert torch.allclose(stream.stock_noise, stream.init_noise), (
+                f"frame {frame}: stock_noise diverged from init_noise (max_abs={max_abs:.3e}) — "
+                "n==1 per-frame reseed missing"
+            )
+            # copy_, not alias: init_noise must never be corrupted through stock_noise
+            assert stream.stock_noise.data_ptr() != stream.init_noise.data_ptr()
+            assert max_abs < 100.0, f"frame {frame}: stock_noise unbounded (max_abs={max_abs:.3e})"
+            assert torch.isfinite(x0).all(), f"frame {frame}: non-finite x0 output"
+
+    def test_divergence_gone_even_at_guidance_1(self):
+        """The recurrence ran (and silently diverged) even at guidance 1.0 —
+        raising guidance later merely exposed the already-corrupt buffer."""
+        stream = _make_stream([16], cfg_type="self", guidance_scale=1.0)
+        x_in = _zero_input(stream)
+        for frame in range(8):
+            x0 = StreamDiffusion.predict_x0_batch(stream, x_in)
+            max_abs = stream.stock_noise.abs().max().item()
+            assert max_abs < 100.0, (
+                f"frame {frame}: stock_noise diverging in background at guidance 1.0 (max_abs={max_abs:.3e})"
+            )
+            assert torch.isfinite(x0).all()
+
+    def test_initialize_cfg_type_bounded(self):
+        """'initialize' self-heals at n==1 (real uncond overwrites the single
+        slot each frame) — must stay bounded before and after the fix."""
+        stream = _make_stream([16], cfg_type="initialize", guidance_scale=1.4)
+        x_in = _zero_input(stream)
+        for frame in range(8):
+            x0 = StreamDiffusion.predict_x0_batch(stream, x_in)
+            max_abs = stream.stock_noise.abs().max().item()
+            assert max_abs < 100.0, f"frame {frame}: stock_noise unbounded (max_abs={max_abs:.3e})"
+            assert torch.isfinite(x0).all()
+
+    def test_full_and_none_cfg_types_unaffected(self):
+        """'full'/'none' never synthesize uncond from stock_noise — just assert
+        the n==1 path runs clean and finite."""
+        for cfg_type in ("full", "none"):
+            stream = _make_stream([16], cfg_type=cfg_type, guidance_scale=1.4)
+            for x0 in _run_frames(stream, 4):
+                assert torch.isfinite(x0).all(), f"cfg_type={cfg_type}: non-finite x0"
+
+
+class TestMultiStepPathUnaffectedByReseed:
+    """n == 2 ping-pong path must be untouched by the n == 1 fix (the new code
+    sits in an elif only reachable when denoising_steps_num == 1)."""
+
+    def test_ping_pong_still_engages_and_stays_stable(self):
+        stream = _make_stream([16, 32], cfg_type="self", guidance_scale=1.4)
+        x_in = _zero_input(stream)
+        expected_pong = 0
+        for frame in range(6):
+            x0 = StreamDiffusion.predict_x0_batch(stream, x_in)
+            expected_pong = 1 - expected_pong
+            assert stream._stock_noise_pong == expected_pong, (
+                f"frame {frame}: ping-pong rotation did not run (n==1 branch leaked into n==2?)"
+            )
+            assert stream.x_t_latent_buffer is not None
+            # The n==1 invariant (stock_noise pinned to init_noise) must NOT leak here
+            assert not torch.allclose(stream.stock_noise, stream.init_noise)
+            max_abs = stream.stock_noise.abs().max().item()
+            assert max_abs < 10_000.0, f"frame {frame}: n==2 stock_noise unstable (max_abs={max_abs:.3e})"
+            assert torch.isfinite(x0).all()
+
+    def test_multi_step_outputs_deterministic_and_finite(self):
+        """Seeded n==2 run is reproducible — used with capture_reference.py-style
+        pre/post-fix diffing to pin the multi-step path bit-identical."""
+        outs_a = _run_frames(_make_stream([16, 32], cfg_type="self", guidance_scale=1.4, seed=77), 6)
+        outs_b = _run_frames(_make_stream([16, 32], cfg_type="self", guidance_scale=1.4, seed=77), 6)
+        for a, b in zip(outs_a, outs_b):
+            assert torch.equal(a, b), "seeded n==2 run not deterministic"
+            assert torch.isfinite(a).all()

--- a/tests/unit/test_sub_timesteps_expanded_refresh.py
+++ b/tests/unit/test_sub_timesteps_expanded_refresh.py
@@ -1,0 +1,118 @@
+"""
+Regression tests for G1: `_sub_timesteps_expanded` never rebuilt after a live
+t_index_list change.
+
+Root cause guarded: `_sub_timesteps_expanded` (pipeline.py's precomputed
+per-step timestep table for the TCD / non-batched sequential loop, read by
+loop position in `predict_x0_batch`) was built only in `prepare()`. A live
+t_index_list change through StreamParameterUpdater never touched it:
+
+  - LENGTH grow: the sequential loop indexes past the old (shorter) table ->
+    IndexError, which is NOT a RuntimeError, so __call__'s error fallback
+    (which only catches RuntimeError) never catches it — the stream dies.
+  - LENGTH shrink: stale extra rows just go unused (silent, not crashing).
+  - VALUE-only change (same length): the table keeps its stale per-frame
+    timestep values — wrong denoising schedule, no crash.
+
+Fix guarded here: the build is extracted into `_rebuild_sub_timesteps_expanded()`
+(pipeline.py), called from `prepare()` (unchanged), from
+`_update_timestep_calculations()` (stream_parameter_updater.py — the single
+funnel shared by the value-only path, the length-changed path, and __call__'s
+error fallback), and (redundantly but harmlessly) from `_refresh_derived_tensors()`.
+
+CPU-only, model-free. Reuses the `_make_stream` harness from
+test_rcfg_self_single_step_reseed.py and the `_make_resizable_stream` /
+`_make_updater` harness from test_live_t_index_resize_buffers.py, forced onto
+the non-batched (TCD-style) sequential path — `_use_seq_loop` is true whenever
+`use_denoising_batch` is False, regardless of scheduler type.
+"""
+
+import torch
+from test_live_t_index_resize_buffers import _make_resizable_stream, _make_updater
+
+from streamdiffusion.pipeline import StreamDiffusion
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sequential_stream(t_index_list, **kwargs):
+    """Non-batched (TCD-style) stream: forces the sequential-loop code path
+    that reads _sub_timesteps_expanded by index."""
+    stream = _make_resizable_stream(t_index_list, **kwargs)
+    stream.use_denoising_batch = False
+    stream.trt_unet_batch_size = stream.frame_bff_size
+    stream.batch_size = stream.frame_bff_size
+    stream._rebuild_sub_timesteps_expanded()
+    return stream
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubTimestepsExpandedRefresh:
+    def test_initial_build_matches_t_index_length(self):
+        stream = _make_sequential_stream([16])
+        assert stream._sub_timesteps_expanded.shape == (1, stream.frame_bff_size)
+
+    def test_grow_length_rebuilds_table(self):
+        """RED before the fix: the table stays at length 1 after a live grow
+        to length 2 -- predict_x0_batch's sequential loop then indexes
+        position 1 of a length-1 tensor -> IndexError."""
+        stream = _make_sequential_stream([16])
+        updater = _make_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        assert stream._sub_timesteps_expanded is not None
+        assert stream._sub_timesteps_expanded.shape == (2, stream.frame_bff_size), (
+            f"_sub_timesteps_expanded not rebuilt after t_index length grow: "
+            f"shape={stream._sub_timesteps_expanded.shape}"
+        )
+
+    def test_shrink_length_rebuilds_table(self):
+        stream = _make_sequential_stream([8, 24, 40])
+        updater = _make_updater(stream)
+
+        updater._recalculate_timestep_dependent_params([16, 32])
+
+        assert stream._sub_timesteps_expanded.shape == (2, stream.frame_bff_size)
+
+    def test_value_only_change_updates_table_values(self):
+        """Same-length t_index VALUE change must also refresh the table's
+        content, not just survive a length check -- _update_timestep_values_only
+        never reaches _refresh_derived_tensors(), so this only passes once the
+        rebuild is reachable from _update_timestep_calculations() itself."""
+        stream = _make_sequential_stream([16, 32])
+        updater = _make_updater(stream)
+        old_table = stream._sub_timesteps_expanded.clone()
+
+        updater._recalculate_timestep_dependent_params([8, 40])
+
+        assert stream._sub_timesteps_expanded.shape == old_table.shape
+        assert not torch.equal(old_table, stream._sub_timesteps_expanded), (
+            "_sub_timesteps_expanded left stale after a same-length t_index value change"
+        )
+        expected = stream.sub_timesteps_tensor.view(-1).unsqueeze(1).expand(-1, stream.frame_bff_size)
+        assert torch.equal(stream._sub_timesteps_expanded, expected)
+
+    def test_error_fallback_rebuild_is_idempotent(self):
+        """_refresh_derived_tensors() (the __call__ error-fallback rebuild
+        hook) must not corrupt an already-correct table when called again."""
+        stream = _make_sequential_stream([16, 32])
+        before = stream._sub_timesteps_expanded.clone()
+
+        StreamDiffusion._refresh_derived_tensors(stream)
+
+        assert torch.equal(before, stream._sub_timesteps_expanded)
+
+    def test_lcm_batched_path_still_collapses_to_none(self):
+        """Non-regression: the batched LCM path (denoising batch + LCMScheduler)
+        must keep collapsing this table to None -- only the sequential path
+        (TCD / non-batched) uses it."""
+        stream = _make_resizable_stream([16, 32])  # default use_denoising_batch=True, LCMScheduler
+        stream._rebuild_sub_timesteps_expanded()
+        assert stream._sub_timesteps_expanded is None

--- a/tests/unit/test_unet_call_backend_gate.py
+++ b/tests/unit/test_unet_call_backend_gate.py
@@ -112,6 +112,7 @@ def _make_pipeline(unet, *, prompt_tokens: int = 4) -> StreamDiffusion:
 
     sd.guidance_scale = 1.0  # skip CFG latent-doubling branch entirely
     sd.cfg_type = "none"
+    sd.denoising_steps_num = 1  # read by the RCFG recurrence gate in unet_step
 
     sd.prompt_embeds = torch.randn(1, prompt_tokens, 8)
     sd.kvo_cache: List[torch.Tensor] = []
@@ -161,8 +162,7 @@ class TestSd15Sd21UnetCallBackendGate:
         assert "kvo_cache" in recording_unet.last_kwargs
         for key in ("fio_cache", "fi_strength", "fi_threshold"):
             assert key not in recording_unet.last_kwargs, (
-                f"non-TRT UNet call must not receive {key!r}; got kwargs="
-                f"{sorted(recording_unet.last_kwargs)}"
+                f"non-TRT UNet call must not receive {key!r}; got kwargs={sorted(recording_unet.last_kwargs)}"
             )
 
     def test_tensorrt_engine_still_receives_feature_injection_kwargs(self):
@@ -176,6 +176,5 @@ class TestSd15Sd21UnetCallBackendGate:
 
         for key in ("kvo_cache", "fio_cache", "fi_strength", "fi_threshold"):
             assert key in fake_engine.last_kwargs, (
-                f"TRT engine call must still receive {key!r}; got kwargs="
-                f"{sorted(fake_engine.last_kwargs)}"
+                f"TRT engine call must still receive {key!r}; got kwargs={sorted(fake_engine.last_kwargs)}"
             )


### PR DESCRIPTION
## Summary

Part II of the cfg_type audit that followed #38 (RCFG reseed) and #39 (t_index resize buffers) — both of those PRs only covered `cfg_type in ("self", "initialize")`. This closes seven of eight gaps found in the two modes they didn't touch (`"none"`, `"full"`), plus cfg-agnostic staleness the audit turned up along the way (shared with the shipped `"self"` path).

**Stacked on #39** — this branch is cut from #39's tip (`816eba3`) and its diff will narrow to just this PR's own commit once #38/#39 merge.

## What's fixed

- **G1** — `_sub_timesteps_expanded` was only ever built in `prepare()`, never rebuilt after a live `t_index` change. On the sequential (TCD / non-batched-LCM) path, a length grow raised `IndexError`; a value change silently went stale. Extracted into `_rebuild_sub_timesteps_expanded()`, now also called from `_refresh_derived_tensors()`.
- **G2** — the live-resize path rebuilt `prompt_embeds` as a naive row-0 repeat with no cfg guard, turning every row into the *uncond* row for `cfg_type in (initialize, full)`. Now re-runs `_apply_prompt_blending` (the function that already knows every cfg layout), falling back to the old repeat only when nothing is cached to re-blend from.
- **G3** — a live `guidance_scale` update crossing `1.0` left `_cfg_latent_buf`/`_cfg_t_buf` stale until an unrelated batch-size change happened to refresh them. `update_stream_params` now detects the crossing and rebuilds them plus re-blends `prompt_embeds` in step.
- **G4** — `uncond_prompt_embeds` was read unconditionally in `prepare()`'s CFG-embeds block but only conditionally assigned, so `{scheduler: tcd, cfg_type: full}` raised an opaque `UnboundLocalError`. Now raises a `ValueError` naming the unsupported combination.
- **G6** — `cfg_type` was `Literal`-hinted but never validated at runtime. Added `VALID_CFG_TYPES` and a runtime check at the single assignment point.
- **G7/G8** — `kvo_cache` is allocated with `trt_unet_batch_size` but was resized against `batch_size`; they diverge for `cfg_type in (initialize, full)`. `fio_cache` was never resized at all — stale on every live `t_index` change, for all four cfg modes, including the shipped `"self"` path. Both now resize off `trt_unet_batch_size` through a shared `_resize_cache_tensors(cache_list, old_b, new_b, batch_dim)` helper, respecting their differing rank/batch-dim (kvo: 5-D, dim 2; fio: 4-D, dim 1).

## What's deliberately not fixed

- **G5** — `cfg_type="full"` has evidently never worked at `batch_size=1` (`_apply_prompt_blending`'s "full" branch computes `batch_size // 2` uncond/cond rows against a UNet batch of `2*batch_size`). No shipped config uses `"full"`; repairing it is closer to a feature than a fix. `prepare()` now warns once instead, so the failure is legible rather than an opaque attention-shape error.

## Verification

- Full unit suite: 287 passed, including 4 new test files (`test_sub_timesteps_expanded_refresh`, `test_prompt_embeds_cfg_resize`, `test_cfg_type_validation`, `test_cache_resize_trt_batch`).
- Live TouchDesigner verification completed (delta re-range gate + this audit's TD-reachable findings — G1, G8 directly; G2/G7 via a `cfg_type: initialize` config edit; no-regression leg on stock `cfg_type: self` + LCM confirmed unchanged output).

## Test plan

- [x] Unit suite green (287 passed) against this branch's own `src/`
- [x] Live TD sweep: t_index length grow/shrink under `scheduler: tcd`
- [x] Live TD: Feature Injection cache survives a live t_index resize
- [x] Live TD: `cfg_type: initialize` config edit exercises G2/G7
- [x] No-regression leg: stock `cfg_type: self` + LCM output unchanged
