### PR TITLE
perf: fuse BGRA channel pack into one kernel

### DIFF
--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -1097,6 +1097,16 @@ class StreamDiffusionWrapper:
         else:
             return postprocess_image(image_tensor.cpu(), output_type=output_type)[0]
 
+    @staticmethod
+    def _pack_bgra(rgb_hwc: torch.Tensor, dst_bgra: torch.Tensor) -> None:
+        """Write the BGR channels of an HWC RGB uint8 tensor into dst_bgra[..., :3].
+
+        flip(-1) reverses the 3-wide channel axis (RGB→BGR) in a single fused
+        kernel instead of three per-channel copies; the alpha channel of dst_bgra
+        is left untouched (set once at buffer allocation).
+        """
+        dst_bgra[..., :3] = rgb_hwc.flip(-1)
+
     def _ipc_pack_rgba(self, image_tensor: torch.Tensor) -> torch.Tensor:
         """Convert pipeline output to HWC uint8 BGRA on GPU for cuda-link wire contract.
 
@@ -1123,9 +1133,7 @@ class StreamDiffusionWrapper:
             ):
                 self._ipc_pack_buf = torch.empty((h, w, 4), dtype=torch.uint8, device=rgb_hwc.device)
                 self._ipc_pack_buf[..., 3] = 255  # constant alpha, set once at (re)allocation
-            self._ipc_pack_buf[..., 0] = rgb_hwc[..., 2]  # B
-            self._ipc_pack_buf[..., 1] = rgb_hwc[..., 1]  # G
-            self._ipc_pack_buf[..., 2] = rgb_hwc[..., 0]  # R
+            self._pack_bgra(rgb_hwc, self._ipc_pack_buf)
             return self._ipc_pack_buf
 
     def _lazy_init_ipc_exporter(self, height: int, width: int):
@@ -1183,9 +1191,7 @@ class StreamDiffusionWrapper:
             ):
                 self._ipc_pack_unit_buf = torch.empty((h, w, 4), dtype=torch.uint8, device=rgb_hwc.device)
                 self._ipc_pack_unit_buf[..., 3] = 255  # constant alpha, set once at (re)allocation
-            self._ipc_pack_unit_buf[..., 0] = rgb_hwc[..., 2]  # B
-            self._ipc_pack_unit_buf[..., 1] = rgb_hwc[..., 1]  # G
-            self._ipc_pack_unit_buf[..., 2] = rgb_hwc[..., 0]  # R
+            self._pack_bgra(rgb_hwc, self._ipc_pack_unit_buf)
             return self._ipc_pack_unit_buf
 
     def _lazy_init_cn_ipc_exporter(self, height: int, width: int):

--- a/tests/unit/test_ipc_pack_bgra_correctness.py
+++ b/tests/unit/test_ipc_pack_bgra_correctness.py
@@ -1,0 +1,54 @@
+"""Correctness test for the B1 `_pack_bgra` refactor (wrapper.py).
+
+The three per-channel writes in `_ipc_pack_rgba` / `_ipc_pack_unit_rgba`
+(`dst[..., 0] = src[..., 2]` etc.) were replaced by a single fused
+`dst[..., :3] = src.flip(-1)`. Both are pure channel permutations, so the
+result must be byte-identical — the frozen pre-B1 formula below is the
+oracle and `torch.equal` compares all 4 channels (alpha must be untouched).
+
+CPU runs always (flip is device-independent); CUDA runs behind the repo's
+skip idiom (see test_sync_free_output_5_2.py).
+"""
+
+import pytest
+import torch
+
+from streamdiffusion.wrapper import StreamDiffusionWrapper
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA device required")
+
+# Both call sites pack an (H, W, 3) uint8 RGB into an (H, W, 4) BGRA buffer:
+# the main IPC path at the pipeline output resolution, the CN-preview twin at
+# the preprocessor output resolution. 512x512 is the production shape; the
+# small non-square shape guards against stride/transpose mistakes.
+SHAPES = [(512, 512), (33, 17)]
+DEVICES = ["cpu", pytest.param("cuda", marks=requires_cuda)]
+
+
+def _reference_three_write_pack(rgb_hwc: torch.Tensor, dst: torch.Tensor) -> None:
+    """Frozen pre-B1 formula: three per-channel copies (B, G, R)."""
+    dst[..., 0] = rgb_hwc[..., 2]  # B
+    dst[..., 1] = rgb_hwc[..., 1]  # G
+    dst[..., 2] = rgb_hwc[..., 0]  # R
+
+
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize("shape", SHAPES, ids=lambda s: f"{s[0]}x{s[1]}")
+def test_pack_bgra_matches_three_write_reference(shape, device):
+    h, w = shape
+    gen = torch.Generator().manual_seed(2416333)
+    rgb_hwc = torch.randint(0, 256, (h, w, 3), dtype=torch.uint8, generator=gen).to(device)
+
+    # Alpha uses a sentinel (not the production 255) to prove the helper never
+    # writes channel 3; RGB channels start as differing garbage so a no-op
+    # would fail the comparison.
+    dst_ref = torch.full((h, w, 4), 7, dtype=torch.uint8, device=device)
+    dst_new = torch.full((h, w, 4), 11, dtype=torch.uint8, device=device)
+    dst_ref[..., 3] = 123
+    dst_new[..., 3] = 123
+
+    _reference_three_write_pack(rgb_hwc, dst_ref)
+    StreamDiffusionWrapper._pack_bgra(rgb_hwc, dst_new)
+
+    assert torch.equal(dst_new, dst_ref)
+    assert torch.equal(dst_new[..., 3], torch.full((h, w), 123, dtype=torch.uint8, device=device))


### PR DESCRIPTION
## Changes

`_ipc_pack_rgba` and `_ipc_pack_unit_rgba` built each frame's shared-memory BGRA payload with
three separate per-channel `copy_` calls (B, G, R) plus a one-time alpha fill at allocation.

Adds `_pack_bgra`, a single fused write: `dst[..., :3].copy_(src.flip(-1))` — one kernel launch
instead of three, same result (BGR channel order via the reversed last-dim view), alpha
untouched since it's only set once at buffer allocation, not per frame.

- Correctness verified against a `_reference_three_write_pack` oracle that reproduces the old
  three-copy path exactly — the fused output matches byte-for-byte.
- Fewer kernel launches on the CUDA-IPC hot path (per-frame packing), no behavior change.

Adds `tests/unit/test_ipc_pack_bgra_correctness.py`, diffing the fused write against the
three-write reference for both call sites.

## Scope note

Touches `wrapper.py`, but in a self-contained new helper (`_pack_bgra`) and its two call sites —
a different region from the other currently-open PRs against this branch.

## Branch

`pr/ipc-pack-bgra-fusion` -> `SDTD_040_beta_release`
