### PR TITLE
feat: fp8 calibration provenance sidecar and image-driven capture

### DIFF
--- a/configs/td_config.yaml.example
+++ b/configs/td_config.yaml.example
@@ -41,6 +41,16 @@ fp8: false
 fp8_allow_fp16_fallback: false
 fp8_mha_qdq: false  # quantize attention BMMs (drops disable_mha_qdq); forks engine tag --fp8v3 -> --fp8v3-mhaq
 
+# fp8_calibration_style_image (fp8-round-9.1 §10): a file or a directory of real IP-Adapter
+# calibration images, used instead of the image_proj_model(zeros) surrogate when fp8=true and
+# IP-Adapter is enabled. A directory is redirected at build time to a subfolder keyed on the
+# live ipadapters[0].type — general/ for regular|plus (CLIP-encoded, any subject), faces/ for
+# faceid (ArcFace-encoded, real photographic faces only; a face-less image raises and is
+# skipped rather than aborting the whole calibration set). Missing/empty subfolder falls back
+# to the flat directory with a warning. See src/streamdiffusion/wrapper.py's
+# _resolve_fp8_calibration_dir and images/calibration/README.md.
+# fp8_calibration_style_image: "images/calibration"
+
 # builder_optimization_level: maps to TensorRT IBuilderConfig.builder_optimization_level
 # Verified against TensorRT 10.x Python API (range 0-5, TRT default 3).
 # TrtProfile UI mapping aligned with NVIDIA reference pipelines

--- a/images/calibration/README.md
+++ b/images/calibration/README.md
@@ -1,0 +1,22 @@
+# FP8 IP-Adapter calibration images
+
+`td_config.yaml`'s `fp8_calibration_style_image` points at this directory. At build time
+`wrapper.py`'s `_resolve_fp8_calibration_dir` redirects it to a subfolder keyed on the live
+`ipadapters[0].type`, not on the folder you see it land in day to day:
+
+- `general/` — `type: regular` or `type: plus`. Both encode through CLIP, so they want
+  identical inputs — any subject works.
+- `faces/` — `type: faceid` (or FaceID-Plus/v2). Encoded through InsightFace/ArcFace, which
+  raises on any image with no detectable face — **real photographic faces only**.
+
+If the resolved subfolder is missing or has no recognized image in it, the flat directory here
+is used as a fallback (a warning names the missing folder), and any image the adapter rejects
+at encode time is skipped individually — see `_encode_fp8_calibration_images` in `wrapper.py`.
+
+Recognized extensions: `.png .jpg .jpeg .bmp .webp` (`fp8_quantize._CALIBRATION_IMAGE_EXTENSIONS`).
+This file isn't one of them, so it's neither loaded nor hashed into the `--ci<hash>` cache tag.
+Directory listing is one level deep only — nested subfolders are invisible to the loader/hasher.
+
+This repo intentionally ships no sample images here — drop your own `general/` and `faces/`
+calibration references locally; both subfolders are gitignored by default (`*.png` etc.) so
+your images stay local-only.

--- a/scripts/fp8/probe_cache_saturation.py
+++ b/scripts/fp8/probe_cache_saturation.py
@@ -1,0 +1,395 @@
+"""
+FP8 round-6 Step 0 diagnostic probe — cache-saturation hypothesis check.
+
+Context: fp8-round-5-handoff plan, "Defect B" — capture_calibration_data hooks the
+raw diffusers UNet, which runs *before* the export wrappers exist, so every input
+that only exists on the wrapped/quantized graph (kvo_cache_in_*, fio_cache_in_*,
+fi_strength, fi_threshold, ipadapter_scale) was synthesized as zeros (ones for
+ipadapter_scale) rather than captured from real activity. Graph-reachability
+analysis found 91.2% of quantized activation tensors are transitively fed by
+those zero-filled inputs. This script checks whether that actually moves
+activation magnitudes enough to explain the reported "less blurry but not as
+sharp" softness, BEFORE paying for a ~50 minute engine rebuild.
+
+Method: load the plain (pre-export-wrapper) SDXL-Turbo UNet, install
+CachedSTAttnProcessor2_0 on every self-attention (attn1) layer exactly as
+wrapper.py does for deployment (down -> mid -> up walk, cache_maxframes=4),
+and drive ONE real row (sample/timestep/encoder_hidden_states/text_embeds/
+time_ids) from the existing round-5 calib_data.npz through it twice:
+
+  (a) "calibration condition" — kvo_cache = zeros, fi_strength = 0,
+      fi_threshold = 0. This reproduces exactly what capture_calibration_data
+      fed the quantizer before fp8-round-5-handoff Step 2/3 existed.
+  (b) "deployment condition" — kvo_cache tiled from THIS SAME forward's own
+      curr_key/curr_value (harvested via attn1.to_k/to_v hooks during pass
+      (a)), fio_cache tiled from pass (a)'s own attn1 block outputs
+      (CachedSTAttnProcessor2_0._fi_cache_out), fi_strength/fi_threshold at
+      the deployment config's values.
+
+Every nn.Linear submodule's output |amax| is recorded for both passes (Q/DQ
+nodes in the exported ONNX graph flank exactly these boundaries). The report
+is the per-tensor distribution of amax_b / amax_a.
+
+Decision rule (per the plan): median ratio >= ~2 confirms Defect B is a
+material contributor to the softness -> proceed with the full fix. Median
+~= 1 -> Defect B is not the driver; the band-math fix (Defect A) should ship
+alone and the softness re-diagnosed.
+
+Scope note: ipadapter_scale is NOT modeled here. IP-Adapter's cross-attention
+(attn2) image-token pathway is a structurally separate mechanism from the
+attn1 K/V-cache + Feature-Injection blend this script probes, and standing up
+a live IP-Adapter forward pass (image encoder, projection, attn2 processor
+swap) is much heavier machinery than this quick diagnostic warrants. The two
+axes this script *does* drive (kvo_cache: 70 inputs, always active regardless
+of fi_strength; fio_cache/fi_strength/fi_threshold: 46+2 inputs, active only
+in the deployment condition) account for 118 of the defect's zero-filled
+synthetic inputs -- ipadapter_scale is filled with 1.0 (not zero) and is
+called out as a separate row in the plan's defect table.
+
+Usage (from the StreamDiffusion/ directory):
+    venv/Scripts/python.exe scripts/fp8/probe_cache_saturation.py
+    venv/Scripts/python.exe scripts/fp8/probe_cache_saturation.py \
+        --fi-strength 0.75 --fi-threshold 0.988 --cache-maxframes 4
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Repo root on sys.path so `from streamdiffusion` works without install
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+import torch
+
+# Importing streamdiffusion applies the kvo_cache monkeypatch to
+# UNet2DConditionModel.forward (src/streamdiffusion/_patches/__init__.py) —
+# required before any unet(..., kvo_cache=...) call below.
+import streamdiffusion  # noqa: F401
+from streamdiffusion.acceleration.tensorrt.fp8_quantize import _walk_attn1_modules
+from streamdiffusion.acceleration.tensorrt.models.attention_processors import (
+    CachedSTAttnProcessor2_0,
+)
+from streamdiffusion.acceleration.tensorrt.models.utils import (
+    convert_list_to_structure,
+    create_fi_cache,
+    create_kvo_cache,
+    get_fi_eligible_mask,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger("probe_cache_saturation")
+
+
+def _newest_calib_npz() -> "Path | None":
+    """Resolve the newest calib_data.npz under engines/td/stabilityai, rather than
+    a single hardcoded engine-dir name (FP8 Round 14). The calv* cache tag forks
+    on every capture-affecting fix (calv4 -> calv5 -> ... -> calv8 and counting),
+    so a fixed default goes stale the day any of them lands -- confirmed: the
+    calv3 dir this constant used to hardcode, h6048ff5c55a8, no longer exists on
+    disk as of the calv8 fork, and the script could not run at its own default."""
+    engines_root = _REPO_ROOT / "engines" / "td" / "stabilityai"
+    candidates = sorted(engines_root.glob("*/calib_data.npz"), key=lambda p: p.stat().st_mtime, reverse=True)
+    return candidates[0] if candidates else None
+
+
+_DEFAULT_CALIB_NPZ = _newest_calib_npz()
+_SDXL_COND_KEYS = ["text_embeds", "time_ids"]
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--model-id", default="stabilityai/sdxl-turbo")
+    p.add_argument(
+        "--calib-npz",
+        type=Path,
+        default=_DEFAULT_CALIB_NPZ,
+        required=_DEFAULT_CALIB_NPZ is None,
+        help="Existing calib_data.npz to source real row-sets from. Defaults to the "
+        "newest one found under engines/td/stabilityai (resolved dynamically -- see "
+        "_newest_calib_npz).",
+    )
+    p.add_argument(
+        "--rows",
+        type=int,
+        nargs="+",
+        default=[1, 2, 3],
+        help=(
+            "Row indices inside calib_data.npz to probe (results pooled across all of them). "
+            "Default [1, 2, 3] = the three real deployment timesteps (799/599/479 for the "
+            "round-5 schedule); row 0 (and its duplicate, row 4) is t=999 — the spurious "
+            "all-noise index Defect A introduces and never visits at inference, and a "
+            "misleading row to test Defect B on since cache content barely matters at pure "
+            "noise. Pass --rows 0 explicitly if you want that row anyway."
+        ),
+    )
+    p.add_argument("--height", type=int, default=512)
+    p.add_argument("--width", type=int, default=512)
+    p.add_argument("--cache-maxframes", type=int, default=4, help="Matches the use_cached_attn default in wrapper.py.")
+    p.add_argument("--max-fi-up-blocks", type=int, default=2)
+    # Deployment values from the plan's Step 0 spec / the current config.
+    p.add_argument("--fi-strength", type=float, default=0.75)
+    p.add_argument("--fi-threshold", type=float, default=0.988)
+    p.add_argument("--ratio-threshold", type=float, default=1.5, help="Count tensors with amax_b/amax_a above this.")
+    return p.parse_args()
+
+
+def _load_row(npz_path: Path, row: int, device: str):
+    data = np.load(npz_path)
+    sample = torch.from_numpy(data["sample"][row : row + 1]).to(device)
+    timestep = torch.tensor(int(data["timestep"][row]), device=device)
+    encoder_hidden_states = torch.from_numpy(data["encoder_hidden_states"][row : row + 1]).to(device)
+    added_cond_kwargs = {key: torch.from_numpy(data[key][row : row + 1]).to(device) for key in _SDXL_COND_KEYS}
+    logger.info(
+        f"[probe] Loaded row {row} from {npz_path.name}: sample={tuple(sample.shape)} "
+        f"timestep={int(timestep)} encoder_hidden_states={tuple(encoder_hidden_states.shape)}"
+    )
+    return sample, timestep, encoder_hidden_states, added_cond_kwargs
+
+
+def _install_cached_attn(unet, fi_mask):
+    """Mirror wrapper.py's cached-attn install block (_load_model, ~:2431-2463):
+    walk down -> mid -> up and install CachedSTAttnProcessor2_0 on every attn1,
+    in the same order get_kvo_cache_info/_walk_attn1_modules use so index i
+    lines up 1:1 with fi_mask[i]."""
+    attn1_modules = _walk_attn1_modules(unet)
+    assert len(attn1_modules) == len(fi_mask), (
+        f"attn1 module count {len(attn1_modules)} != fi_eligible_mask length {len(fi_mask)}"
+    )
+    for i, attn1 in enumerate(attn1_modules):
+        attn1.set_processor(CachedSTAttnProcessor2_0(fi_eligible=bool(fi_mask[i])))
+    return attn1_modules
+
+
+def _register_amax_hooks(unet, amax_store: dict):
+    """Record output |amax| for every nn.Linear submodule — the ONNX-exported
+    graph's Q/DQ nodes flank exactly these boundaries, per the plan's
+    reachability analysis (1955 quantized activation tensors)."""
+    handles = []
+
+    def _make_hook(name):
+        def hook(_module, _inputs, output):
+            out = output[0] if isinstance(output, tuple) else output
+            amax_store[name] = float(out.detach().abs().max().item())
+
+        return hook
+
+    for name, module in unet.named_modules():
+        if isinstance(module, torch.nn.Linear):
+            handles.append(module.register_forward_hook(_make_hook(name)))
+    return handles
+
+
+def _register_kv_capture_hooks(attn1_modules):
+    """Capture attn1.to_k / attn1.to_v outputs (= curr_key/curr_value, the
+    same tensors CachedSTAttnProcessor2_0 stacks into kvo_cache_out) so pass
+    (a)'s own forward can supply pass (b)'s deployment-condition cache."""
+    kv_capture: dict = {}
+    handles = []
+
+    def _make_hook(layer_idx, which):
+        def hook(_module, _inputs, output):
+            kv_capture.setdefault(layer_idx, {})[which] = output.detach().clone()
+
+        return hook
+
+    for i, attn1 in enumerate(attn1_modules):
+        handles.append(attn1.to_k.register_forward_hook(_make_hook(i, "k")))
+        handles.append(attn1.to_v.register_forward_hook(_make_hook(i, "v")))
+    return kv_capture, handles
+
+
+def _tile_maxframes(t: torch.Tensor, cache_maxframes: int) -> torch.Tensor:
+    """(batch, seq, hidden) -> (cache_maxframes, batch, seq, hidden), each
+    frame slot filled with the same real tensor (self-tiled — we only have
+    one real row-set available, per the plan's "tiled from the same forward's
+    own curr_key/curr_value")."""
+    return t.unsqueeze(0).expand(cache_maxframes, *t.shape).contiguous()
+
+
+def _percentiles(values: np.ndarray) -> dict:
+    pcts = [10, 25, 50, 75, 90, 95]
+    return {f"p{p}": float(np.percentile(values, p)) for p in pcts}
+
+
+def main() -> None:
+    args = _parse_args()
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device != "cuda":
+        logger.warning("[probe] CUDA not available — running on CPU (will be slow, but still correct).")
+
+    from diffusers import UNet2DConditionModel
+
+    logger.info(f"[probe] Loading UNet from {args.model_id} (fp16, {device})...")
+    unet = UNet2DConditionModel.from_pretrained(args.model_id, subfolder="unet", torch_dtype=torch.float16)
+    unet = unet.to(device)
+    unet.eval()
+
+    fi_mask = get_fi_eligible_mask(unet, height=args.height, width=args.width, max_fi_up_blocks=args.max_fi_up_blocks)
+    attn1_modules = _install_cached_attn(unet, fi_mask)
+    logger.info(
+        f"[probe] Installed CachedSTAttnProcessor2_0 on {len(attn1_modules)} attn1 layers ({sum(fi_mask)} FI-eligible)."
+    )
+
+    per_layer_views, kvo_structure, _kvo_buckets, _kvo_out_by_bucket = create_kvo_cache(
+        unet,
+        batch_size=1,
+        cache_maxframes=args.cache_maxframes,
+        height=args.height,
+        width=args.width,
+        device=device,
+        dtype=torch.float16,
+    )
+    per_fi_layer_views, fi_layer_indices, _fi_buckets, _fi_out_by_bucket = create_fi_cache(
+        unet,
+        batch_size=1,
+        cache_maxframes=args.cache_maxframes,
+        fi_eligible_mask=fi_mask,
+        height=args.height,
+        width=args.width,
+        max_fi_up_blocks=args.max_fi_up_blocks,
+        device=device,
+        dtype=torch.float16,
+    )
+    kvo_cache_nested = convert_list_to_structure(per_layer_views, kvo_structure)
+
+    amax_store: dict = {}
+    linear_handles = _register_amax_hooks(unet, amax_store)
+    kv_capture, kv_handles = _register_kv_capture_hooks(attn1_modules)
+
+    per_row_ratios: dict = {}
+    pooled_ratios: list = []
+
+    for row in args.rows:
+        sample, timestep, encoder_hidden_states, added_cond_kwargs = _load_row(args.calib_npz, row, device)
+
+        # --- condition (a) setup: zero the cache/scalars fresh for this row
+        # (a prior row's condition (b) pass leaves real data in these buffers) ---
+        for views in per_layer_views:
+            views.zero_()
+        for views in per_fi_layer_views:
+            views.zero_()
+        for fi_local, global_idx in enumerate(fi_layer_indices):
+            proc = attn1_modules[global_idx].processor
+            proc._fi_cache = per_fi_layer_views[fi_local]  # zeros — mutated in place for (b) below
+            proc._fi_strength = torch.zeros(1, dtype=torch.float32, device=device)
+            proc._fi_threshold = torch.zeros(1, dtype=torch.float32, device=device)
+
+        amax_store.clear()
+        kv_capture.clear()
+        logger.info(
+            f"[probe] row {row} (t={int(timestep)}) — pass (a): calibration condition (kvo_cache=zeros, fi_strength=0)..."
+        )
+        with torch.inference_mode():
+            unet(
+                sample,
+                timestep,
+                encoder_hidden_states=encoder_hidden_states,
+                added_cond_kwargs=added_cond_kwargs,
+                kvo_cache=kvo_cache_nested,
+                return_dict=False,
+            )
+        amax_a = dict(amax_store)
+        amax_store.clear()
+
+        missing_kv = [
+            i
+            for i in range(len(attn1_modules))
+            if i not in kv_capture or "k" not in kv_capture[i] or "v" not in kv_capture[i]
+        ]
+        if missing_kv:
+            raise RuntimeError(f"[probe] to_k/to_v capture missing for layer indices {missing_kv} — hook wiring bug.")
+
+        # --- condition (b) setup: real self-derived K/V + real FI output + deployment scalars ---
+        for i, views in enumerate(per_layer_views):
+            k_tile = _tile_maxframes(kv_capture[i]["k"], args.cache_maxframes)
+            v_tile = _tile_maxframes(kv_capture[i]["v"], args.cache_maxframes)
+            views.copy_(torch.stack([k_tile, v_tile], dim=0))
+
+        for fi_local, global_idx in enumerate(fi_layer_indices):
+            proc = attn1_modules[global_idx].processor
+            fio_raw = proc._fi_cache_out  # (1, batch, seq, hidden), captured during pass (a)
+            if fio_raw is None:
+                raise RuntimeError(f"[probe] _fi_cache_out unset for FI-eligible layer {global_idx} after pass (a).")
+            fio_tile = _tile_maxframes(fio_raw.squeeze(0), args.cache_maxframes)
+            per_fi_layer_views[fi_local].copy_(fio_tile)
+            proc._fi_strength = torch.tensor([args.fi_strength], dtype=torch.float32, device=device)
+            proc._fi_threshold = torch.tensor([args.fi_threshold], dtype=torch.float32, device=device)
+
+        logger.info(
+            f"[probe] row {row} (t={int(timestep)}) — pass (b): deployment condition (kvo_cache=self-derived K/V, "
+            f"fi_strength={args.fi_strength}, fi_threshold={args.fi_threshold})..."
+        )
+        with torch.inference_mode():
+            unet(
+                sample,
+                timestep,
+                encoder_hidden_states=encoder_hidden_states,
+                added_cond_kwargs=added_cond_kwargs,
+                kvo_cache=kvo_cache_nested,
+                return_dict=False,
+            )
+        amax_b = dict(amax_store)
+
+        common_names = sorted(set(amax_a) & set(amax_b))
+        dropped = sorted(set(amax_a) ^ set(amax_b))
+        if dropped:
+            logger.warning(
+                f"[probe] row {row}: {len(dropped)} Linear module(s) fired in only one pass (dead code path?): "
+                f"{dropped[:10]}{'...' if len(dropped) > 10 else ''}"
+            )
+
+        eps = 1e-8
+        row_ratios = np.array([amax_b[n] / max(amax_a[n], eps) for n in common_names], dtype=np.float64)
+        per_row_ratios[row] = row_ratios
+        pooled_ratios.append(row_ratios)
+
+    for h in linear_handles + kv_handles:
+        h.remove()
+
+    ratios = np.concatenate(pooled_ratios)
+    over_thresh = int((ratios > args.ratio_threshold).sum())
+
+    pct = _percentiles(ratios)
+    print()
+    print("=" * 70)
+    print(
+        f"FP8 round-6 Step 0 probe — rows {args.rows} pooled, {len(ratios)} tensor comparisons ({len(ratios) // len(args.rows)} nn.Linear tensors/row)"
+    )
+    print("=" * 70)
+    for row, row_ratios in per_row_ratios.items():
+        print(
+            f"  row {row}: median={np.percentile(row_ratios, 50):.3f}  p90={np.percentile(row_ratios, 90):.3f}  max={row_ratios.max():.3f}"
+        )
+    print("-" * 70)
+    print("pooled amax_b / amax_a percentiles: " + ", ".join(f"{k}={v:.3f}" for k, v in pct.items()))
+    print(f"min={ratios.min():.3f}  max={ratios.max():.3f}  mean={ratios.mean():.3f}")
+    print(
+        f"tensor-comparisons with ratio > {args.ratio_threshold}: {over_thresh}/{len(ratios)} ({100.0 * over_thresh / len(ratios):.1f}%)"
+    )
+    print("-" * 70)
+    median = pct["p50"]
+    if median >= 2.0:
+        print(f"DECISION: pooled median ratio {median:.2f} >= ~2 -> Defect B confirmed as a material")
+        print("contributor. Proceed with the full plan (Steps 1-4 already implemented).")
+    elif median <= 1.2:
+        print(f"DECISION: pooled median ratio {median:.2f} ~= 1 -> Defect B is NOT the dominant softness")
+        print("driver. Ship Defect A (band-math fix) alone and re-diagnose after that build.")
+    else:
+        print(f"DECISION: pooled median ratio {median:.2f} is inconclusive (between ~1 and ~2).")
+        print("Inspect the full percentile spread above before deciding whether to proceed.")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fp8/probe_calib_pool_diversity.py
+++ b/scripts/fp8/probe_calib_pool_diversity.py
@@ -1,0 +1,268 @@
+"""
+FP8 Round 14 — permanent, read-only K/V-cache calibration diversity probe.
+
+Context: the calv7 provenance sidecar (fp8-round-13's calib_data.meta.json) exposed
+`"pool_missed_calls": [36, 45, 54, 63]` on both calv7 engines -- half of every
+staggered stagger-fix selection (fp8-round-11) was silently dropped by the K/V/FI
+recorder before _pool_for_layer ever saw it, because `_MAX_CALIB_RECORD_BYTES`
+(4 GiB) trips before the widened `_MAX_CALIB_RECORD_CALLS` (64) at ~124 MiB/call on
+a real SDXL-Turbo UNet. `_pool_for_layer` does not zero-fill a missed call -- it
+skips it, shrinking the pool, and `_fill_kvo_from_pool`'s frame-shift-by-one cyclic
+tiling (`src = (m + 1) % pool_len`) reuses the survivors, silently halving
+calibration diversity rather than raising or zero-filling. capture_calibration_data
+now predicts (before the capture loop runs, `_predict_selected_calls`) exactly
+which calls will be selected and gates the recorder on membership in that set
+instead of a call-count prefix -- the fix this probe verifies.
+
+This is the ad-hoc measurement that surfaced the defect, made permanent and
+repeatable -- same convention as the other scripts/fp8/ probes:
+  - probe_cache_saturation.py (round-6 Step 0): settle a rebuild decision before
+    paying for a ~50 minute build.
+  - measure_fp8_calib_amax.py (round-9.1 §10): real-vs-surrogate token magnitude.
+  - probe_engine_evidence.py (round-11): "the diagnosis loop itself permanent".
+
+What it reports per `calib_data.npz` found under --engines-root:
+  - Ground truth, direct from disk: for every `kvo_cache_in_i` array actually
+    saved into the npz, split it into its n_itr (K, V) chunk pairs (mirroring
+    `_fill_kvo_from_pool`'s `arr[m*2+0]=K, arr[m*2+1]=V` layout) and count how
+    many are byte-distinct via SHA-1 hash. This is exactly the method used to
+    produce the 8/4/4 distinct-K-source table in the FP8 Round 14 plan and
+    SESSION_LOG entry -- no production code involved, just the artifact itself.
+  - Cross-check via the REAL production pooling/tiling code (not reimplemented):
+    given the sidecar's own `selected_calls`/`pool_missed_calls`, the "kept"
+    subset (selected minus missed) is fed through the actual `_pool_for_layer`
+    + `_fill_kvo_from_pool` using single-value markers (each recorded call's
+    synthetic activation IS its own call index), and the resulting distinct-
+    source count is compared against the ground-truth hash count above. A
+    mismatch would mean either the sidecar's own miss-list is stale relative to
+    what's actually in the npz, or a future change to the frame-shift/tiling
+    logic broke the simple "N selected - M missed = N-M distinct" invariant --
+    either way, this catches it without hand-deriving the tiling math.
+  - Predicted vs. recorded calls: re-derives `_predict_selected_calls`'s output
+    from build_stats.json (batch_size) + the sidecar (num_inference_steps,
+    prompt_count) and checks it against the sidecar's `selected_calls` --
+    reusing the real function so this probe can never silently drift from what
+    a real capture predicts.
+
+Usage (from the StreamDiffusion/ directory):
+    venv/Scripts/python.exe scripts/fp8/probe_calib_pool_diversity.py
+    venv/Scripts/python.exe scripts/fp8/probe_calib_pool_diversity.py --engines-root engines/td/stabilityai
+"""
+
+import argparse
+import hashlib
+import json
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Repo root on sys.path so `from streamdiffusion` works without install
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+# Imported, not reimplemented (FP8 Round 14 convention -- see probe_engine_evidence.py's
+# _count_attn_bmm_dq_fed reuse for the precedent): this probe's "expected distinct
+# sources" number can never silently drift from what a real capture would actually
+# produce, even if the frame-shift/tiling math in fp8_quantize.py changes later.
+from streamdiffusion.acceleration.tensorrt.fp8_quantize import (
+    _MAX_CALIB_ROWS,
+    _fill_kvo_from_pool,
+    _pool_for_layer,
+    _predict_selected_calls,
+    load_calib_provenance,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger("probe_calib_pool_diversity")
+
+_DEFAULT_ENGINES_ROOT = _REPO_ROOT / "engines" / "td" / "stabilityai"
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--engines-root", type=Path, default=_DEFAULT_ENGINES_ROOT)
+    return p.parse_args()
+
+
+def _find_calib_npz(root: Path):
+    if not root.exists():
+        return []
+    return sorted(root.glob("*/calib_data.npz"))
+
+
+def _read_build_stats(engine_dir: Path) -> dict:
+    p = engine_dir / "build_stats.json"
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text())
+    except Exception as e:
+        logger.warning(f"[probe] {p}: failed to parse ({e})")
+        return {}
+
+
+def _fmt_bytes(n) -> str:
+    return f"{n / 1024**3:.2f} GiB" if isinstance(n, (int, float)) else str(n)
+
+
+def _distinct_kv_sources(npz_data: dict) -> dict:
+    """Ground-truth measurement, direct from the saved npz: for every
+    kvo_cache_in_i array, split into n_itr (K, V) chunk pairs and count how
+    many are byte-distinct. See module docstring."""
+    result = {}
+    for name in sorted(npz_data):
+        if not name.startswith("kvo_cache_in_"):
+            continue
+        arr = npz_data[name]
+        n_itr = arr.shape[0] // 2
+        if n_itr == 0:
+            continue
+        k_hashes = {hashlib.sha1(np.ascontiguousarray(arr[m * 2 + 0]).tobytes()).hexdigest() for m in range(n_itr)}
+        v_hashes = {hashlib.sha1(np.ascontiguousarray(arr[m * 2 + 1]).tobytes()).hexdigest() for m in range(n_itr)}
+        result[name] = {"n_itr": n_itr, "distinct_k": len(k_hashes), "distinct_v": len(v_hashes)}
+    return result
+
+
+def _expected_distinct_kvo(selected_calls, kept_calls, n_itr: int):
+    """Run the REAL production _pool_for_layer + _fill_kvo_from_pool (not a
+    reimplementation) on synthetic single-value markers -- each "recorded"
+    call's fake activation IS its own call index -- so the resulting distinct-
+    source count after pooling/tiling can be read straight back out, and this
+    probe's expectation can never drift from the actual frame-shift/cyclic-
+    reuse logic even if that logic changes. Returns (distinct_k, missed_calls).
+    """
+    missed: set = set()
+    # (1 sub-row, seq=1, hidden=1): _pool_for_layer indexes _rec[_r] for _r in
+    # range(_rec.shape[0]) to unpack possibly-multiple captured (seq, hidden)
+    # rows per call -- the leading dim of 1 here is that "1 sub-row", not the
+    # (seq, hidden) shape itself.
+    marker_shape = (1, 1, 1)
+    k_records = {int(c): np.full(marker_shape, float(c), dtype=np.float32) for c in kept_calls}
+    v_records = {int(c): np.full(marker_shape, float(c), dtype=np.float32) for c in kept_calls}
+    k_pool = _pool_for_layer(k_records, selected_calls, missed)
+    v_pool = _pool_for_layer(v_records, selected_calls, missed)
+    arr_shape = [2 * n_itr, 1, 1]
+    arr = _fill_kvo_from_pool(k_pool, v_pool, arr_shape, np.float32)
+    k_values = {float(arr[m * 2 + 0].flat[0]) for m in range(n_itr)}
+    return len(k_values), sorted(missed)
+
+
+def _rederive_predicted_calls(stats: dict, provenance: dict):
+    """Re-derive what _predict_selected_calls would output for this capture,
+    from build_stats.json (batch_size) + the sidecar (num_inference_steps,
+    prompt_count) alone -- reuses the real function, see module docstring.
+
+    Approximate (not exact) for an explicit-schedule capture (timesteps=.../
+    scheduler_ref=..., fp8-round-5-handoff Step 2d): the sidecar's
+    num_inference_steps is the value passed into capture_calibration_data, not
+    necessarily len(timesteps) when those differ. Exact for every ordinary
+    num_inference_steps capture -- every production case observed so far.
+    Returns None when the inputs needed aren't available (e.g. a pre-fp8-
+    round-13 engine with no sidecar at all).
+    """
+    capture_stats = (stats or {}).get("stages", {}).get("fp8_calib_capture", {})
+    num_inference_steps = (provenance or {}).get("num_inference_steps") or capture_stats.get("num_inference_steps")
+    prompt_count = (provenance or {}).get("prompt_count") or capture_stats.get("prompt_count")
+    batch_size = (stats or {}).get("batch_size")
+    if not num_inference_steps or not prompt_count or not batch_size:
+        return None
+    num_batches = -(-int(prompt_count) // int(batch_size))  # ceil division
+    return {int(c) for c in _predict_selected_calls(int(num_inference_steps), num_batches, _MAX_CALIB_ROWS)}
+
+
+def main() -> None:
+    args = _parse_args()
+    npz_paths = _find_calib_npz(args.engines_root)
+    if not npz_paths:
+        logger.warning(f"[probe] No calib_data.npz found under {args.engines_root}")
+        return
+    logger.info(f"[probe] Found {len(npz_paths)} calib_data.npz under {args.engines_root}")
+
+    for npz_path in npz_paths:
+        engine_dir = npz_path.parent
+        try:
+            with np.load(npz_path) as _npz:
+                data = {k: _npz[k] for k in _npz.files}
+        except Exception as e:
+            logger.warning(f"[probe] {npz_path}: failed to load ({e})")
+            continue
+
+        stats = _read_build_stats(engine_dir)
+        provenance = load_calib_provenance(str(npz_path))
+        diversity = _distinct_kv_sources(data)
+
+        print()
+        print("=" * 78)
+        print(f"{engine_dir.name}")
+        print("=" * 78)
+
+        if provenance is None:
+            print("  calib_data.meta.json: not found (pre-fp8-round-13 engine)")
+        else:
+            print(f"  sidecar schema_version={provenance.get('schema_version')}")
+            print(f"  selected_calls={provenance.get('selected_calls')}")
+            print(f"  pool_missed_calls={provenance.get('pool_missed_calls')}")
+            if provenance.get("schema_version", 1) >= 2:
+                print(f"  predicted_calls (recorded, schema v2)={provenance.get('predicted_calls')}")
+                print(
+                    f"  record_calls_kept={provenance.get('record_calls_kept')}  "
+                    f"record_bytes={_fmt_bytes(provenance.get('record_bytes'))}  "
+                    f"kvo_pool_len={provenance.get('kvo_pool_len')}"
+                )
+
+        predicted = _rederive_predicted_calls(stats, provenance)
+        if predicted is not None:
+            print(f"  re-derived predicted_calls (via _predict_selected_calls)={sorted(predicted)}")
+            selected = {int(c) for c in (provenance or {}).get("selected_calls") or []}
+            if selected and not selected <= predicted:
+                logger.warning(
+                    f"[probe] {engine_dir.name}: selected_calls "
+                    f"{sorted(selected - predicted)} not covered by the re-derived prediction -- "
+                    "the superset guarantee (_predict_selected_calls docstring) appears violated, investigate."
+                )
+        else:
+            print("  re-derived predicted_calls: unavailable (missing num_inference_steps/prompt_count/batch_size)")
+
+        if not diversity:
+            print("  kvo_cache_in_*: none found in this npz (use_cached_attn was False for this capture)")
+        else:
+            for name, d in sorted(diversity.items()):
+                print(f"  {name}: n_itr={d['n_itr']}  distinct_k={d['distinct_k']}  distinct_v={d['distinct_v']}")
+            headline = diversity.get("kvo_cache_in_0")
+            if headline:
+                print(f"  headline (kvo_cache_in_0): {headline['distinct_k']}/{headline['n_itr']} distinct K sources")
+
+            if provenance is not None and provenance.get("selected_calls") and headline:
+                selected_calls = provenance["selected_calls"]
+                missed = set(provenance.get("pool_missed_calls") or [])
+                kept_calls = [c for c in selected_calls if c not in missed]
+                expected_k, re_missed = _expected_distinct_kvo(selected_calls, kept_calls, headline["n_itr"])
+                print(
+                    f"  cross-check via real _pool_for_layer/_fill_kvo_from_pool: expected_distinct_k={expected_k}"
+                    + (f"  (re-derived missed={sorted(re_missed)})" if re_missed else "")
+                )
+                if expected_k != headline["distinct_k"]:
+                    logger.warning(
+                        f"[probe] {engine_dir.name}: ground-truth distinct_k ({headline['distinct_k']}) != "
+                        f"cross-check expected_distinct_k ({expected_k}) derived from the sidecar's own "
+                        "selected_calls/pool_missed_calls -- the sidecar may be stale relative to this npz, "
+                        "or investigate."
+                    )
+
+    print()
+    print("=" * 78)
+    print(f"Done: inspected {len(npz_paths)} calib_data.npz file(s).")
+    print("=" * 78)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/streamdiffusion/_patches/modelopt_arena_patch.py
+++ b/src/streamdiffusion/_patches/modelopt_arena_patch.py
@@ -1,0 +1,222 @@
+"""Fixes an nvidia-modelopt bug that makes ORT's CUDA BFC arena degenerate during ONNX
+FP8/INT8 static calibration, pinning VRAM at (or above) its true high-water mark for the
+whole calibration pass instead of releasing between the 8 per-sample runs.
+
+Upstream: ``modelopt.onnx.quantization.ort_patching``
+
+``_create_inference_session_with_ep_config`` hardcodes ``arena_extend_strategy:
+kSameAsRequested`` on the CPU/CUDA providers, so every arena growth is an exact-size
+``cudaMalloc`` that can never be reused to satisfy a differently-sized request. With this
+graph's thousands of distinct symbolic dims / unresolved-shape tensors, the arena's
+high-water mark degenerates from "peak live set" toward "sum of every distinct allocation
+ever requested" — the difference between a few GB and 22+ GB observed calibrating the
+SDXL-Turbo UNet.
+
+``kSameAsRequested`` reads, at first glance, like it exists to set up arena *shrinkage*
+between calibration runs — modelopt's ``_collect_data_minmax_calibrator`` does build a
+``RunOptions`` with ``memory.enable_memory_arena_shrinkage`` set to ``f"cpu:0;{gpu_str}"``
+(discarded by a bug of its own: a fresh, unconfigured ``ort.RunOptions()`` is rebuilt inside
+the per-sample loop right before every ``session.run``, so the shrinkage entry never actually
+reaches ORT). Round 2 of this fix "repaired" that by reusing the configured ``RunOptions``
+across iterations — which surfaced a second, independent bug: ORT's own contract
+(``onnxruntime_run_options_config_keys.h``, ``memory.enable_memory_arena_shrinkage``) states
+that if ``"cpu"`` is included in the shrink list, ``DisableCpuMemArena()`` must not have been
+called — but ``_create_inference_session_with_ep_config`` sets
+``sess_options.enable_cpu_mem_arena = False`` unconditionally, in the same code path. Building
+the shrink-list ``RunOptions`` correctly does not help either: measured directly against this
+stack (ORT 1.24.4 + CUDA EP), a `"gpu:0"`-only list is *also* rejected with
+``INVALID_ARGUMENT``, regardless of ``arena_extend_strategy``. Arena shrinkage is unreachable
+here, full stop — so ``kSameAsRequested`` is not a real precondition for anything, just a
+purposeless constraint that starves the CUDA arena of reuse. The fix is to drop it, not to fix
+the shrink-list string.
+
+Not reachable through any public modelopt parameter — the provider config block is hardcoded
+in ``_create_inference_session_with_ep_config`` — so this module carries a verbatim, bug-fixed
+copy of that one function and swaps it into ``ort_patching``'s own module namespace: the exact
+seam ``ort_patching.patch_ort_modules()`` itself reads from when it assigns
+``CalibraterBase.create_inference_session`` on every ``quantize()`` call. Patching the module
+global (rather than the ORT class directly) is required because ``patch_ort_modules()`` is
+called again, unconditionally, on every ``quantize()`` invocation, and would otherwise stomp a
+class-level patch right back to the buggy original.
+
+Scoped, not global: ``apply()``/``revert()`` are meant to bracket a single
+``quantize_onnx_fp8()`` call (see ``fp8_quantize.py``) inside a try/finally. This module is
+intentionally **not** registered in ``_patches/__init__.py`` (unlike ``diffusers_kvo_patch``)
+— it must not alter modelopt's behaviour for any runtime (non-build) code path or any other
+caller of modelopt in this process.
+
+Version-gated hard, on purpose: this is a copied third-party internal, not a call through a
+public API, so a signature probe (the idiom ``diffusers_kvo_patch.py`` uses) cannot tell a
+patched modelopt from an unpatched one — fixing this bug upstream would not change the
+function's signature, only its body. A prior round of this same fix already hit exactly that
+trap elsewhere in this codebase (a ``"name" in signature().parameters`` test that silently
+went ``False`` for two modelopt releases and disabled an unrelated workaround). So: pin to the
+modelopt version(s) this has been diffed against, and on any mismatch — wrong version or a
+missing/renamed attribute — log a loud warning and skip the patch entirely. Never half-apply.
+
+Verified still present on ``main`` as of the nvidia-modelopt 0.45.0 release (``ort_patching.py``
+lines ~298, ~336, ~505-519 there) — upgrading past 0.43.0 would not remove the need for this
+patch, and this repo pins ``modelopt==0.43.0`` for unrelated reasons anyway (see
+``tools/install-tensorrt.py``: unpinned modelopt drags in ``onnx==1.21.0``, which breaks FP8
+quant in a different way).
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_PATCHED = False
+_ORIGINALS: dict = {}
+
+# modelopt.__version__ values this patch has been diffed against and verified to still match
+# ort_patching's function bodies. Extend only after re-diffing both target functions.
+_VERIFIED_VERSIONS = {"0.43.0"}
+
+_PATCHED_ATTRS = ("_create_inference_session_with_ep_config",)
+
+
+def apply() -> None:
+    """Patch modelopt's ``ort_patching`` module in place. Idempotent — safe to call multiple
+    times. Never raises: on any mismatch (unexpected modelopt version, missing/renamed
+    attribute, modelopt not installed), logs a warning and leaves modelopt untouched.
+    """
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    try:
+        import modelopt
+        from modelopt.onnx.quantization import ort_patching
+    except ImportError:
+        logger.debug("modelopt_arena_patch: modelopt not importable, skipping")
+        return
+
+    version = getattr(modelopt, "__version__", None)
+    if version not in _VERIFIED_VERSIONS:
+        logger.warning(
+            f"[FP8] modelopt_arena_patch: modelopt=={version} is not one of the versions this "
+            f"CUDA-arena patch was verified against ({sorted(_VERIFIED_VERSIONS)}). Skipping — "
+            "FP8 calibration may spill VRAM into shared/system memory. See "
+            "_patches/modelopt_arena_patch.py for the upstream bug this works around."
+        )
+        return
+
+    for name in _PATCHED_ATTRS:
+        if not hasattr(ort_patching, name):
+            logger.warning(
+                f"[FP8] modelopt_arena_patch: ort_patching.{name} not found on "
+                f"modelopt=={version} — skipping the CUDA-arena patch entirely (no half-apply)."
+            )
+            return
+
+    for name, replacement in (
+        ("_create_inference_session_with_ep_config", _fixed_create_inference_session_with_ep_config),
+    ):
+        _ORIGINALS[name] = getattr(ort_patching, name)
+        setattr(ort_patching, name, replacement)
+
+    _PATCHED = True
+    logger.info(
+        "[FP8] modelopt_arena_patch: applied (kSameAsRequested removed) — CUDA arena can reuse "
+        "regions across calibration runs instead of exact-size-only growth"
+    )
+
+
+def revert() -> None:
+    """Restore modelopt's original functions. Safe to call even if apply() was skipped."""
+    global _PATCHED
+    if not _PATCHED:
+        return
+
+    from modelopt.onnx.quantization import ort_patching
+
+    for name, original in _ORIGINALS.items():
+        setattr(ort_patching, name, original)
+    _ORIGINALS.clear()
+    _PATCHED = False
+    logger.info("[FP8] modelopt_arena_patch: reverted")
+
+
+# ---------------------------------------------------------------------------
+# Fixed copy of a modelopt.onnx.quantization.ort_patching internal
+#
+# Source: modelopt/onnx/quantization/ort_patching.py, nvidia-modelopt 0.43.0
+# (Apache-2.0 AND MIT — adapted from Microsoft ONNX Runtime; see that file's own header for
+# the full upstream attribution.) Re-diffed end-to-end against the installed package on
+# 2026-08-08 (upstream function spans ort_patching.py:286-353): the only change from upstream
+# is the deletion of the `_update_provider_config` + kSameAsRequested loop, called out in the
+# docstring below. An earlier version of this copy also silently dropped the trailing
+# `group_qdq_tensors` assignment (upstream :350-353) — unintentionally, not as part of the
+# documented fix — which raised AttributeError three minutes into calibration, in
+# `compute_data()`. That tail is restored below; keep it in sync if this is ever re-diffed.
+# ---------------------------------------------------------------------------
+
+
+def _fixed_create_inference_session_with_ep_config(calibrator, **kwargs):
+    """Identical to upstream except the ``arena_extend_strategy: kSameAsRequested`` override
+    is *not* applied to CPU/CUDA providers, so ORT falls back to its default
+    ``kNextPowerOfTwo`` — an arena region can then serve any request up to its size instead of
+    exactly one.
+    """
+    import onnxruntime as ort
+    from modelopt.onnx.logging_config import logger as _modelopt_logger
+
+    model_path = kwargs.get("model_path")
+    _modelopt_logger.debug("Creating inference session with Execution Provider configuration")
+
+    sess_options = ort.SessionOptions()
+    sess_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+    sess_options.add_session_config_entry("session.use_device_allocator_for_initializers", "1")
+    sess_options.enable_cpu_mem_arena = False
+
+    providers = kwargs.get("execution_providers", [])
+    _modelopt_logger.debug(f"Execution providers: {providers}")
+
+    # Note. This path can be an empty string, which denotes that the model has custom ops and
+    # TRT EP is needed.
+    calibrator.trt_extra_plugin_lib_paths = kwargs.get("trt_extra_plugin_lib_paths")
+
+    if calibrator.trt_extra_plugin_lib_paths is not None:
+        _modelopt_logger.debug(f"TRT extra plugin paths: {calibrator.trt_extra_plugin_lib_paths}")
+        if "TensorrtExecutionProvider" not in ort.get_available_providers():
+            raise RuntimeError(f"Could not find `TensorrtExecutionProvider`, only {ort.get_available_providers()}")
+        trt_ep_options = (
+            {"trt_extra_plugin_lib_paths": calibrator.trt_extra_plugin_lib_paths}
+            if calibrator.trt_extra_plugin_lib_paths
+            else {}
+        )
+
+        # Set GPU memory usage limit
+        trt_ep_options["trt_max_workspace_size"] = 80 * (1024**3)  # 80GB
+        _modelopt_logger.debug(f"TRT EP options: {trt_ep_options}")
+
+        if "TensorrtExecutionProvider" in providers:
+            providers.remove("TensorrtExecutionProvider")
+        providers.insert(0, ("TensorrtExecutionProvider", trt_ep_options))
+
+    # --- upstream applies {"arena_extend_strategy": "kSameAsRequested"} to every CPU/CUDA
+    # provider here via a nested `_update_provider_config` + loop. Both are intentionally
+    # omitted — providers keep ORT's default arena_extend_strategy (kNextPowerOfTwo) instead
+    # of being forced into exact-size-only arena growth. ---
+
+    if model_path is None:
+        # Create the inference session with EP configuration on augmented_model
+        calibrator.infer_session = ort.InferenceSession(
+            calibrator.augmented_model_path,
+            sess_options=sess_options,
+            providers=providers,
+        )
+    else:
+        # Create the inference session with EP configuration on provided model path
+        calibrator.infer_session = ort.InferenceSession(
+            model_path,
+            sess_options=sess_options,
+            providers=providers,
+        )
+
+    # Group qdq tensors will have the same scaling factor.
+    calibrator.group_qdq_tensors = kwargs.get("group_qdq_tensors")
+    if calibrator.group_qdq_tensors:
+        _modelopt_logger.debug(f"Group QDQ tensors: {calibrator.group_qdq_tensors}")

--- a/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
+++ b/src/streamdiffusion/acceleration/tensorrt/fp8_quantize.py
@@ -22,16 +22,100 @@ Requirements:
     RTX 4090+ (Ada Lovelace, compute capability 8.9)
 """
 
+import json
 import logging
 import os
+import sys
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 
 logger = logging.getLogger(__name__)
 
 _BUNDLED_PROMPTS_PATH = Path(__file__).parent / "calibration_prompts_sdxl.txt"
+
+# fp8-round-9.1: extensions recognized by both wrapper.py's
+# _load_fp8_calibration_style_images (loads the files) and engine_manager.py's
+# _calibration_image_signature (hashes them for the --ci<hash> cache-key
+# fork). Both import this constant rather than each maintaining their own
+# list — a mismatch would let the cache key disagree with what was actually
+# loaded (e.g. tag hashes a file the loader silently skips).
+_CALIBRATION_IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".bmp", ".webp")
+
+
+def _list_calibration_images(path: Optional[str]) -> List[Path]:
+    """Resolve `fp8_calibration_style_image` (a file or a directory) to the
+    ordered list of image files it denotes (fp8-round-9.1 / round-9.1 §10).
+
+    Single source of truth for "which files count as calibration images" —
+    wrapper.py's loader, wrapper.py's mode-folder resolver, and
+    engine_manager.py's `--ci<hash>` signature all call this instead of each
+    re-implementing the same `iterdir()` + sort + extension filter, so they
+    cannot silently drift apart (e.g. the cache key hashing a file the loader
+    skips, or vice versa).
+
+    Sorted by filename for a deterministic, reproducible order. Deliberately
+    **non-recursive** — a directory is `iterdir()`'d one level only, so a
+    nested subdirectory (e.g. a `general/`/`faces/` mode split sitting a
+    level below `path`) is invisible here unless `path` itself points at it.
+    A `path` that names a single file is returned as that one-element list
+    unconditionally (matching the pre-existing loader/hasher behaviour) —
+    the extension filter only applies when listing a directory. Returns `[]`
+    for a path that is `None`, doesn't exist, or (as a directory) contains
+    nothing with a recognized extension.
+    """
+    if not path:
+        return []
+    p = Path(path)
+    if p.is_dir():
+        return sorted(f for f in p.iterdir() if f.is_file() and f.suffix.lower() in _CALIBRATION_IMAGE_EXTENSIONS)
+    if p.is_file():
+        return [p]
+    return []
+
+
+# Row budget shared with wrapper.py's build_calibration_t_indices() call (fp8-round-5-handoff
+# Step 2b/2c) so the derived calibration timestep schedule and the row cap that consumes it
+# never drift apart. See the n_itr comment below for why this must stay small.
+_MAX_CALIB_ROWS = 8
+
+# Upper bound on how many *captured calls* (not final selected rows) the K/V/FI
+# recorder in capture_calibration_data keeps in memory (fp8-round-5-handoff Step 2).
+# FP8 Round 11 raised this from 4*_MAX_CALIB_ROWS (32) to _MAX_CALIB_ROWS**2 (64) on
+# the theory that a full stagger pass needs a window that wide -- true in principle,
+# but _MAX_CALIB_RECORD_BYTES below (4 GiB) trips first on a real SDXL-Turbo UNet, at
+# ~33 of the needed 64 calls (~124 MiB/call). Calls 36/45/54/63 (the second half of
+# the stagger) were silently dropped every calv7 build, and _pool_for_layer reusing
+# the surviving 4 recorded sources twice each halved kvo/fio calibration diversity
+# (measured: 8 distinct K/V sources pre-Round-11 -> 4 under calv7, both resolutions
+# -- see the calv8 note in engine_manager.py). FP8 Round 14 fixed this at the root:
+# capture_calibration_data now predicts the ~8 calls _select_calibration_calls will
+# actually select (_predict_selected_calls, above _select_calibration_rows) *before*
+# recording starts, and the hooks admit only those -- so this call-count cap is now a
+# hard ceiling behind predictive selection, not a window predictive selection has to
+# fit inside, and normal-path peak memory drops to ~1 GiB. It still matters as the
+# fallback cap for the rare case a mid-capture batch failure invalidates the
+# prediction (call indices shift) -- see _predict_valid in capture_calibration_data.
+# Override: SDTD_FP8_CALIB_RECORD_CALLS=<int>
+_MAX_CALIB_RECORD_CALLS = int(os.environ.get("SDTD_FP8_CALIB_RECORD_CALLS", _MAX_CALIB_ROWS**2))
+
+# Byte-budget companion to the call cap above (FP8 Round 11 decision: a flat cap
+# increase alone is unsafe on this host -- 31.6 GB RAM, 16.8 GB free measured this
+# round, with the final aligned calib_data.npz at 1024 prompts already 17.8 GiB.
+# The K/V/FI recorder pool is live in memory throughout capture, alongside the
+# not-yet-trimmed captured-activations dict, so doubling the call cap with no
+# ceiling risks an OOM mid-capture instead of a graceful degrade. This is an
+# estimate, not a measured figure -- raise via the override below for hosts with
+# more headroom or larger per-layer tensors. Self-limiting: hooks stop recording
+# new calls once either this or _MAX_CALIB_RECORD_CALLS is hit, whichever comes
+# first, and log how many calls were actually kept. FP8 Round 14: under normal
+# (non-fallback) operation the recorder only ever admits the ~8 predicted calls, so
+# this cap sits at ~1 GiB of real usage and is not expected to trip -- it remains a
+# hard OOM backstop for the fallback path and for future larger resolutions/tensors.
+# Override: SDTD_FP8_CALIB_RECORD_BYTES=<bytes>
+_MAX_CALIB_RECORD_BYTES = int(os.environ.get("SDTD_FP8_CALIB_RECORD_BYTES", 4 * 1024**3))
 
 
 def _load_calibration_prompts(user_path: Optional[str] = None) -> List[str]:
@@ -50,6 +134,625 @@ def _load_calibration_prompts(user_path: Optional[str] = None) -> List[str]:
     return prompts
 
 
+def _select_calibration_calls(calib_data: Dict[str, np.ndarray], max_rows: int) -> np.ndarray:
+    """Pick which captured *calls* (keyed on ``timestep``, 1 row/call) survive
+    an ``max_rows``-row budget, stratified round-robin over the distinct
+    timestep values actually visited (descending, so every calibrated
+    timestep is represented before any is doubled up).
+
+    Extracted out of ``_select_calibration_rows`` (fp8-round-5-handoff Step 2)
+    so the K/V/FI cache recorder in ``capture_calibration_data`` can select
+    the exact same calls ``_select_calibration_rows`` will keep, without
+    ``_select_calibration_rows`` itself needing to expose call indices — its
+    return type (a row-expanded dict) is load-bearing for
+    ``tests/quality/test_fp8_calib_tile.py``.
+
+    Returns an empty array if ``timestep`` is missing or there are 0 calls;
+    returns every call index (``0..num_calls-1``) if the capture already fits
+    the budget.
+    """
+    if "timestep" not in calib_data or not calib_data:
+        return np.array([], dtype=int)
+
+    num_calls = calib_data["timestep"].shape[0]
+    if num_calls <= 0:
+        return np.array([], dtype=int)
+
+    multipliers = {}
+    for key, arr in calib_data.items():
+        n = arr.shape[0]
+        m = n // num_calls if n % num_calls == 0 else 1
+        multipliers[key] = max(m, 1)
+    max_multiplier = max(multipliers.values())
+
+    # Budget *calls*, not rows, so the most CFG-doubled key still lands at
+    # <= max_rows rows after expansion.
+    calls_budget = max(1, max_rows // max_multiplier)
+    if num_calls <= calls_budget:
+        return np.arange(num_calls, dtype=int)
+
+    timestep_values = calib_data["timestep"].reshape(num_calls, -1)[:, 0].astype(np.float64)
+    groups: Dict[float, List[int]] = {}
+    for call_idx, t in enumerate(timestep_values):
+        groups.setdefault(float(t), []).append(call_idx)
+
+    # Round-robin one call per distinct timestep (highest first, matching the
+    # descending schedule order) until the budget is spent.
+    ordered_keys = sorted(groups.keys(), reverse=True)
+    selected: List[int] = []
+    round_idx = 0
+    while len(selected) < calls_budget:
+        progressed = False
+        for pos, tkey in enumerate(ordered_keys):
+            bucket = groups[tkey]
+            # Stagger: position `pos` within this round draws bucket[(round_idx +
+            # pos) % len(bucket)], not bucket[round_idx] for every key. The old
+            # per-round-shared index meant that whenever calls_budget matched the
+            # distinct-timestep count (the common case: 8 timesteps, budget 8),
+            # only round 0 ever ran, and round 0 = occurrence 0 of every timestep
+            # = the first pipe() batch, for all 8 selected calls (FP8 Round 11
+            # Item 2). Staggering by position spreads a single round across as
+            # many distinct occurrences (batches) as the bucket holds, wrapping
+            # via modulo instead of dropping when a bucket is shorter than the
+            # round+position offset would otherwise require.
+            offset = (round_idx + pos) % len(bucket)
+            candidate = bucket[offset]
+            if candidate in selected:
+                # Already used (bucket shorter than the stagger window already
+                # wrapped onto it) -- fall back to the earliest unused occurrence
+                # in this bucket rather than a straight duplicate. Bucket is in
+                # ascending call-index order, so unused[0] is the earliest.
+                unused = [c for c in bucket if c not in selected]
+                if not unused:
+                    continue
+                candidate = unused[0]
+            selected.append(candidate)
+            progressed = True
+            if len(selected) >= calls_budget:
+                break
+        if not progressed:
+            break
+        round_idx += 1
+    return np.array(sorted(selected), dtype=int)
+
+
+def _predict_selected_calls(schedule_len: int, num_batches: int, max_rows: int) -> np.ndarray:
+    """Predict, *before capture runs*, which call indices ``_select_calibration_calls``
+    will keep -- so the K/V/FI recorder in ``capture_calibration_data`` can record only
+    those calls instead of an unrelated call-count prefix (FP8 Round 14).
+
+    Round 11 widened ``_MAX_CALIB_RECORD_CALLS`` to 64 so a staggered selection spanning
+    up to 8 distinct prompt batches per timestep would fit inside the recorder's kept
+    window -- but the companion ``_MAX_CALIB_RECORD_BYTES`` byte budget (4 GiB) trips
+    first, at ~33 of the needed 64 calls on a real SDXL-Turbo UNet. Calls 36/45/54/63
+    (the second half of the stagger) were silently dropped, and ``_pool_for_layer``
+    reusing the surviving 4 sources twice each halved kvo/fio calibration diversity --
+    see the FP8 Round 14 SESSION_LOG entry / calv8 cache-tag note in engine_manager.py
+    for the measured 8-vs-4-distinct-source evidence. Recording only the ~8 calls that
+    will actually be selected fixes this and drops peak recorder memory from ~4 GiB to
+    ~1 GiB, well under the byte budget.
+
+    ``_select_calibration_calls`` only needs the per-call ``timestep`` values to decide
+    what to select -- not the real ``sample``/``encoder_hidden_states`` tensors -- so a
+    synthetic descending-timestep schedule, tiled once per prompt batch (mirroring how
+    the real capture visits ``schedule_len`` timesteps per batch, ``num_batches`` times),
+    reproduces the exact same call indices. Delegates to ``_select_calibration_calls``
+    rather than re-deriving the stagger independently -- this module already carries a
+    scar from two copies of comparable per-input-shape logic drifting apart (see
+    ``_resolve_per_step_dim0``'s "caused an n_itr=560 blowup" comment) and this is the
+    same failure mode waiting to happen again.
+
+    Superset guarantee: call with ``max_rows=_MAX_CALIB_ROWS`` (the largest possible
+    row budget). The real post-hoc call inside ``capture_calibration_data`` passes the
+    full captured ``calib_data``, whose CFG-doubled keys can shrink
+    ``_select_calibration_calls``'s effective ``calls_budget`` below ``max_rows`` (see
+    its own docstring) -- which only *truncates* round 0's stagger sequence to a prefix
+    of what a full-budget prediction returns. Predicting at the maximum budget is
+    therefore always a superset of what will actually be selected, never a miss.
+    """
+    if schedule_len <= 0 or num_batches <= 0:
+        return np.array([], dtype=int)
+    stub = {"timestep": np.tile(np.arange(schedule_len, dtype=np.float32)[::-1], num_batches)}
+    return _select_calibration_calls(stub, max_rows)
+
+
+def _recorder_admits_call(call_idx: int, predict_valid_ok: bool, predicted_calls, max_calls: int) -> bool:
+    """Whether the K/V/FI recorder should admit ``call_idx`` -- the gating
+    decision shared by ``_kv_hook``/``_fio_hook`` inside
+    ``capture_calibration_data``, extracted to module level (mirroring
+    ``_pool_for_layer``) so the FP8 Round 14 predictive-recording behaviour,
+    including its batch-failure fallback, can be pinned without a real
+    diffusers pipeline.
+
+    While ``predict_valid_ok`` (the ``_predicted_calls`` set computed before
+    the capture loop is still trustworthy), admit only calls in
+    ``predicted_calls``. A mid-capture batch failure shifts every subsequent
+    call index and invalidates the prediction -- once that happens the caller
+    flips ``predict_valid_ok`` to ``False`` and this falls back to the
+    pre-Round-14 call-count-prefix rule: admit any call below ``max_calls``.
+
+    The byte-budget cap (``_MAX_CALIB_RECORD_BYTES``) is a separate,
+    unconditional check the caller applies after this returns ``True`` -- it
+    is not part of this decision.
+    """
+    if predict_valid_ok:
+        return call_idx in predicted_calls
+    return call_idx < max_calls
+
+
+def _select_calibration_rows(calib_data: Dict[str, np.ndarray], max_rows: int) -> Dict[str, np.ndarray]:
+    """Downselect captured calibration rows, stratified over the distinct UNet
+    timestep values actually visited (fp8-round-5-handoff Step 2e).
+
+    Why not a naive per-key ``linspace(0, n-1, max_rows)``: ``timestep`` is
+    captured once per ``unet()`` forward call, but CFG-doubled keys (``sample``,
+    ``encoder_hidden_states``, and the SDXL ``added_cond_kwargs`` keys) are
+    captured with 2 rows per call whenever ``guidance_scale > 1`` stacks
+    cond+uncond into one batched forward. Computing each key's stride from its
+    own (different) row count silently misaligns which forward call each key's
+    row N came from — row 3 of ``sample`` no longer corresponds to row 3 of
+    ``timestep``. Worse, an even stride across many prompts x few timesteps can
+    alias onto the same handful of timestep phases and miss others entirely —
+    the original round-5 defect this plan's Step 1 isolated.
+
+    Instead this selects whole calls via ``_select_calibration_calls``, then
+    expands each selected call into the matching rows for every other key using
+    that key's own rows-per-call multiplier. The call budget is sized so the
+    most CFG-doubled key still lands at <= max_rows total rows — this preserves
+    the exact memory footprint the old per-key cap gave modelopt's n_itr
+    derivation downstream, it just aligns the rows correctly across keys.
+    """
+    if "timestep" not in calib_data or not calib_data:
+        # No timestep key captured (shouldn't happen for a real UNet hook) --
+        # fall back to the old independent-linspace behavior per key.
+        out = dict(calib_data)
+        for key, arr in out.items():
+            n = arr.shape[0]
+            if n > max_rows:
+                idx = np.linspace(0, n - 1, max_rows).astype(int)
+                out[key] = arr[idx]
+        return out
+
+    num_calls = calib_data["timestep"].shape[0]
+    if num_calls <= 0:
+        return dict(calib_data)
+
+    selected_calls = _select_calibration_calls(calib_data, max_rows)
+    if len(selected_calls) >= num_calls:
+        return dict(calib_data)
+
+    multipliers = {}
+    for key, arr in calib_data.items():
+        n = arr.shape[0]
+        m = n // num_calls if n % num_calls == 0 else 1
+        multipliers[key] = max(m, 1)
+
+    out: Dict[str, np.ndarray] = {}
+    for key, arr in calib_data.items():
+        n = arr.shape[0]
+        multiplier = multipliers[key]
+        row_idx = np.concatenate([np.arange(c * multiplier, c * multiplier + multiplier) for c in selected_calls])
+        row_idx = row_idx[row_idx < n]
+        out[key] = arr[row_idx]
+    return out
+
+
+def _walk_attn1_modules(unet) -> List[Any]:
+    """Return ``attn1`` (self-attention) modules in down -> mid -> up walk
+    order — identical to ``get_kvo_cache_info`` (``models/utils.py``) and
+    ``_collect_fi_processors`` (``export_wrappers/unet_unified_export.py``),
+    so index ``i`` lines up 1:1 with ``kvo_cache_in_{i}`` (fp8-round-5-handoff
+    Step 2). Those two helpers only return shapes/processor instances, not the
+    raw ``attn1`` module objects a K/V recorder hook needs, hence this local
+    re-walk instead of reusing them directly.
+    """
+    modules: List[Any] = []
+    for block in unet.down_blocks:
+        if getattr(block, "attentions", None) is not None:
+            for attn_block in block.attentions:
+                for transformer in attn_block.transformer_blocks:
+                    modules.append(transformer.attn1)
+    if getattr(unet.mid_block, "attentions", None) is not None:
+        for attn_block in unet.mid_block.attentions:
+            for transformer in attn_block.transformer_blocks:
+                modules.append(transformer.attn1)
+    for block in unet.up_blocks:
+        if getattr(block, "attentions", None) is not None:
+            for attn_block in block.attentions:
+                for transformer in attn_block.transformer_blocks:
+                    modules.append(transformer.attn1)
+    return modules
+
+
+def _reconcile_2d(row: np.ndarray, seq_t: int, hidden_t: int) -> np.ndarray:
+    """Pad (zeros) / trim a captured ``(seq, hidden)`` activation row to an
+    ONNX-declared ``(seq_t, hidden_t)``, for the K/V/FI rows recorded off the
+    bare (pre-export-wrapper) UNet (fp8-round-5-handoff Step 2).
+
+    This always zero-pads, unlike ``_reconcile_calib_to_onnx_dims`` below —
+    zero-pad is benign here because K/V/FI rows are never *exclusively* fed by
+    the padded region the way ``encoder_hidden_states``' IP-Adapter token slice
+    is (fp8-round-9). Do not reuse this for ``encoder_hidden_states``."""
+    if row.shape[0] != seq_t:
+        row = (
+            np.pad(row, [(0, seq_t - row.shape[0]), (0, 0)], mode="constant") if row.shape[0] < seq_t else row[:seq_t]
+        )
+    if row.shape[1] != hidden_t:
+        row = (
+            np.pad(row, [(0, 0), (0, hidden_t - row.shape[1])], mode="constant")
+            if row.shape[1] < hidden_t
+            else row[:, :hidden_t]
+        )
+    return row
+
+
+def _reconcile_calib_to_onnx_dims(
+    calib_data: Dict[str, np.ndarray],
+    specs: Dict[str, Any],
+    ipadapter_tokens: Optional[np.ndarray] = None,
+    num_ip_layers: int = 0,
+) -> Dict[str, np.ndarray]:
+    """Reconcile captured tensors with ONNX-declared static dims.
+
+    The bare-pipe forward hook in ``capture_calibration_data`` captures the
+    diffusers UNet *before* feature wrappers run, so dims that wrappers
+    reshape (e.g. IPA's UnifiedExportWrapper concatenates ``num_image_tokens``
+    image tokens onto ``encoder_hidden_states`` → seq_len 77 → 81) won't match
+    the exported ONNX. Trim if oversized, on any static (non-dynamic,
+    non-leading) axis.
+
+    When undersized, ``encoder_hidden_states`` is special-cased: if
+    ``ipadapter_tokens`` is given, the missing width is filled by
+    concatenating those real IP-Adapter projection tokens instead of
+    zero-padding. ``to_k_ip``/``to_v_ip`` are bias-free ``nn.Linear`` layers,
+    so a zero-padded region produces identically-zero activations and starves
+    that branch's FP8 calibration entirely — the fp8-round-9 defect (measured:
+    140 blocks × 3 tensors × 2 scale initializers = 420 uncalibrated
+    initializers landing at ORT's default scale). Every other undersized
+    tensor, and ``encoder_hidden_states`` itself when tokens are unavailable,
+    still falls back to zero-pad — benign for those, since nothing downstream
+    is exclusively fed by the padded region the way the IPA cross-attention
+    branch is.
+
+    ``ipadapter_tokens``'s leading axis (N) need not equal the calibration
+    row count (``_arr.shape[0]``): N==1 (the zeros-surrogate, a real cached
+    embedding, or a single calibration image) broadcasts across every row
+    unchanged; N>1 (fp8-round-9.1: multiple ``fp8_calibration_style_image``
+    files) tiles round-robin and trims to the row count, so e.g. 2 images
+    across 8 rows land as ``[img0, img1, img0, img1, ...]`` — every row still
+    gets a real, non-degenerate token, and both images' activation ranges
+    land in the same amax statistic instead of only the first.
+
+    Returns a new dict (``calib_data`` is not mutated in place); logs
+    ``logger.warning`` when the appended/padded ``encoder_hidden_states``
+    region ends up identically zero while ``num_ip_layers > 0`` — the exact
+    precondition that produced the original defect.
+    """
+    calib_data = dict(calib_data)
+    for _name, (_, _expected_dims) in specs.items():
+        if _name not in calib_data:
+            continue
+        _arr = calib_data[_name]
+        _resized = False
+        for _axis, _expected in enumerate(_expected_dims):
+            if _expected is None or _axis == 0 or _axis >= _arr.ndim:
+                continue
+            if _arr.shape[_axis] == _expected:
+                continue
+            _is_ipa_token_axis = _name == "encoder_hidden_states" and _axis == 1
+            if _arr.shape[_axis] < _expected:
+                _missing = _expected - _arr.shape[_axis]
+                if _is_ipa_token_axis and ipadapter_tokens is not None:
+                    _tokens = np.asarray(ipadapter_tokens)
+                    if _tokens.ndim == _arr.ndim - 1:
+                        _tokens = _tokens[None, ...]
+                    if _tokens.shape[0] != _arr.shape[0]:
+                        if _tokens.shape[0] <= 1:
+                            _tokens = np.broadcast_to(_tokens, (_arr.shape[0],) + _tokens.shape[1:])
+                        else:
+                            # fp8-round-9.1: N>1 style images. The old broadcast_to here
+                            # required N==1 or N==_arr.shape[0] and raised ValueError on
+                            # any other N — unreachable while every token source was N==1,
+                            # reachable the moment fp8_calibration_style_image points at a
+                            # multi-image folder. Tile round-robin instead so every
+                            # calibration row still gets a real token and no image is
+                            # dropped just because N doesn't divide the row count evenly.
+                            _reps = -(-_arr.shape[0] // _tokens.shape[0])  # ceil division
+                            _tokens = np.tile(_tokens, (_reps,) + (1,) * (_tokens.ndim - 1))[: _arr.shape[0]]
+                    if _tokens.shape[1] > _missing:
+                        _tokens = _tokens[:, :_missing]
+                    elif _tokens.shape[1] < _missing:
+                        _tokens = np.pad(
+                            _tokens,
+                            [(0, 0), (0, _missing - _tokens.shape[1])] + [(0, 0)] * (_tokens.ndim - 2),
+                            mode="edge",
+                        )
+                    _fill = np.ascontiguousarray(_tokens).astype(_arr.dtype)
+                else:
+                    _fill_shape = list(_arr.shape)
+                    _fill_shape[_axis] = _missing
+                    _fill = np.zeros(_fill_shape, dtype=_arr.dtype)
+                if _is_ipa_token_axis and num_ip_layers > 0:
+                    # fp8-round-9.1: the magnitude on its own turns "did real tokens
+                    # arrive" into a grep instead of a post-hoc ONNX census — the
+                    # fp8-round-9 plan asked for this and only the zero-warning below
+                    # landed.
+                    _fill_absmax = float(np.abs(_fill).max())
+                    logger.info(
+                        f"[FP8] IP-Adapter token region for '{_name}': appended-fill |x|max={_fill_absmax:.6g}"
+                    )
+                    if _fill_absmax == 0.0:
+                        logger.warning(
+                            f"[FP8] IP-Adapter token region for '{_name}' is identically zero after "
+                            "calibration reconciliation — the IPA cross-attention branch will "
+                            "calibrate on zero signal again (fp8-round-9 defect: 420 uncalibrated "
+                            "scale initializers). Check the ipadapter_tokens source."
+                        )
+                _arr = np.concatenate([_arr, _fill], axis=_axis)
+            else:
+                _slc = [slice(None)] * _arr.ndim
+                _slc[_axis] = slice(0, _expected)
+                _arr = _arr[tuple(_slc)]
+            _resized = True
+        if _resized:
+            calib_data[_name] = _arr
+            logger.info(f"[FP8] Reshaped captured '{_name}' to ONNX dims: shape={_arr.shape}")
+    return calib_data
+
+
+def _pool_for_layer(
+    records: Dict[int, np.ndarray], selected_calls, missed_calls: Optional[set] = None
+) -> List[np.ndarray]:
+    """Row-major (call, subrow) pool of real 2-D (seq, hidden) activations for
+    one layer, restricted to ``selected_calls`` (the calls
+    ``_select_calibration_rows`` is keeping), in call-ascending order.
+
+    Extracted to module level (FP8 Round 11, mirroring the
+    ``_build_capture_call_kwargs`` precedent) so this can be pinned directly
+    without a real diffusers pipeline — it used to be a closure inside
+    ``capture_calibration_data`` over ``_selected_calls``/``_pool_missed_calls``.
+
+    A selected call missing from ``records`` — outside the K/V/FI recorder's
+    kept window (see ``_MAX_CALIB_RECORD_CALLS`` / ``_MAX_CALIB_RECORD_BYTES``)
+    — is skipped, not raised, and its index is added to ``missed_calls`` (if
+    given) so the caller can log it once as a summary rather than per-miss.
+    """
+    pool: List[np.ndarray] = []
+    for _c in selected_calls:
+        _rec = records.get(int(_c))
+        if _rec is None:
+            if missed_calls is not None:
+                missed_calls.add(int(_c))
+            continue
+        for _r in range(_rec.shape[0]):
+            pool.append(_rec[_r])
+    return pool
+
+
+def _fill_kvo_from_pool(k_pool: List[np.ndarray], v_pool: List[np.ndarray], arr_shape: List[int], dtype) -> np.ndarray:
+    """Build a ``kvo_cache_in_i`` array (leading axis = n_itr chunks of the
+    fixed K+V pair, per ``_resolve_per_step_dim0``) from real recorded K/V
+    rows instead of zeros (fp8-round-5-handoff Step 2 / Defect B).
+
+    Each n_itr chunk is filled from the *next* pool position — a frame-shift
+    by one, so the "cache" holds a neighbouring call's K/V rather than the
+    current call's own (matching deployment: the cache always holds a
+    previous frame's K/V, never the current one — see
+    ``attention_processors.py``'s ``cached_key``/``cached_value`` concat) —
+    tiled across every remaining axis (maxframes, batch). Falls back to an
+    all-zeros array (the prior behaviour) when no recording exists for this
+    layer.
+    """
+    arr = np.zeros(arr_shape, dtype=dtype)
+    pool_len = min(len(k_pool), len(v_pool))
+    if pool_len == 0:
+        return arr
+    tail_shape = tuple(arr_shape[1:])
+    seq_t, hidden_t = tail_shape[-2], tail_shape[-1]
+    n_itr = arr_shape[0] // 2
+    for m in range(n_itr):
+        src = (m + 1) % pool_len
+        k_tile = np.broadcast_to(_reconcile_2d(k_pool[src], seq_t, hidden_t), tail_shape)
+        v_tile = np.broadcast_to(_reconcile_2d(v_pool[src], seq_t, hidden_t), tail_shape)
+        arr[m * 2 + 0] = k_tile
+        arr[m * 2 + 1] = v_tile
+    return arr
+
+
+def _fill_fio_from_pool(pool: List[np.ndarray], arr_shape: List[int], dtype, chunk: int) -> np.ndarray:
+    """Build a ``fio_cache_in_i`` array from real recorded ``attn1`` block
+    outputs instead of zeros (fp8-round-5-handoff Step 2 / Defect B), using
+    the same frame-shift-by-one-pool-position scheme as
+    ``_fill_kvo_from_pool``. ``chunk`` is ``per_step_d0`` — the ONNX-declared
+    per-call leading-axis size for this input, which folds the maxframes axis
+    into axis 0 when it is pinned static (see ``_resolve_per_step_dim0``).
+    Falls back to zeros when no recording exists for this layer.
+    """
+    arr = np.zeros(arr_shape, dtype=dtype)
+    pool_len = len(pool)
+    if pool_len == 0:
+        return arr
+    tail_shape = tuple(arr_shape[1:])
+    seq_t, hidden_t = tail_shape[-2], tail_shape[-1]
+    n_itr = arr_shape[0] // chunk
+    for m in range(n_itr):
+        src = (m + 1) % pool_len
+        tile = np.broadcast_to(_reconcile_2d(pool[src], seq_t, hidden_t), tail_shape)
+        arr[m * chunk : (m + 1) * chunk] = tile
+    return arr
+
+
+def _build_capture_call_kwargs(
+    batch: List[str],
+    guidance_scale: float,
+    use_explicit_schedule: bool,
+    timesteps: Optional[List[int]],
+    num_inference_steps: int,
+    image_height: Optional[int] = None,
+    image_width: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Pure builder for the per-batch ``pipe()`` call kwargs used by
+    ``capture_calibration_data``'s capture loop (fp8-round-10). Extracted so a
+    unit test can pin its behavior without CUDA/a real diffusers pipeline.
+
+    ``image_height``/``image_width`` are appended only when **both** are
+    given — a lone one is ambiguous, mirroring the existing
+    ``timesteps``/``scheduler_ref`` one-of-two handling in
+    ``capture_calibration_data``. Omitting them (the default, and the only
+    behavior every pre-fp8-round-10 caller used) reproduces the exact prior
+    kwargs, so 512-native builds are byte-for-byte unaffected by this change.
+    """
+    call_kwargs: Dict[str, Any] = {
+        "prompt": batch if len(batch) > 1 else batch[0],
+        "output_type": "latent",
+        "guidance_scale": guidance_scale,
+    }
+    if use_explicit_schedule:
+        call_kwargs["timesteps"] = list(timesteps)
+    else:
+        call_kwargs["num_inference_steps"] = num_inference_steps
+    if image_height is not None and image_width is not None:
+        call_kwargs["height"] = image_height
+        call_kwargs["width"] = image_width
+    return call_kwargs
+
+
+# fp8-round-13: schema version for calib_data.meta.json, bumped whenever a key is
+# added/removed/renamed so a future reader can tell which fields to expect.
+# v2 (FP8 Round 14): added predicted_calls/record_calls_kept/record_bytes/
+# record_max_calls/record_max_bytes/kvo_pool_len -- see _build_calib_provenance.
+# load_calib_provenance reads the sidecar as plain JSON with no schema
+# validation, so v1 sidecars (missing these keys) still load without raising.
+_CALIB_PROVENANCE_SCHEMA_VERSION = 2
+
+
+def _build_calib_provenance(
+    calib_data: Dict[str, np.ndarray],
+    *,
+    image_height: Optional[int] = None,
+    image_width: Optional[int] = None,
+    prompt_count: Optional[int] = None,
+    num_inference_steps: Optional[int] = None,
+    guidance_scale: Optional[float] = None,
+    ipadapter_tokens_real: Optional[bool] = None,
+    selected_calls: Optional[np.ndarray] = None,
+    pool_missed_calls: Optional[set] = None,
+    predicted_calls: Optional[Any] = None,
+    record_calls_kept: Optional[int] = None,
+    record_bytes: Optional[int] = None,
+    record_max_calls: Optional[int] = None,
+    record_max_bytes: Optional[int] = None,
+    kvo_pool_len: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Pure builder for the ``calib_data.meta.json`` sidecar payload (fp8-round-13
+    calibration provenance). Kept separate from the atomic-write wrapper below so
+    it can be unit tested without touching disk.
+
+    Answers "how was this cached calib_data.npz actually made?" -- before this,
+    a cache hit at the top of ``capture_calibration_data``'s caller
+    (``builder.py``) logged only the path, and an aborted run that crashed before
+    reaching ``_write_build_stats`` left literally zero trace of having run at
+    all (fp8-round-10's ~07:14 aborted capture, found only by the npz's own
+    mtime predating the engine it fed). This is metadata-only -- it does not
+    change what gets calibrated or how, so it never forks the ``calv*`` cache tag.
+
+    Deliberately NOT written as extra npz keys: ``load_calibration_data`` (below)
+    returns every key in the npz verbatim via ``{k: _npz[k] for k in
+    _npz.files}``, and the quantize-side row/spec alignment
+    (``_reconcile_calib_to_onnx_dims`` et al.) indexes ONNX input specs by name
+    for every key present in the loaded dict -- an extra non-tensor key would
+    raise ``KeyError`` the first time a cached capture is loaded back for
+    quantization. The sidecar is a parallel file for this reason, not stylistic
+    preference.
+
+    ``predicted_calls``/``record_calls_kept``/``record_bytes``/``record_max_calls``/
+    ``record_max_bytes``/``kvo_pool_len`` (FP8 Round 14, schema v2) record the K/V/FI
+    recorder's own state: which calls ``_predict_selected_calls`` predicted, how many
+    calls and bytes it actually kept, the caps it was bounded by (both env-overridable
+    via ``SDTD_FP8_CALIB_RECORD_CALLS``/``SDTD_FP8_CALIB_RECORD_BYTES`` and therefore
+    *not* part of the ``calv*`` cache tag), and the observed kvo pool length after
+    filling. All ``None`` on the ControlNet capture path (``capture_calibration_data_
+    controlnet``), which has no K/V recorder at all -- expected, not a defect.
+    """
+    captured_timesteps: List[float] = []
+    if "timestep" in calib_data and calib_data["timestep"].size:
+        captured_timesteps = sorted({float(v) for v in calib_data["timestep"].reshape(-1)}, reverse=True)
+
+    row_count = None
+    for _arr in calib_data.values():
+        row_count = int(_arr.shape[0])
+        break
+
+    return {
+        "schema_version": _CALIB_PROVENANCE_SCHEMA_VERSION,
+        "captured_at_utc": datetime.now(timezone.utc).isoformat(),
+        "image_height": image_height,
+        "image_width": image_width,
+        "prompt_count": prompt_count,
+        "num_inference_steps": num_inference_steps,
+        "guidance_scale": guidance_scale,
+        "ipadapter_tokens_real": ipadapter_tokens_real,
+        # calib_data here is the final, post-selection dict that was saved to
+        # the npz, so "captured" and "selected" coincide -- both are recorded
+        # under distinct keys anyway so a future caller that passes the
+        # pre-selection dict does not silently mislabel one as the other.
+        "captured_timesteps": captured_timesteps,
+        "selected_timesteps": captured_timesteps,
+        "selected_calls": (sorted(int(c) for c in selected_calls) if selected_calls is not None else None),
+        "pool_missed_calls": sorted(int(c) for c in pool_missed_calls) if pool_missed_calls else [],
+        "row_count": row_count,
+        # FP8 Round 14 / schema v2:
+        # `is not None` + `len()`, not a bare truthiness check -- predicted_calls is
+        # typed Optional[Any] (the real caller passes a frozenset, but a future caller
+        # could pass a numpy array) and `if predicted_calls` raises ValueError ("truth
+        # value of an array... is ambiguous") for any multi-element ndarray.
+        "predicted_calls": (
+            sorted(int(c) for c in predicted_calls) if predicted_calls is not None and len(predicted_calls) else []
+        ),
+        "record_calls_kept": record_calls_kept,
+        "record_bytes": record_bytes,
+        "record_max_calls": record_max_calls,
+        "record_max_bytes": record_max_bytes,
+        "kvo_pool_len": kvo_pool_len,
+    }
+
+
+def _write_calib_provenance_sidecar(save_path: str, provenance: Dict[str, Any]) -> None:
+    """Atomically write the provenance sidecar beside ``save_path`` (i.e.
+    ``calib_data.npz`` -> ``calib_data.meta.json``, same directory).
+
+    Wrapped in try/except and never raises -- a metadata write must not abort a
+    capture that just spent up to ~47 minutes producing the npz it describes.
+    """
+    meta_path = str(Path(save_path).with_name(Path(save_path).stem + ".meta.json"))
+    try:
+        tmp_path = meta_path + ".tmp"
+        with open(tmp_path, "w", encoding="utf-8") as _f:
+            json.dump(provenance, _f, indent=2)
+        os.replace(tmp_path, meta_path)
+        logger.info(f"[FP8] Saved calibration provenance: {meta_path}")
+    except Exception as e:
+        logger.warning(f"[FP8] Failed to write calibration provenance sidecar {meta_path}: {e}")
+
+
+def load_calib_provenance(npz_path: str) -> Optional[Dict[str, Any]]:
+    """Load the ``calib_data.meta.json`` sidecar beside ``npz_path``, if present.
+
+    Returns ``None`` (not an error) for every pre-fp8-round-13 engine dir, which
+    has a ``calib_data.npz`` but no sidecar -- callers should degrade to a
+    "provenance unavailable" message rather than warn.
+    """
+    meta_path = str(Path(npz_path).with_name(Path(npz_path).stem + ".meta.json"))
+    if not os.path.exists(meta_path):
+        return None
+    try:
+        with open(meta_path, encoding="utf-8") as _f:
+            return json.load(_f)
+    except Exception as e:
+        logger.warning(f"[FP8] Cannot load calibration provenance {meta_path}: {e}")
+        return None
+
+
 def capture_calibration_data(
     pipe,
     prompts: List[str],
@@ -59,8 +762,18 @@ def capture_calibration_data(
     guidance_scale: float = 7.5,
     onnx_path: Optional[str] = None,
     use_cached_attn: bool = False,
+    use_feature_injection: bool = False,
     use_controlnet: bool = False,
     num_ip_layers: int = 0,
+    max_fi_up_blocks: int = 2,
+    fi_strength: float = 0.0,
+    fi_threshold: float = 0.0,
+    ipadapter_scale: float = 1.0,
+    ipadapter_tokens: Optional[np.ndarray] = None,
+    timesteps: Optional[List[int]] = None,
+    scheduler_ref: Any = None,
+    image_height: Optional[int] = None,
+    image_width: Optional[int] = None,
 ) -> Dict[str, np.ndarray]:
     """
     Capture UNet input activations from a real diffusers pipeline run.
@@ -76,9 +789,69 @@ def capture_calibration_data(
         pipe: StableDiffusionPipeline or StableDiffusionXLPipeline.
         prompts: Calibration texts (32–128 recommended).
         num_inference_steps: Denoising steps per prompt. 20 for SDXL, 4 for Turbo.
+            Ignored when ``timesteps``/``scheduler_ref`` are both given.
         save_path: Optional path to write calib_data.npz for caching between builds.
         batch_size: Prompts per pipe() call.
         guidance_scale: CFG scale (affects conditional/unconditional stacking).
+        timesteps: Explicit descending raw UNet timestep list to calibrate
+            against (fp8-round-5-handoff Step 2d), e.g. the output of
+            param_schema.compute_sub_timesteps(build_calibration_t_indices(...)).
+            When given together with ``scheduler_ref``, drives
+            ``pipe(timesteps=timesteps)`` instead of ``pipe(num_inference_steps=...)``
+            — SDXL's ``retrieve_timesteps`` dispatches an explicit ``timesteps=``
+            straight to ``scheduler.set_timesteps(timesteps=...)``, bypassing
+            ``num_inference_steps`` entirely. This is what lets calibration sample
+            the exact region deployment's ``t_index_list`` visits instead of a
+            generic turbo/base step sweep.
+        scheduler_ref: The deployment scheduler instance (``stream.scheduler``)
+            that produced ``timesteps``. ``pipe.scheduler`` is temporarily swapped
+            to this for the capture and restored afterward — the checkpoint's
+            default scheduler is not identity in ``scale_model_input`` the way the
+            deployment LCM scheduler is, so calibrating on the wrong one produces
+            mismatched ``sample`` activation magnitudes even with the right
+            timestep values.
+        use_cached_attn: Whether the deployment engine has StreamV2V cached
+            self-attention (``kvo_cache_in_*``) inputs. When True, this also
+            records real ``attn1.to_k``/``attn1.to_v`` outputs during the same
+            capture pass, so those inputs calibrate on realistic K/V instead
+            of zeros (fp8-round-5-handoff Step 2 / Defect B).
+        use_feature_injection: Whether the deployment engine also has Feature
+            Injection (``fio_cache_in_*``) inputs. Only meaningful together
+            with ``use_cached_attn=True``. When True, also records real
+            ``attn1`` block outputs for FI-eligible layers during capture.
+        max_fi_up_blocks: Must match the value the engine is built with
+            (default 2, the same default used everywhere else in this
+            codebase — see ``models/utils.get_fi_eligible_mask``). Used to
+            recompute which layers are FI-eligible for the recorder above.
+        fi_strength: Deployment value of the ``fi_strength`` scalar input
+            (fp8-round-5-handoff Step 3). Read from config by the caller —
+            defaults to 0.0 (the prior always-zero synthesis) when omitted.
+        fi_threshold: Deployment value of the ``fi_threshold`` scalar input.
+            Same sourcing/default rationale as ``fi_strength``.
+        ipadapter_scale: Deployment value of the ``ipadapter_scale`` input
+            (broadcast across all IP-Adapter layers). Defaults to 1.0 (the
+            prior always-one synthesis) when omitted.
+        ipadapter_tokens: Real IP-Adapter projection tokens, shape
+            ``[num_image_tokens, hidden_dim]`` or ``[1, num_image_tokens,
+            hidden_dim]``, used by ``_reconcile_calib_to_onnx_dims`` to fill
+            the ``encoder_hidden_states`` region the export wrapper appends
+            for IPA cross-attention, instead of zero-padding it
+            (fp8-round-9). ``None`` (the default) preserves the prior
+            zero-pad behavior.
+        image_height: Deployment build height in pixels. When given together
+            with ``image_width``, passed straight through to ``pipe(height=...,
+            width=...)`` so the capture runs at the engine's actual build
+            resolution instead of silently falling back to
+            ``pipe.unet.config.sample_size`` (512 for SDXL-Turbo) — the
+            fp8-round-10 defect. This matters because ``sample``'s H/W ONNX
+            axes are exported dynamic, so nothing downstream can recover the
+            right shape once the capture itself ran at the wrong one: the
+            statically-declared ``kvo_cache_in_*``/``fio_cache_in_*`` inputs
+            get zero-padded to the ONNX-declared size by ``_reconcile_2d``,
+            and the real-vs-padded fraction is ``(512 / R)²`` — 25% real at
+            1024, 11% at 1536. ``None`` (the default) preserves the prior
+            resolution-blind behavior.
+        image_width: Companion to ``image_height``; see above.
 
     Returns:
         Dict mapping UNet input names to np.ndarray arrays of shape [N, ...].
@@ -95,7 +868,43 @@ def capture_calibration_data(
     if _unet_orig_device.type != "cuda":
         pipe.unet.to("cuda")
 
+    _use_explicit_schedule = timesteps is not None and scheduler_ref is not None
+    _pipe_orig_scheduler = pipe.scheduler if _use_explicit_schedule else None
+    if _use_explicit_schedule:
+        pipe.scheduler = scheduler_ref
+        logger.info(
+            f"[FP8] Calibrating on explicit deployment schedule: {len(timesteps)} timesteps "
+            f"{list(timesteps)} via {type(scheduler_ref).__name__} (overrides num_inference_steps)"
+        )
+    elif timesteps is not None or scheduler_ref is not None:
+        logger.warning(
+            "[FP8] capture_calibration_data got only one of timesteps/scheduler_ref "
+            f"(timesteps={'set' if timesteps is not None else None}, "
+            f"scheduler_ref={'set' if scheduler_ref is not None else None}) — both are "
+            "required to drive the explicit schedule; falling back to num_inference_steps."
+        )
+
+    if image_height is not None and image_width is not None:
+        # width x height, matching builder.py's "[BUILD] FP8 activation capture: ...
+        # res={width}x{height}" line -- the two used to disagree in axis order (height x
+        # width here), which is invisible at square 512x512 builds but reads as a
+        # transposition bug on a non-square build (e.g. 640x384 logged as 640x384 vs
+        # 384x640 back to back).
+        logger.info(f"[FP8] Calibrating at build resolution {image_width}x{image_height}")
+    elif image_height is not None or image_width is not None:
+        logger.warning(
+            "[FP8] capture_calibration_data got only one of image_height/image_width "
+            f"(image_height={image_height}, image_width={image_width}) — both are "
+            "required to set the capture resolution; falling back to the checkpoint's "
+            "default (pipe.unet.config.sample_size), which is the exact fp8-round-10 defect."
+        )
+
     captured: Dict[str, list] = {}
+
+    # Computed here (rather than inside the capture loop below, where it lived
+    # before FP8 Round 14) because the K/V/FI recorder's predicted-calls gate,
+    # a few lines down, needs len(batches) before the use_cached_attn block runs.
+    batches = [prompts[i : i + batch_size] for i in range(0, len(prompts), batch_size)]
 
     def _to_npy(t):
         # Keep dtype as-is (FP16 model → FP16 captures). modelopt's max-abs
@@ -104,9 +913,39 @@ def capture_calibration_data(
         # prompt calls; np.concatenate(axis=0) requires at least 1 axis.
         return np.atleast_1d(t.detach().cpu().numpy())
 
+    # fp8-round-5-handoff Step 2 (Defect B): record real per-layer K/V (and, for
+    # FI-eligible layers, real attn1 block output) during this same capture pass,
+    # keyed by call index, so the kvo_cache_in_*/fio_cache_in_* synthesis below can
+    # fill from real deployment-shaped activations instead of zeros. Call index is
+    # 0-based and shared with `captured["timestep"]`'s row order (both advance once
+    # per pipe.unet() forward call).
+    _call_counter = {"n": -1}
+    _kv_records: Dict[int, Dict[str, Dict[int, np.ndarray]]] = {}  # layer_idx -> {"k"/"v": {call_idx: arr}}
+    _fio_records: Dict[int, Dict[int, np.ndarray]] = {}  # fi_local_idx -> {call_idx: arr}
+    _fi_mask: List[bool] = []
+    _kv_hook_handles: List[Any] = []
+    # Shared mutable byte counter (self-limiting recorder cap, FP8 Round 11) --
+    # both hooks below stop recording once this crosses _MAX_CALIB_RECORD_BYTES,
+    # independent of the call-count cap. Dict instead of a plain int so the
+    # closures below can mutate it without a `nonlocal` declaration per hook.
+    _record_bytes = {"n": 0}
+    _record_calls_kept: set = set()
+    # FP8 Round 14: whether the predicted-calls set below (`_predicted_calls`) is
+    # still trustworthy. A mid-capture batch failure (the `except` in the capture
+    # loop) shifts every subsequent call index, invalidating the prediction --
+    # flipped to False there, at which point the hooks fall back to the pre-Round-14
+    # call-count-prefix behavior (still bounded by _MAX_CALIB_RECORD_CALLS/_BYTES).
+    _predict_valid = {"ok": True}
+    # Initialized ahead of the use_cached_attn branch below (mirroring the
+    # _selected_calls/_pool_missed_calls pre-init further down) so the provenance
+    # sidecar writer can reference it without a NameError when use_cached_attn is
+    # False or K/V recorder setup raises before reassigning it.
+    _predicted_calls: frozenset = frozenset()
+
     def _hook(module, args, kwargs):
         # SDXL pipeline calls unet(sample, t, encoder_hidden_states=..., added_cond_kwargs=...)
         # — encoder_hidden_states arrives as a kwarg, not positional. Fall through to kwargs.
+        _call_counter["n"] += 1
         for idx, key in _KEY_MAP.items():
             val = args[idx] if idx < len(args) else kwargs.get(key)
             if val is not None:
@@ -118,23 +957,117 @@ def capture_calibration_data(
             if key in added and added[key] is not None:
                 captured.setdefault(key, []).append(_to_npy(added[key]))
 
+    if use_cached_attn:
+        try:
+            from .models.utils import get_fi_eligible_mask
+
+            _attn1_modules = _walk_attn1_modules(pipe.unet)
+            # height/width don't change get_fi_eligible_mask's output (eligibility is
+            # purely structural — down/mid/up-block position), but threading them
+            # keeps this call consistent with capture resolution rather than the
+            # function's 512 default (fp8-round-10).
+            _fi_mask = (
+                list(
+                    get_fi_eligible_mask(
+                        pipe.unet,
+                        height=image_height or 512,
+                        width=image_width or 512,
+                        max_fi_up_blocks=max_fi_up_blocks,
+                    )
+                )
+                if use_feature_injection
+                else [False] * len(_attn1_modules)
+            )
+            _fi_local_of_global = {gi: li for li, gi in enumerate(gi for gi, e in enumerate(_fi_mask) if e)}
+
+            # FP8 Round 14: predict, before the capture loop runs, exactly which call
+            # indices _select_calibration_calls will keep -- see _predict_selected_calls
+            # for why this is safe (it's a superset of what post-hoc selection picks) and
+            # the module-preamble comment above _MAX_CALIB_RECORD_CALLS for the defect
+            # this replaces (byte cap defeating the call cap, halving kvo/fio diversity).
+            _schedule_len = len(timesteps) if _use_explicit_schedule else num_inference_steps
+            _predicted_calls = frozenset(_predict_selected_calls(_schedule_len, len(batches), _MAX_CALIB_ROWS))
+
+            def _make_kv_hook(_layer_idx, _which):
+                def _kv_hook(_module, _inputs, _output):
+                    if not _recorder_admits_call(
+                        _call_counter["n"], _predict_valid["ok"], _predicted_calls, _MAX_CALIB_RECORD_CALLS
+                    ):
+                        return
+                    if _record_bytes["n"] >= _MAX_CALIB_RECORD_BYTES:
+                        return
+                    _arr = _to_npy(_output)
+                    _kv_records.setdefault(_layer_idx, {}).setdefault(_which, {})[_call_counter["n"]] = _arr
+                    _record_bytes["n"] += _arr.nbytes
+                    _record_calls_kept.add(_call_counter["n"])
+
+                return _kv_hook
+
+            def _make_fio_hook(_layer_idx):
+                _fi_local = _fi_local_of_global[_layer_idx]
+
+                def _fio_hook(_module, _inputs, _output):
+                    if not _recorder_admits_call(
+                        _call_counter["n"], _predict_valid["ok"], _predicted_calls, _MAX_CALIB_RECORD_CALLS
+                    ):
+                        return
+                    if _record_bytes["n"] >= _MAX_CALIB_RECORD_BYTES:
+                        return
+                    _out = _output[0] if isinstance(_output, tuple) else _output
+                    _arr = _to_npy(_out)
+                    _fio_records.setdefault(_fi_local, {})[_call_counter["n"]] = _arr
+                    _record_bytes["n"] += _arr.nbytes
+                    _record_calls_kept.add(_call_counter["n"])
+
+                return _fio_hook
+
+            for _gi, _attn1 in enumerate(_attn1_modules):
+                _kv_hook_handles.append(_attn1.to_k.register_forward_hook(_make_kv_hook(_gi, "k")))
+                _kv_hook_handles.append(_attn1.to_v.register_forward_hook(_make_kv_hook(_gi, "v")))
+                if _gi < len(_fi_mask) and _fi_mask[_gi]:
+                    _kv_hook_handles.append(_attn1.register_forward_hook(_make_fio_hook(_gi)))
+            logger.info(
+                f"[FP8] K/V recorder armed: {len(_attn1_modules)} attn1 layers"
+                + (f", {sum(_fi_mask)} FI-eligible" if use_feature_injection else "")
+            )
+        except Exception as e:
+            logger.warning(f"[FP8] K/V recorder setup failed: {e}. kvo/fio calibration data will fall back to zeros.")
+            for _h in _kv_hook_handles:
+                _h.remove()
+            _kv_hook_handles = []
+            _kv_records, _fio_records = {}, {}
+
     handle = pipe.unet.register_forward_pre_hook(_hook, with_kwargs=True)
     try:
         with torch.inference_mode(), torch.autocast("cuda", dtype=torch.float16):
-            batches = [prompts[i : i + batch_size] for i in range(0, len(prompts), batch_size)]
+            _res_suffix = (
+                f" @ {image_width}x{image_height}" if (image_height is not None and image_width is not None) else ""
+            )
             for i, batch in enumerate(batches):
-                logger.info(f"[FP8] Capture batch {i + 1}/{len(batches)}: {batch[0][:60]}")
+                logger.info(f"[FP8] Capture batch {i + 1}/{len(batches)}{_res_suffix}: {batch[0][:60]}")
+                _call_kwargs = _build_capture_call_kwargs(
+                    batch,
+                    guidance_scale,
+                    _use_explicit_schedule,
+                    timesteps,
+                    num_inference_steps,
+                    image_height=image_height,
+                    image_width=image_width,
+                )
                 try:
-                    _ = pipe(
-                        prompt=batch if len(batch) > 1 else batch[0],
-                        num_inference_steps=num_inference_steps,
-                        output_type="latent",
-                        guidance_scale=guidance_scale,
-                    ).images
+                    _ = pipe(**_call_kwargs).images
                 except Exception as e:
                     logger.warning(f"[FP8] Capture batch {i + 1} failed ({type(e).__name__}): {e}. Skipping.")
+                    # A skipped batch shifts every subsequent call index, invalidating
+                    # the predicted-calls set computed above _make_kv_hook -- fall back
+                    # to the pre-Round-14 call-count-prefix admission rule (FP8 Round 14).
+                    _predict_valid["ok"] = False
     finally:
         handle.remove()
+        for _h in _kv_hook_handles:
+            _h.remove()
+        if _use_explicit_schedule:
+            pipe.scheduler = _pipe_orig_scheduler
         if _unet_orig_device.type != "cuda":
             pipe.unet.to(_unet_orig_device)
             torch.cuda.empty_cache()
@@ -142,92 +1075,207 @@ def capture_calibration_data(
     if not captured:
         raise RuntimeError("[FP8] No UNet activations captured — check pipe.unet forward signature.")
 
+    if use_cached_attn and _record_calls_kept:
+        logger.info(
+            f"[FP8] K/V/FI recorder kept {len(_record_calls_kept)} calls "
+            f"({_record_bytes['n'] / 1024**3:.2f} GiB) — capped at "
+            f"{_MAX_CALIB_RECORD_CALLS} calls / {_MAX_CALIB_RECORD_BYTES / 1024**3:.1f} GiB."
+        )
+
     calib_data: Dict[str, np.ndarray] = {}
     for key, arrays in captured.items():
         stacked = np.concatenate(arrays, axis=0)
         calib_data[key] = stacked
         logger.info(f"[FP8] Captured '{key}': shape={stacked.shape}, dtype={stacked.dtype}")
 
-    # Synthesize zero/one tensors for feature-specific ONNX inputs not captured by the
-    # bare-pipe hook (kvo_cache_in_*, input_control_*, middle_control_*, ipadapter_scale).
-    # These inputs feed Q/DQ-excluded layers (see _FEATURE_EXCLUDE_PATTERNS), so the
-    # synthetic values only need to be shape-compatible — they never drive scale computation.
+    # kvo_cache_in_*/fio_cache_in_* (and ipadapter_scale/control inputs) are not
+    # produced by the bare-pipe forward hook above -- they only exist once the
+    # export wrappers run. Measured via ONNX graph reachability from these
+    # synthetic inputs (fp8-round-5-handoff Defect B): 1782 of 1955 quantized
+    # activation tensors (91.2%) are transitively fed by them, so filling them
+    # with zeros/ones starves 91.2% of FP8 scales of real signal. Real per-layer
+    # K/V (and, for FI, per-layer block output) recorded above during this same
+    # capture pass is used instead wherever a recording exists (see
+    # _fill_kvo_from_pool / _fill_fio_from_pool); np.zeros is kept only as the
+    # fallback for layers with no recording, and ipadapter_scale/control inputs
+    # (never recorded here) keep the prior ones/zeros synthesis.
+    # fp8-round-13: initialized ahead of the branch below (which only runs when
+    # onnx_path + one of use_cached_attn/use_controlnet/num_ip_layers is set) so
+    # the provenance sidecar writer at the save block can reference these
+    # without a NameError when that branch doesn't run.
+    _selected_calls: Optional[np.ndarray] = None
+    _pool_missed_calls: set = set()
+    # FP8 Round 14 provenance field: observed length of the K/V pool actually used
+    # to fill kvo_cache_in_* (post _pool_for_layer, so it reflects any misses).
+    # Every kvo layer draws from the same _selected_calls against recorder state
+    # gated by the same shared _predicted_calls/_call_counter, so pool length is
+    # expected to be identical across layers -- tracked as a max defensively.
+    _kvo_pool_len = 0
     if onnx_path and (use_cached_attn or use_controlnet or num_ip_layers):
         # modelopt's CalibrationDataProvider computes n_itr = first_input.shape[0] /
         # first_input_onnx_dim_0, then np.array_split(arr, n_itr, axis=0) for EVERY
         # input. Each chunk must satisfy the ONNX-declared dim 0 (fixed or dynamic).
         # Bound captured leading dims so n_itr stays small — synthesized KV-cache memory
         # scales as n_itr × per-layer-size × n_layers, which blows up at large n_itr.
-        _MAX_CALIB_ROWS = 8
-        for _k in list(calib_data.keys()):
-            if calib_data[_k].shape[0] > _MAX_CALIB_ROWS:
-                calib_data[_k] = calib_data[_k][:_MAX_CALIB_ROWS]
+        # Stratified-over-timesteps + call-aligned selection (fp8-round-5-handoff
+        # Step 2e) — see _select_calibration_rows for why a naive per-key linspace
+        # stride is unsafe once CFG doubles some keys but not `timestep`.
+        # _select_calibration_calls is re-derived here (same calib_data, same
+        # budget) purely to learn *which* calls _select_calibration_rows is about
+        # to keep, so the K/V/FI pools below stay aligned with the rows that
+        # actually survive -- deterministic given the same inputs, so this never
+        # drifts from the trim on the next line without also changing
+        # _select_calibration_rows's own behavior.
+        _selected_calls = _select_calibration_calls(calib_data, _MAX_CALIB_ROWS)
+        calib_data = _select_calibration_rows(calib_data, _MAX_CALIB_ROWS)
+        # Aggregated across every _pool_for_layer call below (FP8 Round 11) --
+        # previously a selected call missing from a layer's records was a silent
+        # `continue`, and the layer just zero-fell-back with no visibility into
+        # *why*. Logged once as a summary after the fill loop, not per-miss, since
+        # a single out-of-window call can recur across many layers.
+        _pool_missed_calls: set = set()
 
         try:
             _specs = _read_onnx_input_specs(onnx_path)
 
-            # Reconcile captured tensors with ONNX-declared static dims. The bare-pipe
-            # forward hook captures the diffusers UNet *before* feature wrappers run,
-            # so dims that wrappers reshape (e.g. IPA's UnifiedExportWrapper concatenates
-            # 4 image tokens onto encoder_hidden_states → seq_len 77 → 81) won't match
-            # the exported ONNX. Pad with zeros if undersized, trim if oversized, on any
-            # static (non-dynamic, non-leading) axis. Padding zeros is benign for max-abs
-            # calibration — the zero-region contributes no signal to scale computation.
-            for _name, (_, _expected_dims) in _specs.items():
-                if _name not in calib_data:
-                    continue
-                _arr = calib_data[_name]
-                _resized = False
-                for _axis, _expected in enumerate(_expected_dims):
-                    if _expected is None or _axis == 0 or _axis >= _arr.ndim:
-                        continue
-                    if _arr.shape[_axis] == _expected:
-                        continue
-                    if _arr.shape[_axis] < _expected:
-                        _pw = [(0, 0)] * _arr.ndim
-                        _pw[_axis] = (0, _expected - _arr.shape[_axis])
-                        _arr = np.pad(_arr, _pw, mode="constant")
-                    else:
-                        _slc = [slice(None)] * _arr.ndim
-                        _slc[_axis] = slice(0, _expected)
-                        _arr = _arr[tuple(_slc)]
-                    _resized = True
-                if _resized:
-                    calib_data[_name] = _arr
-                    logger.info(f"[FP8] Reshaped captured '{_name}' to ONNX dims: shape={_arr.shape}")
+            # See _reconcile_calib_to_onnx_dims (beside _reconcile_2d, above) for the
+            # IP-Adapter real-token vs. zero-pad reconciliation logic (fp8-round-9).
+            calib_data = _reconcile_calib_to_onnx_dims(
+                calib_data, _specs, ipadapter_tokens=ipadapter_tokens, num_ip_layers=num_ip_layers
+            )
 
             # Mirror CalibrationDataProvider's n_itr derivation (calib_utils.py:90):
             # first ONNX-declared input that appears in calib_data drives the count.
             _present = [n for n in _specs if n in calib_data]
             if _present:
                 _first = _present[0]
-                _first_d0 = max(1, (_specs[_first][1][0] or 1))
+                # Shared with the quantize-side row alignment — see
+                # _resolve_per_step_dim0 for the ipadapter_scale exception. (Also
+                # guards a rank-0-scalar IndexError the old [0] index had.)
+                _first_d0 = _resolve_per_step_dim0(_first, _specs[_first][1], num_ip_layers)
                 _n_itr = max(1, calib_data[_first].shape[0] // _first_d0)
             else:
                 _n_itr = 1
 
+            _kvo_real, _fio_real, _kvo_zero, _fio_zero = 0, 0, 0, 0
+            # fp8-round-10: this failure was silent (the h92807e04ef45/hb290e7269028
+            # comparison found 75% zero-padded kvo/fio rows with no warning anywhere in
+            # the build log). Track the worst real-captured-seq vs ONNX-target-seq
+            # fraction across every real-sourced kvo/fio row and warn once, loudly, if
+            # it drops far below 1.0 -- the signature of a capture resolution mismatch.
+            _worst_real_seq_fraction = 1.0
+            _worst_real_seq_detail = None
             for name, (dtype, dims) in _specs.items():
                 if name in calib_data:
                     continue
                 # Resolve symbolic dims to 1. dim 0 is the per-chunk shape ORT sees.
                 resolved = [d if d is not None else 1 for d in dims]
-                # ipadapter_scale: ONNX dim 0 is dynamic ("L_ip") but the exported
-                # graph has hardcoded Gather(scale_vec, idx=k) for k=0..num_ip_layers-1
-                # at every IPA layer. A length-1 chunk would OOB at idx≥1 during
-                # modelopt's _exclude_matmuls_by_inference ORT probe. Force per-chunk
-                # length to num_ip_layers so every Gather sees the expected vector.
-                per_step_d0 = num_ip_layers if name == "ipadapter_scale" and num_ip_layers > 0 else resolved[0]
+                # Shared with the quantize-side row alignment — see
+                # _resolve_per_step_dim0 for the ipadapter_scale / "L_ip" exception.
+                # Keeping this in one place is load-bearing: the two copies
+                # drifting apart caused an n_itr=560 blowup (~290 GiB tile attempt).
+                per_step_d0 = _resolve_per_step_dim0(name, dims, num_ip_layers)
                 # Total leading dim = n_itr × per-chunk dim 0 so every split chunk
                 # has exactly the ONNX-declared leading dim (fixed Q+K=2 for kvo_cache,
                 # fixed 2 for control inputs, num_ip_layers for ipadapter_scale).
                 arr_shape = [_n_itr * per_step_d0] + list(resolved[1:])
-                arr = (
-                    np.ones(arr_shape, dtype=dtype) if name == "ipadapter_scale" else np.zeros(arr_shape, dtype=dtype)
-                )
+
+                if name.startswith("kvo_cache_in_") and _kv_records:
+                    _layer_idx = int(name.rsplit("_", 1)[-1])
+                    _rec = _kv_records.get(_layer_idx, {})
+                    _k_pool = _pool_for_layer(_rec.get("k", {}), _selected_calls, _pool_missed_calls)
+                    _v_pool = _pool_for_layer(_rec.get("v", {}), _selected_calls, _pool_missed_calls)
+                    arr = _fill_kvo_from_pool(_k_pool, _v_pool, arr_shape, dtype)
+                    if min(len(_k_pool), len(_v_pool)) > 0:
+                        _kvo_real += 1
+                        _kvo_pool_len = max(_kvo_pool_len, min(len(_k_pool), len(_v_pool)))
+                        _source = "recorded K/V activations"
+                        _target_seq = arr_shape[-2]
+                        if _target_seq:
+                            _frac = min(1.0, _k_pool[0].shape[0] / _target_seq)
+                            if _frac < _worst_real_seq_fraction:
+                                _worst_real_seq_fraction = _frac
+                                _worst_real_seq_detail = (
+                                    f"'{name}': captured seq={_k_pool[0].shape[0]}, ONNX target seq={_target_seq}"
+                                )
+                    else:
+                        _kvo_zero += 1
+                        _source = "zero fallback (no recording)"
+                elif name.startswith("fio_cache_in_") and _fio_records:
+                    _fi_local = int(name.rsplit("_", 1)[-1])
+                    _pool = _pool_for_layer(_fio_records.get(_fi_local, {}), _selected_calls, _pool_missed_calls)
+                    arr = _fill_fio_from_pool(_pool, arr_shape, dtype, per_step_d0)
+                    if _pool:
+                        _fio_real += 1
+                        _source = "recorded FI activations"
+                        _target_seq = arr_shape[-2]
+                        if _target_seq:
+                            _frac = min(1.0, _pool[0].shape[0] / _target_seq)
+                            if _frac < _worst_real_seq_fraction:
+                                _worst_real_seq_fraction = _frac
+                                _worst_real_seq_detail = (
+                                    f"'{name}': captured seq={_pool[0].shape[0]}, ONNX target seq={_target_seq}"
+                                )
+                    else:
+                        _fio_zero += 1
+                        _source = "zero fallback (no recording)"
+                elif name == "ipadapter_scale":
+                    # fp8-round-5-handoff Step 3: deployment scale (config-derived via the
+                    # caller), not a hardcoded 1.0 placeholder.
+                    arr = np.full(arr_shape, ipadapter_scale, dtype=dtype)
+                    _source = "deployment config value"
+                elif name == "fi_strength":
+                    arr = np.full(arr_shape, fi_strength, dtype=dtype)
+                    _source = "deployment config value"
+                elif name == "fi_threshold":
+                    arr = np.full(arr_shape, fi_threshold, dtype=dtype)
+                    _source = "deployment config value"
+                else:
+                    arr = np.zeros(arr_shape, dtype=dtype)
+                    _source = "synthetic zeros"
+
                 calib_data[name] = arr
                 logger.info(
-                    f"[FP8] Synthesized '{name}': shape={arr.shape}, dtype={arr.dtype} "
+                    f"[FP8] Filled '{name}' from {_source}: shape={arr.shape}, dtype={arr.dtype} "
                     f"(n_itr={_n_itr}, per-step-dim0={per_step_d0})"
+                )
+            if _kvo_real or _fio_real or _kvo_zero or _fio_zero:
+                logger.info(
+                    f"[FP8] K/V cache recorder: kvo real={_kvo_real} zero-fallback={_kvo_zero}, "
+                    f"fio real={_fio_real} zero-fallback={_fio_zero}"
+                )
+            if _pool_missed_calls:
+                # FP8 Round 14: this is not a zero-fallback -- _pool_for_layer skips a
+                # missed call rather than inserting a zero row, shrinking pool_len, and
+                # _fill_kvo_from_pool's src = (m + 1) % pool_len then cyclically re-uses
+                # the surviving recorded calls to fill the gap. The cost is calibration
+                # *diversity*, not zeros: fewer distinct real activations get reused
+                # across more n_itr chunks (measured: 8 distinct K/V sources dropped to
+                # 4 under the pre-Round-14 recorder — see the calv8 note in
+                # engine_manager.py). Under normal (non-fallback) operation the
+                # predictive recorder above should make this list empty; a non-empty
+                # list here means _predict_valid["ok"] went False mid-capture (a batch
+                # failed) and the legacy call-count-prefix admission missed some of the
+                # calls actually selected.
+                logger.warning(
+                    f"[FP8] {len(_pool_missed_calls)} selected calibration call(s) "
+                    f"{sorted(_pool_missed_calls)} were not recorded by the K/V/FI recorder "
+                    f"(_MAX_CALIB_RECORD_CALLS={_MAX_CALIB_RECORD_CALLS}, "
+                    f"_MAX_CALIB_RECORD_BYTES={_MAX_CALIB_RECORD_BYTES / 1024**3:.1f} GiB) — "
+                    "affected layers reuse other recorded calls for those positions instead, "
+                    "reducing calibration diversity (not a zero-fill)."
+                )
+            if _worst_real_seq_detail is not None and _worst_real_seq_fraction < 0.9:
+                # fp8-round-10: a low fraction here means capture ran at a lower
+                # resolution than the engine's build target -- pass image_height/
+                # image_width so pipe() captures at the real shape, or the zero-padded
+                # remainder starves FP8 scales of real signal (measured: 91.2% of
+                # quantized activation tensors are transitively fed by these inputs).
+                logger.warning(
+                    f"[FP8] K/V/FI cache calibration is under-resolution: worst real-vs-target "
+                    f"sequence-length fraction is {_worst_real_seq_fraction:.1%} ({_worst_real_seq_detail}). "
+                    "This usually means capture_calibration_data ran at a lower resolution than "
+                    "the engine is being built for — pass image_height/image_width."
                 )
         except Exception as e:
             logger.warning(
@@ -245,6 +1293,26 @@ def capture_calibration_data(
             np.savez(_f, **calib_data)
         os.replace(tmp_path, save_path)
         logger.info(f"[FP8] Saved calibration data: {save_path} ({os.path.getsize(save_path) / 1e6:.1f} MB)")
+        _write_calib_provenance_sidecar(
+            save_path,
+            _build_calib_provenance(
+                calib_data,
+                image_height=image_height,
+                image_width=image_width,
+                prompt_count=len(prompts),
+                num_inference_steps=num_inference_steps,
+                guidance_scale=guidance_scale,
+                ipadapter_tokens_real=ipadapter_tokens is not None,
+                selected_calls=_selected_calls,
+                pool_missed_calls=_pool_missed_calls,
+                predicted_calls=_predicted_calls,
+                record_calls_kept=len(_record_calls_kept),
+                record_bytes=_record_bytes["n"],
+                record_max_calls=_MAX_CALIB_RECORD_CALLS,
+                record_max_bytes=_MAX_CALIB_RECORD_BYTES,
+                kvo_pool_len=_kvo_pool_len,
+            ),
+        )
 
     return calib_data
 
@@ -361,6 +1429,15 @@ def capture_calibration_data_controlnet(
             np.savez(_f, **calib_data)
         os.replace(tmp_path, save_path)
         logger.info(f"[FP8-CN] Saved calibration data: {save_path} ({os.path.getsize(save_path) / 1e6:.1f} MB)")
+        _write_calib_provenance_sidecar(
+            save_path,
+            _build_calib_provenance(
+                calib_data,
+                image_height=image_height,
+                image_width=image_width,
+                num_inference_steps=n_calibration_steps,
+            ),
+        )
 
     return calib_data
 
@@ -373,7 +1450,11 @@ def load_calibration_data(npz_path: str) -> Optional[Dict[str, np.ndarray]]:
     if not os.path.exists(npz_path):
         return None
     try:
-        data = dict(np.load(npz_path))
+        # Explicit `with` (not dict(np.load(...))) so the NpzFile's underlying
+        # zip handle closes deterministically here rather than whenever GC gets
+        # around to the finalizer — this file is 4+ GB, don't leave it pinned.
+        with np.load(npz_path) as _npz:
+            data = {k: _npz[k] for k in _npz.files}
         logger.info(f"[FP8] Loaded calibration data from {npz_path} ({len(data)} tensors)")
         return data
     except Exception as e:
@@ -399,6 +1480,29 @@ _FEATURE_EXCLUDE_PATTERNS = {
     "ipadapter": [r".*to_k_ip.*", r".*to_v_ip.*", r".*to_out_ip.*"],
 }
 
+# fp8-round-8: the two attention BMMs (Q@K^T and softmax@V), never the QKV/output
+# *projections*. Node names verified against a built graph:
+#   catches  .../attn1/MatMul, .../attn1/MatMul_1, .../attn2/MatMul, _1, _2, _3
+#   spares   .../attn1/to_q/MatMul, .../attn2/to_out.0/MatMul, .../attn2/to_k_ip/MatMul, ...
+# The trailing `(_\d+)?$` anchor is load-bearing — `.*attn1.*` would also catch every
+# projection MatMul under that block, which are correctly calibrated and must stay FP8.
+_ATTENTION_EXCLUDE_PATTERNS = [r".*/attn[12]/MatMul(_\d+)?$"]
+
+# fp8-round-9: the three IP-Adapter cross-attention *activation* tensors that fed
+# fp8_exclude_ipadapter's motivating defect (Mul_4 = k_ip after RoPE-less transpose,
+# Transpose_4 = v_ip, Mul_5 = scale·ip_attn_out — see fp8-round-9 handoff). Deliberately
+# NOT the two IPA BMMs (attn2/MatMul_2, attn2/MatMul_3) — those already match
+# _ATTENTION_EXCLUDE_PATTERNS above (r".*/attn[12]/MatMul(_\d+)?$"), per
+# tests/unit/test_fp8_rescale.py. Duplicating them here would make the two flags
+# silently overlap. Net effect of each flag alone:
+#   fp8_exclude_ipadapter alone  -> IPA BMMs stay quantized, these 3 activations don't
+#   fp8_exclude_attention alone  -> these 3 activations stay quantized, IPA BMMs don't
+#   both together                -> the whole IPA cross-attention path is FP16
+# The trailing `$` is load-bearing — modelopt's expand_node_names_from_patterns uses
+# re.match (anchored at the start only, graph_utils.py:1018), so an unanchored tail
+# would also swallow `Mul_5_output_0`-style consumer names and any future `Mul_40+`.
+_IPADAPTER_ACTIVATION_EXCLUDE_PATTERNS = [r".*/attn2/(Mul_4|Mul_5|Transpose_4)$"]
+
 
 def _read_onnx_input_specs(onnx_path: str) -> Dict[str, tuple]:
     """Return {name: (np_dtype, shape)} from ONNX graph inputs. Shape dims are int or None."""
@@ -418,6 +1522,101 @@ def _read_onnx_input_specs(onnx_path: str) -> Dict[str, tuple]:
     return result
 
 
+def _resolve_per_step_dim0(name: str, dims: List[Optional[int]], num_ip_layers: int = 0) -> int:
+    """Per-chunk leading dim for `name` — the dim 0 ORT sees after modelopt's
+    CalibrationDataProvider does np.array_split(arr, n_itr, axis=0).
+
+    Static ONNX dim 0 → itself; symbolic (None) → 1; empty dims (rank-0 scalar) → 1.
+    Sole exception is ipadapter_scale: its ONNX dim 0 is the dynamic symbol "L_ip"
+    (models/models.py:716), but the traced graph Gathers scale_vec[0..num_ip_layers-1]
+    at every IPA layer, so a length-1 chunk goes out of bounds during modelopt's
+    _exclude_matmuls_by_inference ORT probe.
+
+    MUST remain the single source of truth for both capture_calibration_data's
+    synthesis and _align_calibration_rows. The two drifting apart previously let
+    ipadapter_scale contribute 560 rows / resolved_dim0=1 = 560 to the elected
+    n_itr instead of 8, tiling every kvo/fio cache tensor 70× (~290 GiB, OOM).
+    """
+    if name == "ipadapter_scale" and num_ip_layers > 0:
+        return num_ip_layers
+    if not dims:
+        return 1
+    return max(1, dims[0] or 1)
+
+
+# Upper bound on the row-aligned calibration set's in-memory footprint. Sized well
+# above a real SDXL + cached-attn + FI + IPA capture (~4.1 GiB at n_itr=8) and far
+# below the ~290 GiB an n_itr drift demands, so it fires long before a numpy
+# MemoryError would. Override for exotic configs: SDTD_FP8_CALIB_MAX_BYTES=<bytes>
+_MAX_CALIB_TOTAL_BYTES = 24 * 1024**3
+
+
+def _align_calibration_rows(
+    calibration_data: Dict[str, np.ndarray],
+    specs: Dict[str, tuple],
+    num_ip_layers: int = 0,
+) -> Dict[str, np.ndarray]:
+    """Tile/trim every calibration tensor to n_itr × per-step-dim0 rows.
+
+    modelopt's CalibrationDataProvider does np.array_split(arr, n_itr, axis=0) for
+    EVERY input, so each input needs exactly n_itr × its own per-chunk dim 0 rows —
+    a single global row count breaks kvo_cache_in_* (ONNX dim0=2 static) by handing
+    modelopt (1, ...) chunks. n_itr is the max over inputs so no input is silently
+    down-sampled; because the loop re-tiles every input — including the first ONNX
+    graph input — modelopt recomputes that same n_itr from first_input.shape[0] //
+    dim0, so max() stays self-consistent with what modelopt does downstream.
+
+    Pure numpy (no ORT/modelopt/torch): unit-testable by passing a hand-built
+    `specs` dict in _read_onnx_input_specs' format. Returns a new dict; entries
+    that already match their target are returned by identity (no copy).
+    """
+    _dim0 = {name: _resolve_per_step_dim0(name, specs[name][1], num_ip_layers) for name in calibration_data}
+    _per_key_itr = {name: arr.shape[0] // _dim0[name] for name, arr in calibration_data.items()}
+    _n_itr = max(1, max(_per_key_itr.values(), default=1))
+
+    # Projected-footprint guard. A per-step-dim0 that disagrees with what capture
+    # wrote inflates n_itr by that input's true chunk length, which then multiplies
+    # into every other calibration tensor. Fail loudly and actionably here instead
+    # of letting numpy raise a bare MemoryError partway through the tile loop.
+    # a[:1] is a view, so .nbytes gives the per-row size with no allocation.
+    _projected = sum(_n_itr * _dim0[n] * a[:1].nbytes for n, a in calibration_data.items())
+    _cap = int(os.environ.get("SDTD_FP8_CALIB_MAX_BYTES", _MAX_CALIB_TOTAL_BYTES))
+    if _projected > _cap:
+        _sorted_itr = sorted(_per_key_itr.values())
+        _median = _sorted_itr[len(_sorted_itr) // 2]
+        _drivers = sorted(n for n, v in _per_key_itr.items() if v == _n_itr)
+        raise RuntimeError(
+            f"[FP8] Calibration row alignment would need {_projected / 1024**3:.1f} GiB "
+            f"(cap {_cap / 1024**3:.1f} GiB) at n_itr={_n_itr}. "
+            f"n_itr is driven by {_drivers[:5]}"
+            f"{f' (+{len(_drivers) - 5} more)' if len(_drivers) > 5 else ''}, "
+            f"while the median input implies n_itr={_median}. "
+            f"That gap means a calibration input's row count disagrees with its "
+            f"ONNX-declared dim 0 — delete calib_data.npz to recapture, or raise "
+            f"SDTD_FP8_CALIB_MAX_BYTES if this row count is genuinely intended."
+        )
+
+    _aligned: Dict[str, np.ndarray] = {}
+    for _k, _arr in calibration_data.items():
+        _target_rows = _n_itr * _dim0[_k]
+        if _arr.shape[0] == _target_rows:
+            _aligned[_k] = _arr
+            continue
+        if _arr.shape[0] == 0:
+            raise RuntimeError(f"[FP8] Calibration input '{_k}' has 0 rows — delete calib_data.npz and recapture.")
+        # Modulo fancy-index instead of np.tile(...)[:target]: allocates only the
+        # output. np.tile first materializes ceil(target/rows)×rows rows, and the
+        # trailing slice is a *view*, so that oversized base stays alive for the
+        # lifetime of the dict. Semantics are identical in both directions: up-tile
+        # gives arr[j % n] for j < target (what np.tile(...)[:target] produces);
+        # down-trim (target < n) gives arr[:target] in both.
+        _aligned[_k] = _arr[np.arange(_target_rows) % _arr.shape[0]]
+        logger.info(
+            f"[FP8] Tiled '{_k}' {_arr.shape[0]} → {_target_rows} rows (n_itr={_n_itr} × per-step-dim0={_dim0[_k]})"
+        )
+    return _aligned
+
+
 def _assert_finite_qdq_scales(onnx_path: str) -> None:
     """Raise RuntimeError if any FP8 Q/DQ scale in onnx_path is non-finite.
 
@@ -435,6 +1634,14 @@ def _assert_finite_qdq_scales(onnx_path: str) -> None:
     import onnx as _onnx
     from onnx import numpy_helper as _numpy_helper
 
+    # modelopt's save_onnx (utils.py:654-687) externalizes any tensor >= 1024 bytes
+    # once the model as a whole exceeds 2 GB — and it passes per_channel=True to
+    # quantize_static (fp8.py:302), so wide layers' per-channel weight scales are
+    # exactly the kind of tensor that legitimately ends up in external data, not
+    # just the multi-GB weights. A previous version of this check loaded with
+    # load_external_data=False to avoid that read and silently skipped any scale
+    # stored externally — host RAM was never actually the constraint here, and
+    # skipping meant those scales were never checked for non-finite values at all.
     model = _onnx.load(onnx_path, load_external_data=True)
     graph = model.graph
     init_map = {init.name: init for init in graph.initializer}
@@ -471,6 +1678,231 @@ def _assert_finite_qdq_scales(onnx_path: str) -> None:
         )
 
 
+def _rescale_fp8_qdq_scales(onnx_path: str, headroom: float = 1.0, dry_run: bool = False) -> Dict[str, Any]:
+    """Correct modelopt's inverted INT8->FP8 scale-conversion factor, in place.
+
+    modelopt/onnx/quantization/fp8.py's _int8_scale_to_fp8_scale computes
+
+        np_fp8_scale = (np_scale * 448.0) / 127.0
+
+    where np_scale is the *INT8* QuantizeLinear scale (amax / 127). The correct FP8
+    scale is amax / 448 = np_scale * 127 / 448 -- modelopt applies the reciprocal
+    factor instead, so every calibrated amax lands at 127**2/448 = 36.0 in E4M3 space
+    (full range is 448.0), a uniform 12.4437x under-utilization. Measured directly on
+    a shipped engine: every sampled weight peaked at exactly 36.04. See the fp8-round-8
+    plan for the full derivation and why this specifically shows up as blur in
+    attention (softmax outputs are bounded in [0,1] with typical values far below 1,
+    the tensor class most likely to fall below E4M3's narrowed normal-range floor).
+
+    TensorRT's STRONGLY_TYPED FP8 builder (utilities.py::_build_fp8) parses this ONNX
+    file directly and constant-folds each weight's QuantizeLinear at *engine build*
+    time -- there is no pre-baked FP8 payload sitting in this file for either weights
+    or activations, only the FP16 value plus the scale that will quantize it later.
+    Rescaling the scale tensors here, before TRT ever sees this file, is therefore
+    sufficient: TRT re-derives every quantized value from the corrected scale.
+
+    Called once, directly on modelopt_quantize's raw output, before
+    _assert_finite_qdq_scales and before the .ok sentinel is written. Not idempotent:
+    running this twice on the same file compounds the correction.
+
+    Args:
+        onnx_path: Path to the modelopt-quantized ONNX (mutated in place unless
+            dry_run). External-data scales are patched in the sibling *_data file at
+            their existing offset/length -- byte length is unchanged (fp16 in, fp16
+            out), so nothing else in the model shifts.
+        headroom: Extra multiplier past the corrected amax->448 mapping. >1.0 leaves
+            outlier margin for activations that exceed the calibrated max, at the
+            cost of resolution. 1.0 uses the full E4M3 range.
+        dry_run: Compute and return the report without writing anything -- used to
+            verify this function against an already-shipped (uncorrected) engine
+            without mutating it.
+
+    Returns:
+        Report dict: scales_seen, scales_corrected, realized_peak_before,
+        realized_peak_after, min_scale_after, underflow_count, uncalibrated_count,
+        uncalibrated_samples.
+    """
+    import onnx as _onnx
+    from onnx import TensorProto as _TensorProto
+    from onnx import numpy_helper as _numpy_helper
+    from onnx.external_data_helper import load_external_data_for_tensor as _load_ext_tensor
+
+    # modelopt stores  s_mo  = amax * 448 / 127**2      (fp8.py:70-74, inverted factor)
+    # we want          s_tgt = amax * headroom / 448
+    # so               k     = headroom * (127 / 448) ** 2      # 0.080362 at headroom=1.0
+    k = headroom * (127.0 / 448.0) ** 2
+    _UNCALIBRATED = float(np.float16(448.0 / 127.0))  # INT8 amax == 127.0 exactly -> never calibrated
+    _UNCALIBRATED_TOL = 1e-3
+    _FP16_MIN_NORMAL = 6.103515625e-05
+    _SAMPLE_N = 5
+
+    model = _onnx.load(onnx_path, load_external_data=False)
+    graph = model.graph
+    base_dir = os.path.dirname(os.path.abspath(onnx_path))
+    init_map = {init.name: init for init in graph.initializer}
+
+    const_scale_nodes: Dict[str, Any] = {}
+    for node in graph.node:
+        if node.op_type == "Constant" and node.output:
+            attr = {a.name: a for a in node.attribute}
+            if "value" in attr:
+                const_scale_nodes[node.output[0]] = node
+
+    # Dedupe by initializer/constant-output name: a QuantizeLinear/DequantizeLinear
+    # pair for the same tensor share one scale source (modelopt's own
+    # `processed_tensor` guard, fp8.py:85-96). A set is load-bearing here -- applying
+    # k twice to the same tensor would be a silent 12.4x error in the other direction.
+    inline_names: set = set()
+    const_names: set = set()
+    for node in graph.node:
+        if node.op_type not in ("QuantizeLinear", "DequantizeLinear") or len(node.input) < 2:
+            continue
+        sname = node.input[1]
+        if sname in init_map:
+            inline_names.add(sname)
+        elif sname in const_scale_nodes:
+            const_names.add(sname)
+
+    def _materialize(t) -> np.ndarray:
+        tc = _onnx.TensorProto()
+        tc.CopyFrom(t)
+        if tc.data_location == _TensorProto.EXTERNAL:
+            _load_ext_tensor(tc, base_dir)
+            tc.data_location = _TensorProto.DEFAULT
+            del tc.external_data[:]
+        return _numpy_helper.to_array(tc)
+
+    def _set_raw(t, arr: np.ndarray) -> None:
+        t.raw_data = arr.tobytes()
+        if t.int32_data:
+            del t.int32_data[:]
+        if t.float_data:
+            del t.float_data[:]
+        t.data_location = _TensorProto.DEFAULT
+
+    # --- realized-peak sample, taken BEFORE any mutation: max|w_fp16| / scale over a
+    # handful of static-weight QuantizeLinear nodes. This is what makes the fix
+    # self-verifying in the build log (36.04 -> 448.00). ---
+    peak_before = None
+    sampled = 0
+    for node in graph.node:
+        if node.op_type != "QuantizeLinear" or sampled >= _SAMPLE_N:
+            continue
+        w, s = init_map.get(node.input[0]), init_map.get(node.input[1])
+        if w is None or s is None:
+            continue
+        try:
+            wa = _materialize(w).astype(np.float32)
+            sa = _materialize(s).astype(np.float32).reshape(-1)
+        except Exception:
+            continue
+        axis = next((a.i for a in node.attribute if a.name == "axis"), None)
+        if sa.size > 1 and axis is not None:
+            mv = np.moveaxis(np.abs(wa), axis, 0).reshape(sa.size, -1).max(axis=1)
+            peak = float((mv / sa).max())
+        else:
+            peak = float(np.abs(wa).max() / sa[0])
+        peak_before = peak if peak_before is None else max(peak_before, peak)
+        sampled += 1
+
+    report: Dict[str, Any] = {
+        "scales_seen": len(inline_names) + len(const_names),
+        "scales_corrected": 0,
+        "underflow_count": 0,
+        "uncalibrated_count": 0,
+        "uncalibrated_samples": [],
+        "min_scale_after": None,
+        "realized_peak_before": peak_before,
+        "realized_peak_after": (peak_before / k) if peak_before is not None else None,
+    }
+    min_after_holder = [None]
+
+    def _correct(arr16: np.ndarray, name: str) -> np.ndarray:
+        arr32 = arr16.astype(np.float32)
+        if np.all(np.abs(arr32 - _UNCALIBRATED) < _UNCALIBRATED_TOL):
+            report["uncalibrated_count"] += 1
+            if len(report["uncalibrated_samples"]) < 10:
+                report["uncalibrated_samples"].append(name)
+        corrected = (arr32 * np.float32(k)).astype(np.float16)
+        if np.any(corrected == 0):
+            raise RuntimeError(
+                f"[FP8] Rescale produced an exact-zero FP16 scale for '{name}' in "
+                f"{onnx_path} -- its DequantizeLinear output would be zeroed. This "
+                f"scale was far below anything measured while deriving fp8_scale_headroom; "
+                f"investigate before lowering headroom further."
+            )
+        mag = np.abs(corrected.astype(np.float32))
+        if mag.size:
+            m = float(mag.min())
+            if min_after_holder[0] is None or m < min_after_holder[0]:
+                min_after_holder[0] = m
+        report["underflow_count"] += int(np.count_nonzero(mag < _FP16_MIN_NORMAL))
+        report["scales_corrected"] += 1
+        return corrected
+
+    # --- inline (protobuf) initializer scales ---
+    for name in inline_names:
+        t = init_map[name]
+        if t.data_location == _TensorProto.EXTERNAL:
+            continue  # handled in the external-data pass below
+        arr16 = _numpy_helper.to_array(t).reshape(-1).astype(np.float16)
+        corrected = _correct(arr16, name)
+        if not dry_run:
+            _set_raw(t, corrected)
+
+    # --- scales produced by a Constant node (fp8.py:86-95's other storage form; none
+    # observed in this build, handled defensively for future modelopt/graph changes) ---
+    for name in const_names:
+        node = const_scale_nodes[name]
+        attr = {a.name: a for a in node.attribute}
+        t = attr["value"].t
+        arr16 = _numpy_helper.to_array(t).reshape(-1).astype(np.float16)
+        corrected = _correct(arr16, name)
+        if not dry_run:
+            _set_raw(t, corrected)
+
+    # --- external-data scales: patch bytes in place at their existing offset/length.
+    # Never load the multi-GB weight payload alongside them; group by backing file so
+    # one handle serves every tensor stored in it. ---
+    by_location: Dict[str, list] = {}
+    for name in inline_names:
+        t = init_map[name]
+        if t.data_location != _TensorProto.EXTERNAL:
+            continue
+        ed = {kv.key: kv.value for kv in t.external_data}
+        by_location.setdefault(ed["location"], []).append((name, int(ed["offset"]), int(ed.get("length", 0))))
+
+    for location, entries in by_location.items():
+        data_path = os.path.join(base_dir, location)
+        mode = "r+b" if not dry_run else "rb"
+        with open(data_path, mode) as f:
+            for name, offset, length in entries:
+                f.seek(offset)
+                raw = f.read(length)
+                arr16 = np.frombuffer(raw, dtype=np.float16)
+                corrected = _correct(arr16, name)
+                if not dry_run:
+                    f.seek(offset)
+                    f.write(corrected.tobytes())
+
+    report["min_scale_after"] = min_after_holder[0]
+
+    if not dry_run:
+        _onnx.save_model(model, onnx_path)
+
+    peak_before_s = f"{report['realized_peak_before']:.2f}" if report["realized_peak_before"] is not None else "n/a"
+    peak_after_s = f"{report['realized_peak_after']:.2f}" if report["realized_peak_after"] is not None else "n/a"
+    min_after_s = f"{report['min_scale_after']:.3e}" if report["min_scale_after"] is not None else "n/a"
+    logger.info(
+        f"[FP8] Rescale: {report['scales_corrected']}/{report['scales_seen']} scales corrected "
+        f"(k={k:.6f}, headroom={headroom}); realized peak {peak_before_s} -> {peak_after_s} "
+        f"(target {448.0 * headroom:.1f}); {report['uncalibrated_count']} uncalibrated "
+        f"(amax==127.0 exactly); {report['underflow_count']} FP16-subnormal after correction "
+        f"(min {min_after_s})."
+    )
+    return report
+
+
 def quantize_onnx_fp8(
     onnx_path: str,
     output_path: str,
@@ -481,6 +1913,9 @@ def quantize_onnx_fp8(
     use_feature_injection: bool = False,
     use_controlnet: bool = False,
     num_ip_layers: int = 0,
+    fp8_scale_headroom: float = 1.0,
+    fp8_exclude_attention: bool = False,
+    fp8_exclude_ipadapter: bool = False,
 ) -> None:
     """
     Inject native FLOAT8E4M3FN Q/DQ nodes into a FP16 ONNX model via ORT.
@@ -493,9 +1928,30 @@ def quantize_onnx_fp8(
         calibration_data: Dict[str, np.ndarray] from capture_calibration_data().
         nodes_to_exclude: ONNX node name patterns to skip quantization on.
                           Defaults to time/add embedding layers.
-        disable_mha_qdq: Skip MHA-specific Q/DQ injection (default True for Ada).
-                         General FP8 calibration still inserts Q/DQ on all attention
-                         MatMuls; TRT Myelin fuses them into _gemm_mha_v2 FP8 kernels.
+        disable_mha_qdq: Skip MHA-specific Q/DQ injection (default True for Ada). When
+                         True, modelopt excludes the attention MatMuls from
+                         quantization entirely (graph_utils.find_nodes_from_mha_to_exclude
+                         -> fp8.py's nodes_to_exclude filter) — no Q/DQ is inserted on
+                         them, so TRT cannot fuse a _gemm_mha_v2 FP8 kernel there; those
+                         MatMuls run at their original (FP16) precision instead.
+        fp8_scale_headroom: Multiplier applied on top of the corrected amax->448 mapping
+                         (see _rescale_fp8_qdq_scales). 1.0 uses the full E4M3 range;
+                         >1.0 leaves outlier headroom for activations that exceed the
+                         calibrated max, at the cost of resolution.
+        fp8_exclude_attention: When True, adds _ATTENTION_EXCLUDE_PATTERNS to
+                         nodes_to_exclude so the two attention BMMs (QK^T and
+                         softmax@V) run FP16 instead of FP8. Fallback lever for the
+                         12.4x scale defect fp8-round-8 fixes directly — should not be
+                         needed once _rescale_fp8_qdq_scales is in place, but forks the
+                         engine cache tag (--fp8v4-noattn) so it stays a clean A/B.
+        fp8_exclude_ipadapter: When True, adds _IPADAPTER_ACTIVATION_EXCLUDE_PATTERNS
+                         to nodes_to_exclude so the three IP-Adapter cross-attention
+                         activations (Mul_4/Mul_5/Transpose_4) run FP16 instead of FP8.
+                         Orthogonal to fp8_exclude_attention — see the pattern's own
+                         comment for the non-overlap with the IPA BMMs. Fallback lever
+                         for fp8-round-9's calibration fix; not needed once real
+                         IP-Adapter tokens feed calibration, but forks the engine cache
+                         tag (--fp8v4-noip) so it stays a clean A/B.
     """
     try:
         from modelopt.onnx.quantization import quantize as modelopt_quantize
@@ -541,6 +1997,10 @@ def quantize_onnx_fp8(
             nodes_to_exclude.extend(_FEATURE_EXCLUDE_PATTERNS["controlnet"])
         if num_ip_layers > 0:
             nodes_to_exclude.extend(_FEATURE_EXCLUDE_PATTERNS["ipadapter"])
+        if fp8_exclude_attention:
+            nodes_to_exclude.extend(_ATTENTION_EXCLUDE_PATTERNS)
+        if fp8_exclude_ipadapter:
+            nodes_to_exclude.extend(_IPADAPTER_ACTIVATION_EXCLUDE_PATTERNS)
 
     # The optimized ONNX may expose fewer inputs than capture_calibration_data
     # records (e.g. SDXL UnifiedExportWrapper hides text_embeds/time_ids inside
@@ -562,27 +2022,12 @@ def quantize_onnx_fp8(
             logger.info(f"[FP8] Casting calibration '{_k}': {calibration_data[_k].dtype} → {_expected}")
             calibration_data[_k] = calibration_data[_k].astype(_expected)
 
-    # Per-input tile: target rows = n_itr × resolved_dim0(name) so every input
-    # splits into exactly n_itr chunks of shape (resolved_dim0, ...).
-    # Mirrors modelopt CalibrationDataProvider: symbolic dims → 1, static dims kept.
-    # Naïve _max_rows tile breaks kvo_cache_in_* (ONNX dim0=2 static) by pumping
-    # sample to 2×_n_itr rows, causing modelopt to split kvo into (1,...) chunks.
-    import math as _math
-
-    # Empty dims list means scalar ONNX input (shape ()); treat resolved_dim0 as 1.
-    _resolved_dim0 = {name: (max(1, _specs[name][1][0] or 1) if _specs[name][1] else 1) for name in calibration_data}
-    _n_itr = max(arr.shape[0] // _resolved_dim0[name] for name, arr in calibration_data.items())
-    _n_itr = max(1, _n_itr)
-    for _k in list(calibration_data.keys()):
-        _arr = calibration_data[_k]
-        _target_rows = _n_itr * _resolved_dim0[_k]
-        if _arr.shape[0] != _target_rows:
-            _repeats = _math.ceil(_target_rows / max(1, _arr.shape[0]))
-            calibration_data[_k] = np.tile(_arr, (_repeats,) + (1,) * (_arr.ndim - 1))[:_target_rows]
-            logger.info(
-                f"[FP8] Tiled '{_k}' {_arr.shape[0]} → {_target_rows} rows "
-                f"(n_itr={_n_itr} × resolved_dim0={_resolved_dim0[_k]})"
-            )
+    # Per-input row alignment: target rows = n_itr × per-step-dim0(name) so every
+    # input splits into exactly n_itr chunks of shape (per-step-dim0, ...). Shares
+    # _resolve_per_step_dim0 with the capture-side synthesis so the two cannot
+    # drift — see _align_calibration_rows for the full rationale and the
+    # projected-memory guard that replaces an opaque numpy MemoryError.
+    calibration_data = _align_calibration_rows(calibration_data, _specs, num_ip_layers)
 
     import inspect as _inspect
 
@@ -601,20 +2046,79 @@ def quantize_onnx_fp8(
         "disable_mha_qdq": disable_mha_qdq,
         "nodes_to_exclude": nodes_to_exclude,
     }
-    # enable_gemv_detection_for_trt was removed in modelopt >= 0.42
-    if "enable_gemv_detection_for_trt" in _params:
-        kwargs["enable_gemv_detection_for_trt"] = False
+    # enable_gemv_detection_for_trt moved from a named parameter into **kwargs in
+    # modelopt 0.42 — it was NOT removed. The old `in _params` test therefore went
+    # permanently False and fp8.py's `kwargs.get(..., True)` default silently
+    # re-enabled the probe: it promotes every MatMul/Gemm output to a graph output
+    # (ORT can never free a graph output) and runs the full model once, pinning
+    # multiple GB of activations in VRAM and writing a full extra copy of the model
+    # to disk. Detect **kwargs acceptance too so this can't silently regress again.
+    _takes_var_kw = any(
+        p.kind is _inspect.Parameter.VAR_KEYWORD for p in _inspect.signature(modelopt_quantize).parameters.values()
+    )
+    _gemv_param_supported = "enable_gemv_detection_for_trt" in _params or _takes_var_kw
+    # --- ITERATION 1 DIAGNOSTIC (round-5 quality regression, see the
+    # fp8-round-5-handoff plan) --- The capability check above is correct: it
+    # detects that modelopt 0.42+ moved this kwarg into **kwargs rather than
+    # dropping it, fixing a check that used to be permanently False. But round
+    # 5 then used that corrected detection to force
+    # enable_gemv_detection_for_trt=False, which silently changed *what gets
+    # quantized*: HEAD's broken check always left the kwarg unset, so
+    # modelopt's own default (True, fp8.py:218) applied and excluded every
+    # GEMV-shaped MatMul/Gemm (m or n == 1, can't use TensorCores) from FP8.
+    # Force it explicitly True here to reproduce that effective behaviour,
+    # isolated from the calibration-stride fix above. DO NOT SHIP this if it
+    # doesn't restore render sharpness — re-enabling the probe reintroduces
+    # the full-model GEMV probe (every MatMul/Gemm output promoted to a graph
+    # output, a full extra ~5.5 GB model copy on disk, a large VRAM spike, and
+    # extra build time) that round 5 removed for a reason.
+    if _gemv_param_supported:
+        kwargs["enable_gemv_detection_for_trt"] = True
+    else:
+        logger.warning(
+            "[FP8] modelopt build accepts no enable_gemv_detection_for_trt — "
+            "expect a full-model GEMV probe and a large VRAM/disk spike."
+        )
+    _gemv_enabled = kwargs.get("enable_gemv_detection_for_trt", True)
 
     logger.info(
         f"[FP8] ONNX-level FP8 quantization: {os.path.basename(onnx_path)}"
         f" → {os.path.basename(output_path)}"
         f" ({next(iter(calibration_data.values())).shape[0]} calibration samples,"
-        f" disable_mha_qdq={disable_mha_qdq})"
+        f" disable_mha_qdq={disable_mha_qdq}, enable_gemv_detection_for_trt={_gemv_enabled})"
     )
-    modelopt_quantize(**kwargs)
+    # The dtype-cast loop above and _align_calibration_rows can each leave a
+    # transient multi-GB copy of the calibration set as garbage — collect before
+    # handing off to modelopt so ORT's own (already large) allocations don't
+    # stack on top of copies Python hasn't reclaimed yet.
+    import gc as _gc
+
+    _gc.collect()
+
+    # Works around an nvidia-modelopt bug that makes ORT's CUDA arena degenerate during static
+    # calibration (arena_extend_strategy hardcoded to exact-size-only) — see
+    # _patches/modelopt_arena_patch.py for the full writeup, including why a related
+    # arena-shrinkage fix was tried and abandoned as unreachable on this ORT/CUDA EP stack.
+    # Scoped to this call only: applied immediately before modelopt_quantize and always
+    # reverted, so nothing leaks into any other caller of modelopt in this process.
+    from streamdiffusion._patches import modelopt_arena_patch
+
+    modelopt_arena_patch.apply()
+    try:
+        modelopt_quantize(**kwargs)
+    finally:
+        modelopt_arena_patch.revert()
 
     if not os.path.exists(output_path):
         raise RuntimeError(f"[FP8] modelopt_quantize completed but output not found: {output_path}")
+
+    # Round 8: modelopt's int8->fp8 scale conversion is inverted (fp8.py:70-74),
+    # mapping every calibrated amax to 36.0 in E4M3 space instead of 448.0. Must run
+    # before _assert_finite_qdq_scales so the finite check validates the shipped
+    # values, and before the .ok sentinel so a crash mid-rescale leaves no
+    # false-positive cache hit — the next run re-quantizes from scratch instead of
+    # double-applying the correction.
+    rescale_report = _rescale_fp8_qdq_scales(output_path, headroom=fp8_scale_headroom)
 
     _assert_finite_qdq_scales(output_path)
 
@@ -627,6 +2131,67 @@ def quantize_onnx_fp8(
         )
 
     # Sentinel marker — only written after modelopt_quantize returns. The builder's
-    # cache check looks for this file, so a crash mid-write leaves no false-positive.
+    # cache check only tests os.path.exists() on this file (never its content), so
+    # widening it from a plain "ok" string to JSON carrying the rescale report is
+    # safe for the cache-hit path; the report gives the parent process (builder.py)
+    # the uncalibrated-scale count without re-opening the multi-GB ONNX itself.
+    import json as _json
+
     with open(output_path + ".ok", "w") as _f:
-        _f.write("ok")
+        _json.dump({"ok": True, "rescale": rescale_report}, _f)
+
+
+def _main(argv: List[str]) -> int:
+    """Standalone entry point for the FP8 ONNX quantize stage.
+
+    Lets this one stage run in isolation — as its own process (builder.py's
+    _quant_fn launches it via `subprocess.run`) or invoked directly for local
+    iteration against a cached unet.engine.opt.onnx + calib_data.npz, without
+    paying for a full TouchDesigner + model-load cycle per attempt.
+
+    Usage: python -m streamdiffusion.acceleration.tensorrt.fp8_quantize '<json>'
+    JSON keys mirror quantize_onnx_fp8's args, plus calib_data_path (loaded here
+    via load_calibration_data so the multi-GB calibration set never has to cross
+    a process boundary as a subprocess argument):
+        onnx_path, output_path, calib_data_path, disable_mha_qdq,
+        use_cached_attn, use_feature_injection, use_controlnet, num_ip_layers,
+        fp8_scale_headroom, fp8_exclude_attention, fp8_exclude_ipadapter.
+    """
+    import json as _json
+
+    if len(argv) != 2:
+        print(
+            "Usage: python -m streamdiffusion.acceleration.tensorrt.fp8_quantize '<json args>'",
+            file=sys.stderr,
+        )
+        return 2
+
+    args = _json.loads(argv[1])
+    calib_data = load_calibration_data(args["calib_data_path"])
+    if calib_data is None:
+        print(f"[FP8] Calibration data missing: {args['calib_data_path']}", file=sys.stderr)
+        return 1
+
+    try:
+        quantize_onnx_fp8(
+            onnx_path=args["onnx_path"],
+            output_path=args["output_path"],
+            calibration_data=calib_data,
+            disable_mha_qdq=args.get("disable_mha_qdq", True),
+            use_cached_attn=args.get("use_cached_attn", False),
+            use_feature_injection=args.get("use_feature_injection", False),
+            use_controlnet=args.get("use_controlnet", False),
+            num_ip_layers=args.get("num_ip_layers", 0),
+            fp8_scale_headroom=args.get("fp8_scale_headroom", 1.0),
+            fp8_exclude_attention=args.get("fp8_exclude_attention", False),
+            fp8_exclude_ipadapter=args.get("fp8_exclude_ipadapter", False),
+        )
+    except Exception:
+        logger.exception("[FP8] quantize_onnx_fp8 failed")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    sys.exit(_main(sys.argv))

--- a/src/streamdiffusion/config.py
+++ b/src/streamdiffusion/config.py
@@ -79,7 +79,7 @@ def create_wrapper_from_config(config: Dict[str, Any], **overrides) -> Any:
             seed_blend_config = final_config["seed_blending"]
             prepare_params_with_blending["seed_list"] = seed_blend_config.get("seed_list", [])
             prepare_params_with_blending["seed_interpolation_method"] = seed_blend_config.get(
-                "interpolation_method", "linear"
+                "interpolation_method", "average"
             )
 
         wrapper.prepare(**prepare_params_with_blending)
@@ -95,7 +95,7 @@ def create_wrapper_from_config(config: Dict[str, Any], **overrides) -> Any:
         seed_blend_config = final_config["seed_blending"]
         wrapper.update_stream_params(
             seed_list=seed_blend_config.get("seed_list", []),
-            seed_interpolation_method=seed_blend_config.get("interpolation_method", "linear"),
+            seed_interpolation_method=seed_blend_config.get("interpolation_method", "average"),
         )
 
     return wrapper
@@ -106,6 +106,11 @@ def _extract_wrapper_params(config: Dict[str, Any]) -> Dict[str, Any]:
     param_map = {
         "model_id_or_path": config.get("model_id", "stabilityai/sd-turbo"),
         "t_index_list": config.get("t_index_list", list(DEFAULTS["t_index_list"])),
+        # Reference step count for FP8 build-time calibration schedule derivation
+        # (see StreamDiffusionWrapper.__init__'s num_inference_steps docstring).
+        # Mirrors _extract_prepare_params's identical lookup below so a build-time
+        # config and the first prepare() call agree on the deployment grid.
+        "num_inference_steps": config.get("num_inference_steps", DEFAULTS["num_inference_steps"]),
         "lora_dict": config.get("lora_dict"),
         "mode": config.get("mode", "img2img"),
         "output_type": config.get("output_type", "pil"),
@@ -143,6 +148,10 @@ def _extract_wrapper_params(config: Dict[str, Any]) -> Dict[str, Any]:
         "build_engines_if_missing": config.get("build_engines_if_missing", True),
         "fp8_allow_fp16_fallback": config.get("fp8_allow_fp16_fallback", False),
         "fp8_mha_qdq": config.get("fp8_mha_qdq", False),
+        "fp8_scale_headroom": config.get("fp8_scale_headroom", 1.0),
+        "fp8_exclude_attention": config.get("fp8_exclude_attention", False),
+        "fp8_exclude_ipadapter": config.get("fp8_exclude_ipadapter", False),
+        "fp8_calibration_style_image": config.get("fp8_calibration_style_image"),
     }
     if config.get("controlnets"):
         param_map["use_controlnet"] = True
@@ -241,7 +250,7 @@ def _extract_prepare_params(config: Dict[str, Any]) -> Dict[str, Any]:
         seed_blend_config = config["seed_blending"]
         prepare_params["seed_blending"] = {
             "seed_list": seed_blend_config.get("seed_list", []),
-            "interpolation_method": seed_blend_config.get("interpolation_method", "linear"),
+            "interpolation_method": seed_blend_config.get("interpolation_method", "average"),
             "enable_caching": seed_blend_config.get("enable_caching", True),
         }
 
@@ -371,7 +380,7 @@ def create_prompt_blending_config(
 def create_seed_blending_config(
     base_config: Dict[str, Any],
     seed_list: List[Tuple[int, float]],
-    interpolation_method: str = "linear",
+    interpolation_method: str = "average",
     enable_caching: bool = True,
 ) -> Dict[str, Any]:
     """Create a configuration with seed blending settings"""
@@ -479,8 +488,8 @@ def _validate_config(config: Dict[str, Any]) -> None:
                     raise ValueError(f"_validate_config: Prompt weight {i} must be a non-negative number")
 
         interpolation_method = blend_config.get("interpolation_method", "slerp")
-        if interpolation_method not in ["linear", "slerp", "cosine_weighted"]:
-            raise ValueError("_validate_config: interpolation_method must be 'linear', 'slerp', or 'cosine_weighted'")
+        if interpolation_method not in ["average", "slerp", "cosine_weighted"]:
+            raise ValueError("_validate_config: interpolation_method must be 'average', 'slerp', or 'cosine_weighted'")
 
     # Validate seed blending configuration if present
     if "seed_blending" in config:

--- a/src/streamdiffusion/param_schema.py
+++ b/src/streamdiffusion/param_schema.py
@@ -16,10 +16,14 @@ with ``PARAM_NAMES`` / ``UPDATER_PARAM_NAMES``, so drift is *caught*, not
 
 Note on ``default`` vs. the runtime signatures: every parameter in
 ``update_stream_params`` defaults to ``None`` at the call-site (meaning
-"leave the current value unchanged"), except the two interpolation-method
-Literals. ``ParamSpec.default`` here is a *different* concept — the
-concrete construction-time value — and intentionally does not mirror the
-``None`` sentinels.
+"leave the current value unchanged") — including the two interpolation-method
+Literals, which are additionally *sticky*: the last explicitly-supplied value
+is persisted on the updater (``_last_prompt_interpolation_method`` /
+``_last_seed_interpolation_method``) and re-applied whenever a caller omits
+it, so a method-only update takes effect immediately and a later list-only
+update doesn't silently revert it. ``ParamSpec.default`` here is a *different*
+concept — the concrete construction-time value — and intentionally does not
+mirror the ``None`` sentinels.
 
 This module has no torch import and no dependency on the rest of the
 ``streamdiffusion`` package, so it stays cheap to import in isolation
@@ -31,11 +35,11 @@ for current consumers.
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Tuple
+from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Set, Tuple
 
 # Interpolation-method aliases shared by the wrapper and updater signatures.
-PromptInterpolationMethod = Literal["linear", "slerp", "cosine_weighted"]
-SeedInterpolationMethod = Literal["linear", "slerp"]
+PromptInterpolationMethod = Literal["average", "slerp", "cosine_weighted"]
+SeedInterpolationMethod = Literal["average", "slerp", "cosine_weighted"]
 
 # The four cfg_type values StreamDiffusion.__init__ accepts (pipeline.py's single
 # assignment choke point, :85). cfg_type is construction-time only — it is not in
@@ -56,7 +60,7 @@ class ParamSpec:
     default:
         Construction-time default (see module docstring) — NOT the
         ``update_stream_params`` runtime default, which is ``None`` for
-        all but the two interpolation-method params.
+        every param.
     updater:
         Whether this param is forwarded to
         ``StreamParameterUpdater.update_stream_params``. False only for
@@ -85,7 +89,7 @@ PARAMS: Tuple[ParamSpec, ...] = (
     ParamSpec("prompt_interpolation_method", "slerp"),
     ParamSpec("normalize_prompt_weights", True),
     ParamSpec("seed_list", None),
-    ParamSpec("seed_interpolation_method", "linear"),
+    ParamSpec("seed_interpolation_method", "average"),
     ParamSpec("normalize_seed_weights", True),
     ParamSpec("controlnet_config", None),
     ParamSpec("ipadapter_config", None),
@@ -176,3 +180,253 @@ def rescale_t_index_list(old_t_list: List[int], old_num_steps: int, new_num_step
     """
     scale_factor = (new_num_steps - 1) / (old_num_steps - 1) if old_num_steps > 1 else 1.0
     return [min(round(t * scale_factor), new_num_steps - 1) for t in old_t_list]
+
+
+def compute_sub_timesteps(timesteps: Any, t_index_list: List[int]) -> List[Any]:
+    """Select the UNet-facing timestep value for each configured t_index.
+
+    Extracted 1:1 from pipeline.py's prepare() (``for t in self.t_list:
+    self.sub_timesteps.append(self.timesteps[t])``) and
+    stream_parameter_updater.py's ``_update_timestep_calculations``, which
+    duplicate the exact same indexing.
+
+    ``timesteps`` must already be the scheduler's *materialised* grid
+    (``scheduler.timesteps`` after ``set_timesteps`` — and, in prepare(),
+    after any sampler-specific spacing override has been applied). This
+    helper deliberately does not call ``set_timesteps`` itself: doing so
+    would silently discard prepare()'s spacing override for the
+    ``_SPACING_SAMPLERS`` samplers (see pipeline.py's ``prepare()``).
+    """
+    return [timesteps[t] for t in t_index_list]
+
+
+# LCM/TCD ignore timestep_spacing natively; only these samplers get the
+# spacing override in materialise_timestep_grid. Mirrors pipeline.py
+# prepare()'s local _SPACING_SAMPLERS (:615) — duplicated here too rather
+# than imported, so this module stays import-free of the rest of the
+# package (see module docstring).
+_SPACING_SAMPLERS: Set[str] = frozenset({"simple", "sgm_uniform", "ddim"})
+
+
+def materialise_timestep_grid(
+    scheduler: Any,
+    num_inference_steps: int,
+    sampler_type: str,
+    device: Any,
+    get_spaced_timesteps: Callable[[str, int], Any],
+) -> Any:
+    """Build the scheduler's timestep grid, applying the sampler-specific
+    spacing override StreamDiffusion's own schedules use.
+
+    Extracted 1:1 from pipeline.py's prepare() (:612-620), which is also
+    duplicated verbatim in wrapper.py's fp8-calibration path (~:2919-2926,
+    self-documented there as a duplicate of this exact block). Both call
+    sites — and any standalone probe — should call this instead of
+    reimplementing the ``_SPACING_SAMPLERS`` override, so they can never
+    silently drift apart on what "spacing override" means. This is the
+    other half of the contract ``compute_sub_timesteps`` names in its own
+    docstring: that helper deliberately won't call ``set_timesteps`` itself
+    because doing so would discard this override.
+
+    LCM/TCD ignore ``timestep_spacing`` natively — only samplers in
+    ``_SPACING_SAMPLERS`` ("simple", "sgm_uniform", "ddim") get it; "normal"
+    (LCM's native grid) passes through untouched.
+
+    ``get_spaced_timesteps`` takes ``(spacing, num_inference_steps)`` and
+    returns a tensor already placed on a device — see
+    ``StreamDiffusion._get_spaced_timesteps``, which callers with a live
+    pipeline should pass bound (``pipeline._get_spaced_timesteps``); a probe
+    with no pipeline instance can pass any equivalent free function. Mutates
+    ``scheduler.timesteps`` in place (matching prepare()'s own behaviour) and
+    also returns the resulting grid, moved to ``device``, for callers that
+    only want the return value (e.g. a standalone probe).
+    """
+    scheduler.set_timesteps(num_inference_steps, device)
+    if sampler_type in _SPACING_SAMPLERS:
+        spacing = getattr(scheduler.config, "timestep_spacing", "leading")
+        if spacing in ("trailing", "linspace", "leading"):
+            scheduler.timesteps = get_spaced_timesteps(spacing, num_inference_steps).to(device)
+    return scheduler.timesteps.to(device)
+
+
+# Ghost-bleed inter-step beta_sqrt threshold. See bleed_risk_message.
+GHOST_BLEED_THRESHOLD: float = 0.75
+
+
+def bleed_risk_message(
+    inter_step_betas: Sequence[float],
+    t_list: Sequence[int],
+    use_denoising_batch: bool,
+    do_add_noise: bool,
+    threshold: float = GHOST_BLEED_THRESHOLD,
+) -> Optional[str]:
+    """Warning text if the current schedule risks ghost bleed from the
+    previous frame's content, or None if it doesn't apply.
+
+    Extracted 1:1 from stream_parameter_updater.py's
+    ``_update_timestep_calculations`` (~:1216-1236). Only meaningful on the
+    batched multi-step path: with ``do_add_noise=False`` the denoising-batch
+    pipelining trick hands each inter-step slot the *previous frame's*
+    partially-denoised latent with no noise re-injected, so a large
+    inter-step beta_sqrt (marginal noise std at that step) means the model
+    is being asked to resolve a residual it was never given the noise budget
+    to explain — audible as bleed from the prior frame.
+
+    ``inter_step_betas`` must be the per-step ``beta_prod_t_sqrt`` values for
+    the sub_timesteps *after* the first (index 0 has no "previous step" to
+    bleed from), pre-``repeat_interleave`` — i.e. ``beta_prod_t_sqrt[1:, 0,
+    0, 0]`` in pipeline.py's tensor layout.
+
+    Callers own their own logging call (this returns text, not a log side
+    effect), so the same message can be shared between
+    ``_update_timestep_calculations`` and a schedule-diagnostics dump without
+    either one depending on the other's logger.
+    """
+    if not (use_denoising_batch and not do_add_noise and len(t_list) > 1):
+        return None
+    if not inter_step_betas:
+        return None
+    max_beta = max(inter_step_betas)
+    if max_beta <= threshold:
+        return None
+    return (
+        f"do_add_noise=False + use_denoising_batch: inter-step beta_sqrt={max_beta:.3f} "
+        f"(t_index={list(t_list[1:])}) exceeds {threshold:.2f}. Previous-frame ghost bleed likely -- "
+        "consider enabling do_add_noise (reference fork default)."
+    )
+
+
+def _band_interior_ints(span_len: int, count: int) -> List[int]:
+    """Pick up to ``count`` offsets into ``range(span_len)``, at sub-interval
+    *centers* rather than endpoints: ``floor((i + 0.5) * span_len / count)``
+    for ``i in range(count)``.
+
+    Unlike an endpoint-inclusive linspace, these offsets never land on 0 or
+    ``span_len - 1`` unless the band is so narrow relative to ``count`` that
+    centers collapse onto the edges. This matters because adjacent bands are
+    half-open and touch at their boundary, and a caller's configured values
+    often sit exactly on a decade boundary — an endpoint sampler wastes
+    budget re-picking those already-``picked`` boundary values (see
+    ``build_calibration_t_indices``). May return fewer than ``count``
+    distinct values if the span is narrower than the request — callers dedup
+    via a set.
+    """
+    if count <= 0 or span_len <= 0:
+        return []
+    return [int(min((i + 0.5) * span_len // count, span_len - 1)) for i in range(count)]
+
+
+def _widest_gap_index(lo: int, hi: int, picked: Set[int]) -> Optional[int]:
+    """The unpicked index in ``[lo, hi]`` sitting in the band's widest
+    remaining gap — furthest from any already-picked value. Ties resolve
+    toward the band midpoint (then the lowest index), keeping the pick
+    interior for the same reason ``_band_interior_ints`` avoids endpoints.
+    None when the band holds no unpicked index.
+    """
+    candidates = [i for i in range(lo, hi + 1) if i not in picked]
+    if not candidates:
+        return None
+    mid = (lo + hi) / 2
+
+    def _distance(i: int) -> int:
+        return min(abs(i - p) for p in picked) if picked else 0
+
+    return min(candidates, key=lambda i: (-_distance(i), abs(i - mid), i))
+
+
+def build_calibration_t_indices(
+    t_index_list: List[int],
+    num_inference_steps: int,
+    budget: int,
+) -> List[int]:
+    """Derive a calibration t_index schedule covering the timestep region
+    deployment actually visits, per a neighbour-midpoint band rule: each
+    distinct, clamped value in ``t_index_list`` owns the index range up to
+    the midpoint with its neighbours, so bands are derived from the values
+    themselves rather than from a fixed decade grid. The first band floors
+    at 1 and the last extends to ``num_inference_steps - 1``, so the bands
+    partition ``[1, num_inference_steps - 1]`` with no gaps and no overlaps,
+    and every configured value is provably inside its own band — including
+    the single-entry case, where one band spans the full range. Band 0's
+    floor is 1, not 0 — index 0 is the highest-noise raw timestep (~999) and
+    must never be calibrated implicitly; it only enters the result if
+    ``t_index_list`` configures it explicitly. Bands scale automatically with
+    the number of distinct values in ``t_index_list``, so this stays correct
+    for whatever step count a static TRT engine has locked in for its
+    lifetime.
+
+    Every value in ``t_index_list`` is always included in the result — the
+    exact deployment points must never be missed, even though only the
+    *union* of bands matters for FP8 scale correctness (a per-tensor amax at
+    a given raw timestep doesn't care which step index produced it). The
+    remaining budget (``budget - len(set(t_index_list))``) is spread as
+    evenly as possible across the bands, sampling each band's *interior*
+    (see ``_band_interior_ints``) so spare slots don't collide with the
+    band-boundary values ``t_index_list`` typically already occupies. Any
+    per-band budget a narrow band can't absorb spills forward into the
+    remaining bands; a later band whose own interior picks collide with
+    already-picked values can still fall short even after that spill, so a
+    final round-robin top-up (widest remaining gap per band) mops up
+    whatever is left, guaranteeing the full budget is consumed whenever the
+    bands have room for it. A live ``/t_list`` change that stays within its
+    calibrated band doesn't need an engine rebuild.
+
+    Returns a sorted-ascending, deduplicated list of t_index values. Normally
+    ``len(result) <= budget``; if ``budget < len(set(t_index_list))`` the
+    configured values still all win and the result exceeds budget — never
+    drop a deployment point to fit a smaller budget.
+    """
+    max_idx = max(num_inference_steps - 1, 0)
+
+    picked = {min(max(t, 0), max_idx) for t in t_index_list}
+
+    # Bands derive from the configured values themselves (sorted ascending),
+    # not a fixed decade grid -- band k owns the range up to the midpoint
+    # with its neighbours, so every value is guaranteed to land inside the
+    # band derived for it, regardless of len(t_index_list) or spacing.
+    values = sorted(picked)
+    n_bands = max(len(values), 1)
+    bands = []
+    if not values:
+        bands.append((min(1, max_idx), max_idx))
+    else:
+        for k, t in enumerate(values):
+            lo = 1 if k == 0 else (values[k - 1] + t) // 2 + 1
+            hi = max_idx if k == n_bands - 1 else (t + values[k + 1]) // 2
+            bands.append((min(max(lo, 0), max_idx), min(hi, max_idx)))
+
+    remaining = max(budget - len(picked), 0)
+    base, extra = divmod(remaining, n_bands)
+    band_budgets = [base + (1 if i < extra else 0) for i in range(n_bands)]
+
+    # Two passes so unused budget (band narrower than its share) spills
+    # forward into later bands instead of being silently dropped.
+    spill = 0
+    for i, (lo, hi) in enumerate(bands):
+        span_len = hi - lo + 1
+        want = band_budgets[i] + spill
+        span = list(range(lo, hi + 1))
+        before = len(picked)
+        for j in _band_interior_ints(span_len, want):
+            picked.add(span[j])
+        used = len(picked) - before
+        spill = max(want - used, 0) if used < want else 0
+
+    # Forward-only spill can still leave budget on the table -- the last band
+    # has nowhere further to spill into if its own interior picks collide
+    # with already-picked values (see module-level defect notes). Top up by
+    # sweeping every band's widest remaining gap, round-robin, until the
+    # budget is met or every band is saturated.
+    while len(picked) < budget:
+        progress = False
+        for lo, hi in bands:
+            if len(picked) >= budget:
+                break
+            idx = _widest_gap_index(lo, hi, picked)
+            if idx is not None:
+                picked.add(idx)
+                progress = True
+        if not progress:
+            break
+
+    return sorted(picked)

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -10,7 +10,13 @@ from PIL import Image
 
 from .image_utils import postprocess_image
 from .model_detection import detect_model
-from .param_schema import PromptInterpolationMethod, SeedInterpolationMethod
+from .param_schema import (
+    PromptInterpolationMethod,
+    SeedInterpolationMethod,
+    build_calibration_t_indices,
+    compute_sub_timesteps,
+    materialise_timestep_grid,
+)
 from .pipeline import StreamDiffusion
 from .tools.gpu_profiler import configure as _configure_profiler
 from .tools.gpu_profiler import profiler
@@ -30,6 +36,240 @@ def _is_oom_error(exc: BaseException) -> bool:
     return (
         "out of memory" in error_msg or "outofmemory" in error_msg or "oom" in error_msg or "cuda error" in error_msg
     )
+
+
+def _encode_fp8_calibration_images(ipa: Any, images: List[Any]) -> Tuple[Optional[torch.Tensor], int, int]:
+    """Encode `images` through `ipa.get_image_embeds`, retrying per-image on
+    failure so one bad image can't cost the whole calibration set
+    (fp8-round-9.1 §10).
+
+    `get_image_embeds` is all-or-nothing: under `type: faceid` the encoder is
+    InsightFace/ArcFace, and `extract_face_embeddings` raises `ValueError` on
+    any image with no detectable face
+    (`diffusers_ipadapter/ip_adapter/face_utils.py`) *before any embedding is
+    returned* — so one non-face image in a calibration folder shared with a
+    CLIP-based adapter would previously delete every other image's
+    contribution too, degrading the whole set to zero-pad.
+
+    Batch-encodes first — identical to the pre-hardening call, and the
+    common case costs nothing extra. On failure with more than one image,
+    retries one image at a time, keeping survivors and warning once per
+    rejection. A single-image "batch" that fails is not retried (there is
+    nothing smaller to retry with) — the caller falls through to the next
+    calibration source instead.
+
+    Per-image encoding is not an approximation of the batch call: CLIP,
+    ArcFace, and the projection all run per row with no cross-image
+    interaction (`ip_adapter.py:163-251`), so the retry path's surviving
+    rows are identical to what the batch call would have produced for the
+    same images.
+
+    Returns `(embeds, kept, total)`. `embeds` is `None` only when `kept == 0`
+    (nothing survived); `total` is always `len(images)`, for the caller's
+    "n=<kept> of <total>" log line. Never raises — every exception from
+    `ipa.get_image_embeds` is caught and logged here.
+    """
+    total = len(images)
+    try:
+        embeds, _ = ipa.get_image_embeds(images=images)
+        return embeds, total, total
+    except Exception as e:
+        if total <= 1:
+            logger.warning(f"[TRT] FP8 calib image rejected by adapter ({type(e).__name__}: {e}); skipping.")
+            return None, 0, total
+        logger.warning(
+            f"[TRT] FP8 calib: batch encode of {total} image(s) failed "
+            f"({type(e).__name__}: {e}); retrying individually."
+        )
+    kept: List[torch.Tensor] = []
+    for i, image in enumerate(images):
+        try:
+            embed, _ = ipa.get_image_embeds(images=[image])
+            kept.append(embed)
+        except Exception as e:
+            logger.warning(
+                f"[TRT] FP8 calib image {i + 1}/{total} rejected by adapter ({type(e).__name__}: {e}); skipping."
+            )
+    if not kept:
+        return None, 0, total
+    return torch.cat(kept, dim=0), len(kept), total
+
+
+def _resolve_fp8_ipadapter_calibration_tokens(
+    ipa: Any,
+    cached_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    style_images: Optional[List[Any]] = None,
+) -> Tuple[Optional[np.ndarray], str]:
+    """Resolve real (or surrogate) IP-Adapter projection tokens for FP8
+    calibration's encoder_hidden_states reconciliation (fp8-round-9,
+    fp8-round-9.1), instead of the zero-pad fallback (None).
+
+    fp8-round-9 dispatched on adapter flavour (`is_faceid and not is_plus`),
+    which happened to match the FaceID config the round was measured against
+    but left every other adapter type — including plain `type: regular` —
+    silently zero-padded regardless of flavour. fp8-round-9.1 dispatches on
+    `image_proj_model.proj`'s actual structure instead, which is what
+    determines whether the zeros-surrogate call is even well-formed:
+
+    - `proj` is an `nn.Sequential` (FaceIDProjectionModel): `proj[0].in_features`
+      is `id_embeddings_dim` (512). Measured in the fp8-round-9 plan.
+    - `proj` is a bare `nn.Linear` (ImageProjModel, regular adapters):
+      `proj.in_features` is `clip_embeddings_dim`. `forward()` is
+      `Linear -> reshape(-1, 4, 2048) -> LayerNorm`, so a zeros input yields
+      the LayerNorm-normalised bias — non-degenerate and O(1), the same
+      structural argument fp8-round-9 measured for FaceID.
+    - Anything else (Plus / Resampler / FaceID-Plus-v2): call signature is
+      unmeasured here — skip, zero-pad fallback applies, unchanged from
+      fp8-round-9.
+
+    fp8-round-9.1 (this revision) also adds `style_images`, a fourth and
+    highest-priority source: a list of PIL images (or anything
+    `ipa.get_image_embeds` accepts), encoded through the adapter's own
+    runtime call — the same one `IPAdapterEmbeddingPreprocessor` uses at
+    inference. Unlike the zeros-surrogate, `get_image_embeds` dispatches
+    FaceID/Plus/regular internally, so it is not limited to the two `proj`
+    shapes this function otherwise recognizes. A configured image set beats
+    an incidentally-cached runtime embedding — an operator who deliberately
+    supplies calibration images expects them used, not silently superseded
+    by whatever the last live frame happened to cache.
+
+    `get_image_embeds` has a side effect (`ipa.set_tokens(len(images) *
+    ipa.num_tokens)`) that mutates `num_tokens` on every live
+    `IPAttnProcessor` in `ipa.pipe.unet.attn_processors` — correct for its
+    normal single-frame runtime call (batch=1), but a stale artifact here
+    whenever `style_images` has more than one entry (e.g. 2 images leaves
+    `num_tokens=8` sitting on live state meant for the next single-frame
+    call). Restored to the per-image invariant (`ipa.num_tokens`) in a
+    `finally` so a multi-image calibration set can't corrupt the live
+    adapter's runtime state for the next real frame.
+
+    fp8-round-9.1 §10: the `style_images` branch encodes via
+    `_encode_fp8_calibration_images`, which retries per-image on a batch
+    failure and keeps whatever survives — see its docstring for why. Unlike
+    the surrogate branch below, a `style_images` encode failure therefore
+    does NOT propagate; if nothing survives, this function falls through to
+    `cached_embeddings` or the zeros-surrogate instead. This matters most
+    under `type: faceid`: ArcFace raises on any image with no detectable
+    face, and a calibration folder shared with a CLIP-based adapter could
+    otherwise contain one. The surrogate/cached branches are unchanged —
+    they still run arbitrary third-party forward code with no internal
+    try/except, so callers must keep wrapping the whole call, since an FP8
+    calibration token failure must never hard-fail an engine build.
+
+    Returns ``(tokens_or_None, method)`` where ``method`` is one of
+    ``"image"`` (`_encode_fp8_calibration_images` kept at least one row),
+    ``"cached"`` (real cached embedding used verbatim), ``"surrogate"``
+    (`image_proj_model(zeros)`, `proj` shape recognized), or ``"skipped"``
+    (`ipa` is None or `proj` shape unrecognized — zero-pad fallback applies).
+    """
+    if ipa is None:
+        return None, "skipped"
+    if style_images:
+        try:
+            image_embeds, _kept, _total = _encode_fp8_calibration_images(ipa, style_images)
+        finally:
+            try:
+                ipa.set_tokens(ipa.num_tokens)
+            except Exception:
+                pass
+        if image_embeds is not None:
+            return image_embeds.detach().cpu().numpy(), "image"
+        # Every configured image was rejected by the adapter (e.g. no
+        # detectable face under FaceID) -- fall through rather than losing
+        # calibration entirely to a bad image.
+    if cached_embeddings is not None:
+        return cached_embeddings[0].detach().cpu().numpy(), "cached"
+    proj = getattr(getattr(ipa, "image_proj_model", None), "proj", None)
+    if isinstance(proj, torch.nn.Sequential):
+        in_features = proj[0].in_features
+    elif isinstance(proj, torch.nn.Linear):
+        in_features = proj.in_features
+    else:
+        return None, "skipped"
+    zeros = torch.zeros(1, in_features, device=ipa.device, dtype=ipa.dtype)
+    with torch.inference_mode():
+        tokens = ipa.image_proj_model(zeros)
+    return tokens.detach().cpu().numpy(), "surrogate"
+
+
+def _load_fp8_calibration_style_images(path: Optional[str]) -> Optional[List["Image.Image"]]:
+    """Load calibration images for FP8 IP-Adapter token resolution
+    (fp8-round-9.1) from `fp8_calibration_style_image`: a single image file,
+    or a directory of them, loaded in sorted filename order — deterministic,
+    and the same order `engine_manager.py`'s `_calibration_image_signature`
+    hashes in, so the `--ci<hash>` cache tag matches what was actually loaded.
+
+    Returns None (not an empty list) when nothing was configured, the path
+    doesn't exist, or nothing loadable was found, so callers can treat it the
+    same as "not configured" and fall through to the next calibration source.
+    """
+    if not path:
+        return None
+    from .acceleration.tensorrt.fp8_quantize import _list_calibration_images
+
+    p = Path(path)
+    if not p.exists():
+        logger.warning(f"[TRT] fp8_calibration_style_image path not found: {path}")
+        return None
+    files = _list_calibration_images(path)
+    images: List[Any] = []
+    for f in files:
+        try:
+            images.append(Image.open(f).convert("RGB"))
+        except Exception as e:
+            logger.warning(f"[TRT] Failed to load calibration image {f}: {type(e).__name__}: {e}")
+    return images or None
+
+
+# fp8-round-9.1 §10: `type: faceid` encodes through InsightFace/ArcFace, which
+# raises ValueError on any image with no detectable face (face_utils.py's
+# extract_face_embeddings) — so a calibration folder shared with a CLIP-based
+# adapter (regular/plus) risks feeding it non-face art and losing the whole
+# calibration set. Two folders, keyed on encoder *modality* rather than the
+# config `type` string, because regular and plus both encode through CLIP and
+# want identical inputs — a third modality just adds one more entry here.
+_FP8_CALIB_MODE_DIRS = {"faceid": "faces"}
+_FP8_CALIB_DEFAULT_MODE_DIR = "general"
+
+
+def _resolve_fp8_calibration_dir(path: Optional[str], adapter_type: Optional[str]) -> Optional[str]:
+    """Redirect `fp8_calibration_style_image` to its adapter-mode subfolder
+    (fp8-round-9.1 §10), e.g. `images/calibration` -> `images/calibration/faces`
+    for `type: faceid`, so a mode switch can't hand ArcFace an image with no
+    face in it.
+
+    Computed once here and threaded into *both* `EngineManager.get_engine_path`
+    (the `--ci<hash>` cache key) and `_load_fp8_calibration_style_images` (the
+    actual load) from the same call site in `configure_engines`/
+    `compile_and_load_engine` — never re-derived independently at each site —
+    so the two can't disagree about which folder is in play. Same reasoning
+    that put `_CALIBRATION_IMAGE_EXTENSIONS`/`_list_calibration_images` in one
+    module shared by both.
+
+    Returns `path` **unchanged** whenever it can't confidently improve on it:
+    `path` is `None`, names a single file (no mode folder applies to a single
+    explicit file), doesn't exist, or its mode subfolder is missing or empty
+    of recognized images. In every unchanged case the existing warnings in
+    the loader/hasher fire exactly as before — this function only adds a
+    redirect, it never removes a diagnostic.
+    """
+    if not path:
+        return path
+    from .acceleration.tensorrt.fp8_quantize import _list_calibration_images
+
+    p = Path(path)
+    if not p.is_dir():
+        return path
+    subdir_name = _FP8_CALIB_MODE_DIRS.get(adapter_type, _FP8_CALIB_DEFAULT_MODE_DIR)
+    candidate = p / subdir_name
+    if candidate.is_dir() and _list_calibration_images(str(candidate)):
+        return str(candidate)
+    logger.warning(
+        f"[TRT] FP8 calib: no usable '{subdir_name}/' subfolder under {path} for "
+        f"type={adapter_type!r}; using the flat folder — images unsuited to this "
+        f"adapter mode will be skipped at encode time rather than aborting the set."
+    )
+    return path
 
 
 # Text-encoder CPU offload frees ~1.6 GB VRAM but each prompt update pays a
@@ -149,11 +389,42 @@ class StreamDiffusionWrapper:
         fi_strength: float = 0.75,
         fi_threshold: float = 0.98,
         fp8: bool = False,
+        # Reference step count for FP8 build-time calibration schedule derivation
+        # (see _load_model's FP8 build seam) — NOT the live num_inference_steps
+        # used by prepare()/update_stream_params, which can still change at
+        # runtime. Defaults to 50 to match the internal warm-up prepare() call
+        # below; set it from config so a non-default deployment step count still
+        # calibrates the timestep region inference actually visits.
+        num_inference_steps: int = 50,
         static_shapes: bool = False,
         fp8_allow_fp16_fallback: bool = False,
         # Experimental: include attention BMM1/BMM2 in FP8 Q/DQ (modelopt disable_mha_qdq=False).
         # Forks the engine cache tag to --fp8v3-mhaq; default False keeps production identity.
         fp8_mha_qdq: bool = False,
+        # fp8-round-8: corrects modelopt's inverted INT8->FP8 scale-conversion factor
+        # (see fp8_quantize.py::_rescale_fp8_qdq_scales). 1.0 = full E4M3 range; >1.0
+        # trades resolution for outlier headroom. Forks the cache tag (--fp8v4-hr<N>).
+        fp8_scale_headroom: float = 1.0,
+        # fp8-round-8 fallback lever: excludes the two attention BMMs (QK^T, softmax@V)
+        # from FP8 Q/DQ entirely, running them FP16. Should not be needed once
+        # fp8_scale_headroom's correction is in place — see the fp8-round-8 plan.
+        # Forks the cache tag (--fp8v4-noattn).
+        fp8_exclude_attention: bool = False,
+        # fp8-round-9 fallback lever: excludes the three IP-Adapter cross-attention
+        # activation tensors (Mul_4/Mul_5/Transpose_4) from FP8 Q/DQ, running them
+        # FP16. Orthogonal to fp8_exclude_attention — see
+        # _IPADAPTER_ACTIVATION_EXCLUDE_PATTERNS's comment for the non-overlap.
+        # Forks the cache tag (--fp8v4-noip).
+        fp8_exclude_ipadapter: bool = False,
+        # fp8-round-9.1: real calibration source for the IP-Adapter cross-attention
+        # branch — a single image file, or a directory of them (loaded sorted via
+        # PIL), encoded through ipa.get_image_embeds — the same call the runtime
+        # IPAdapterEmbeddingPreprocessor uses. Highest-priority calibration token
+        # source: beats both a cached runtime embedding and the zeros-surrogate
+        # (see _resolve_fp8_ipadapter_calibration_tokens). None (default) preserves
+        # current behavior. Forks the cache tag (--ci<hash-of-file-contents>) since
+        # the calibration image set is part of the build recipe.
+        fp8_calibration_style_image: Optional[str] = None,
         builder_optimization_level: Optional[int] = None,
         # CUDA IPC output (SD→TD zero-copy GPU transport via cuda-link)
         use_cuda_ipc_output: bool = False,
@@ -401,6 +672,10 @@ class StreamDiffusionWrapper:
         self.static_shapes = static_shapes
         self.fp8_allow_fp16_fallback = fp8_allow_fp16_fallback
         self.fp8_mha_qdq = fp8_mha_qdq
+        self.fp8_scale_headroom = fp8_scale_headroom
+        self.fp8_exclude_attention = fp8_exclude_attention
+        self.fp8_exclude_ipadapter = fp8_exclude_ipadapter
+        self.fp8_calibration_style_image = fp8_calibration_style_image
         self.builder_optimization_level = builder_optimization_level
         # Per-engine VAE optlvl (None → inherit builder_optimization_level).
         # Tiny-VAE engines are small and gain little from optlvl 4 — defaulting to
@@ -448,6 +723,7 @@ class StreamDiffusionWrapper:
             fi_strength=fi_strength,
             fi_threshold=fi_threshold,
             fp8=fp8,
+            num_inference_steps=num_inference_steps,
         )
 
         # Store skip_diffusion on wrapper for execution flow control
@@ -497,9 +773,9 @@ class StreamDiffusionWrapper:
         guidance_scale: float = 1.2,
         delta: float = 1.0,
         # Blending-specific parameters (only used when prompt is a list)
-        prompt_interpolation_method: Literal["linear", "slerp", "cosine_weighted"] = "slerp",
+        prompt_interpolation_method: Literal["average", "slerp", "cosine_weighted"] = "slerp",
         seed_list: Optional[List[Tuple[int, float]]] = None,
-        seed_interpolation_method: Literal["linear", "slerp"] = "linear",
+        seed_interpolation_method: Literal["average", "slerp", "cosine_weighted"] = "average",
     ) -> None:
         """
         Prepares the model for inference.
@@ -524,13 +800,13 @@ class StreamDiffusionWrapper:
             Valid range [1.0, 5.0] (clamped); only used by cfg_type
             'self'/'initialize' at guidance_scale > 1. Values above
             guidance_scale/(guidance_scale-1) re-inject noise.
-        prompt_interpolation_method : Literal["linear", "slerp"], optional
+        prompt_interpolation_method : Literal["average", "slerp", "cosine_weighted"], optional
             Method for interpolating between prompt embeddings (only used for prompt blending),
             by default "slerp".
         seed_list : Optional[List[Tuple[int, float]]], optional
             List of seeds with weights for blending, by default None.
-        seed_interpolation_method : Literal["linear", "slerp"], optional
-            Method for interpolating between seed noise tensors, by default "linear".
+        seed_interpolation_method : Literal["average", "slerp", "cosine_weighted"], optional
+            Method for interpolating between seed noise tensors, by default "average".
         """
 
         # Handle both single prompt and prompt blending
@@ -634,7 +910,7 @@ class StreamDiffusionWrapper:
         self,
         prompt: Union[str, List[Tuple[str, float]]],
         negative_prompt: str = "",
-        prompt_interpolation_method: Literal["linear", "slerp", "cosine_weighted"] = "slerp",
+        prompt_interpolation_method: Optional[Literal["average", "slerp", "cosine_weighted"]] = None,
         clear_blending: bool = True,
         warn_about_conflicts: bool = True,
     ) -> None:
@@ -654,8 +930,9 @@ class StreamDiffusionWrapper:
             - Blending: [("cat", 0.7), ("dog", 0.3)]
         negative_prompt : str, optional
             The negative prompt (used with blending), by default "".
-        prompt_interpolation_method : Literal["linear", "slerp", "cosine_weighted"], optional
-            Method for interpolating between prompt embeddings (used with blending), by default "slerp".
+        prompt_interpolation_method : Optional[Literal["average", "slerp", "cosine_weighted"]], optional
+            Method for interpolating between prompt embeddings (used with blending), by default
+            None (keeps the last method set via update_stream_params / the UI, sticky).
         clear_blending : bool, optional
             Whether to clear existing blending when switching to single prompt, by default True.
         warn_about_conflicts : bool, optional
@@ -712,11 +989,11 @@ class StreamDiffusionWrapper:
         # Prompt blending parameters
         prompt_list: Optional[List[Tuple[str, float]]] = None,
         negative_prompt: Optional[str] = None,
-        prompt_interpolation_method: PromptInterpolationMethod = "slerp",
+        prompt_interpolation_method: Optional[PromptInterpolationMethod] = None,
         normalize_prompt_weights: Optional[bool] = None,
         # Seed blending parameters
         seed_list: Optional[List[Tuple[int, float]]] = None,
-        seed_interpolation_method: SeedInterpolationMethod = "linear",
+        seed_interpolation_method: Optional[SeedInterpolationMethod] = None,
         normalize_seed_weights: Optional[bool] = None,
         # ControlNet configuration
         controlnet_config: Optional[List[Dict[str, Any]]] = None,
@@ -761,16 +1038,18 @@ class StreamDiffusionWrapper:
             Example: [("cat", 0.7), ("dog", 0.3)]
         negative_prompt : Optional[str]
             The negative prompt to apply to all blended prompts.
-        prompt_interpolation_method : Literal["linear", "slerp", "cosine_weighted"]
-            Method for interpolating between prompt embeddings, by default "slerp".
+        prompt_interpolation_method : Optional[Literal["average", "slerp", "cosine_weighted"]]
+            Method for interpolating between prompt embeddings, by default None (sticky —
+            keeps the last method set; falls back to "slerp" if none has been set yet).
         normalize_prompt_weights : Optional[bool]
             Whether to normalize prompt weights in blending to sum to 1, by default None (no change).
             When False, weights > 1 will amplify embeddings.
         seed_list : Optional[List[Tuple[int, float]]]
             List of seeds with weights for blending. Each tuple contains (seed_value, weight).
             Example: [(123, 0.6), (456, 0.4)]
-        seed_interpolation_method : Literal["linear", "slerp"]
-            Method for interpolating between seed noise tensors, by default "linear".
+        seed_interpolation_method : Optional[Literal["average", "slerp", "cosine_weighted"]]
+            Method for interpolating between seed noise tensors, by default None (sticky —
+            keeps the last method set; falls back to "average" if none has been set yet).
         normalize_seed_weights : Optional[bool]
             Whether to normalize seed weights in blending to sum to 1, by default None (no change).
             When False, weights > 1 will amplify noise.
@@ -1554,6 +1833,7 @@ class StreamDiffusionWrapper:
         fi_strength: float = 0.75,
         fi_threshold: float = 0.98,
         fp8: bool = False,
+        num_inference_steps: int = 50,
     ) -> StreamDiffusion:
         """
         Loads the model.
@@ -1637,6 +1917,15 @@ class StreamDiffusionWrapper:
             Model ID for the safety checker, by default "Freepik/nsfw_image_detector".
         compile_engines_only : bool, optional
             Whether to only compile engines and not load the model, by default False.
+        fp8 : bool, optional
+            Whether to build the UNet TensorRT engine with FP8 quantization, by default False.
+        num_inference_steps : int, optional
+            Reference step count for the diffusion schedule, by default 50. Used at FP8
+            build time (see acceleration/tensorrt/fp8_quantize.py's capture_calibration_data)
+            to derive the band-based calibration timestep schedule from t_index_list via
+            param_schema.build_calibration_t_indices/compute_sub_timesteps — this must match
+            the num_inference_steps the deployment prepare() call will actually use, or the
+            calibration grid and the inference grid diverge.
 
         Returns
         -------
@@ -1918,6 +2207,10 @@ class StreamDiffusionWrapper:
             stream._fi_threshold_tensor = torch.tensor(
                 [float(fi_threshold)], dtype=torch.float32, device=stream.device
             )
+            # StreamDiffusion.__init__ ran with fio_cache=[] (use_feature_injection forced
+            # False, so _fi_strength_base defaulted to 0.75) — resync it now so unet_step's
+            # per-frame base * warp-attenuation write uses the actually-configured strength.
+            stream._fi_strength_base = float(fi_strength)
 
         # Load and properly merge LoRA weights using the standard diffusers approach
         lora_adapters_to_merge = []
@@ -2005,8 +2298,6 @@ class StreamDiffusionWrapper:
             if acceleration == "xformers":
                 stream.pipe.enable_xformers_memory_efficient_attention()
             if acceleration == "tensorrt":
-                from polygraphy import cuda
-
                 from streamdiffusion.acceleration.tensorrt import TorchVAEEncoder
                 from streamdiffusion.acceleration.tensorrt.engine_manager import EngineManager, EngineType
                 from streamdiffusion.acceleration.tensorrt.models.models import (
@@ -2019,6 +2310,7 @@ class StreamDiffusionWrapper:
                     AutoencoderKLEngine,
                     NSFWDetectorEngine,
                 )
+                from streamdiffusion.acceleration.tensorrt.utilities import NonBlockingStream
 
                 # Add ControlNet detection and support
                 from streamdiffusion.model_detection import extract_unet_architecture, validate_architecture
@@ -2115,12 +2407,42 @@ class StreamDiffusionWrapper:
                 # Strength is now a runtime input, so we do NOT bake scale into engine identity
                 ipadapter_scale = None
                 ipadapter_tokens = None
+                # Deployment scale for FP8 calibration (fp8-round-5-handoff Step 3) — the actual
+                # runtime weight (IPAdapterConfig.scale, ipadapter_module.py:37) applied via
+                # set_scale()/UnetKwargsDelta, not the `ipadapter_scale` local above (which stays
+                # None — only used for engine-naming, real strength is a runtime input by design).
+                # fp8-round-9: calibrate at the runtime *bound*, not the deployment value — scale
+                # is live-adjustable via OSC (/ipadapter_update), so no single build-time value
+                # bounds the range calibration must cover. max(config, 1.0) covers the normal
+                # 0-1 range; a runtime scale pushed above 1.0 re-exposes the merge point to
+                # clipping (see fp8-round-9 plan's residual-risk note). Default 1.0 also matches
+                # IPAdapterConfig's own default when scale is unset in config.
+                fp8_deploy_ipadapter_scale = 1.0
+                # fp8-round-9: style key for resolving real calibration tokens below (None
+                # when unset in config / IP-Adapter not installed — kept as a plain local,
+                # never touching cfg0 outside this block, since cfg0 itself is only bound
+                # when this if fires).
+                _fp8_ipa_style_key = None
+                # fp8-round-9.1 §10: adapter-mode-resolved calibration directory (None until
+                # computed below). Resolved exactly once here and threaded into both
+                # get_engine_path (the --ci<hash> cache key, right below) and the loader
+                # call site further down — never re-derived at each site — so the two can't
+                # disagree about which folder is in play. See
+                # _resolve_fp8_calibration_dir's docstring.
+                _fp8_calib_dir = None
                 if use_ipadapter_trt and has_ipadapter and ipadapter_config:
                     cfg0 = ipadapter_config[0] if isinstance(ipadapter_config, list) else ipadapter_config
                     # scale omitted from engine naming; runtime will pass ipadapter_scale vector
                     ipadapter_tokens = cfg0.get("num_image_tokens", 4)
                     # Determine FaceID type from config for engine naming
                     is_faceid = cfg0["type"] == "faceid"
+                    fp8_deploy_ipadapter_scale = max(float(cfg0.get("scale", 1.0)), 1.0)
+                    _fp8_ipa_style_key = cfg0.get("style_image_key")
+                    _fp8_calib_dir = (
+                        _resolve_fp8_calibration_dir(self.fp8_calibration_style_image, cfg0.get("type"))
+                        if fp8
+                        else None
+                    )
                 # Generate engine paths using EngineManager
                 unet_path = engine_manager.get_engine_path(
                     EngineType.UNET,
@@ -2138,6 +2460,23 @@ class StreamDiffusionWrapper:
                     use_controlnet=use_controlnet_trt,
                     fp8=fp8,
                     fp8_mha_qdq=self.fp8_mha_qdq,
+                    fp8_scale_headroom=self.fp8_scale_headroom,
+                    fp8_exclude_attention=self.fp8_exclude_attention,
+                    fp8_exclude_ipadapter=self.fp8_exclude_ipadapter,
+                    # fp8-round-9.1: the calibration image set is part of the build
+                    # recipe — fork on its content hash (see
+                    # EngineManager._calibration_image_signature), same reasoning as
+                    # every other fp8_* recipe flag above. fp8-round-9.1 §10: pass the
+                    # already-resolved mode subfolder (_fp8_calib_dir), not the raw
+                    # config value — this is the same directory the loader call site
+                    # below will read, so the cache key can't disagree with the load.
+                    fp8_calibration_style_image=_fp8_calib_dir,
+                    # Fork the cache key on the calibration band layout (fp8-round-5-handoff
+                    # Step 2f) — not on t_index_list's literal values, only its length, so a
+                    # live /t_list change within the calibrated band doesn't need a rebuild.
+                    fp8_calib_t_index_len=len(t_index_list) if fp8 else None,
+                    fp8_calib_num_steps=num_inference_steps if fp8 else None,
+                    fp8_calib_scheduler_type=scheduler if fp8 else None,
                     resolution=(self.height, self.width),
                     builder_optimization_level=self.builder_optimization_level,
                     # Must match the build_static_batch value in _unet_build_opts below so
@@ -2518,12 +2857,22 @@ class StreamDiffusionWrapper:
                     },
                 )
 
-                # Use polygraphy's default Blocking stream. A NonBlocking engine stream
-                # would skip the legacy/per-thread NULL-stream auto-sync that the rest of
-                # the pipeline relies on (PyTorch ops run on stream 0x0), creating a data
-                # race where the engine reads stale inputs and writes outputs that
-                # downstream PyTorch never observes — symptom is black/zero output frames.
-                cuda_stream = cuda.Stream()
+                # A NonBlocking engine stream used to produce black/zero output frames
+                # here, because it skips the legacy/per-thread NULL-stream auto-sync
+                # that the rest of the pipeline (PyTorch ops on stream 0x0) implicitly
+                # relied on for ordering. That implicit-sync rationale has been replaced
+                # by explicit torch.cuda.Event barriers around every engine-stream use
+                # in Engine.infer (utilities.py, Fix 1a) — pre/post events plus
+                # record_stream() on every tensor crossing the stream boundary — so the
+                # ordering guarantee no longer depends on the stream being blocking.
+                # NonBlockingStream is a minimal cudaStreamNonBlocking wrapper (see
+                # utilities.py) required for Relaxed CUDA-graph capture mode alongside
+                # it (Fix 1c) — see Engine.infer's capture branch for the rationale.
+                # If output regresses to black/zero frames again, that means an
+                # engine-stream use site was missed by the event barriers; the
+                # independently-safe fallback is reverting just this one line to
+                # `from polygraphy import cuda; cuda_stream = cuda.Stream()`.
+                cuda_stream = NonBlockingStream()
 
                 vae_config = stream.vae.config
                 vae_dtype = stream.vae.dtype
@@ -2550,23 +2899,149 @@ class StreamDiffusionWrapper:
                     if fp8:
                         _is_turbo = getattr(self, "_is_turbo", False)
                         _unet_build_opts["fp8"] = True
-                        _unet_build_opts["onnx_opset"] = 19  # FP8 Q/DQ scales require opset ≥19
+                        _unet_build_opts["onnx_opset"] = (
+                            21  # FP8 Q/DQ scales with FP16 scale factors require opset ≥21
+                        )
                         _unet_build_opts["pipe_ref"] = stream.pipe
-                        # SDXL-Turbo: 4 steps, guidance_scale=0.0 (matches inference);
-                        # SDXL base: 20 steps, guidance_scale=7.5.
-                        # Calibration activations must match inference-time ranges.
-                        _unet_build_opts["calibration_steps"] = 4 if _is_turbo else 20
+                        # The CLIP image encoder (ip-adapter/faceid) hangs off
+                        # stream._ipadapter_module.ipadapter, not stream.pipe, so it's
+                        # invisible to the pipe_ref-only VRAM release below unless passed
+                        # separately. None when IP-Adapter isn't installed.
+                        _unet_build_opts["ipadapter_ref"] = getattr(stream, "_ipadapter_module", None)
+                        # guidance_scale still follows the turbo/non-turbo split (matches
+                        # inference CFG); this axis is independent of *which* timesteps are
+                        # calibrated, so it rides alongside the schedule derivation below.
                         _unet_build_opts["fp8_guidance_scale"] = 0.0 if _is_turbo else 7.5
+
+                        # --- band-based, config-derived calibration schedule ---
+                        # (fp8-round-5-handoff plan, Step 2c). Calibration must sample the raw
+                        # UNet timesteps deployment actually visits (t_index_list on the
+                        # num_inference_steps-step grid), not a mismatched turbo schedule — see
+                        # the plan for the full diagnosis. prepare() has not run yet at this
+                        # point in _load_model, so stream.scheduler.timesteps is still the
+                        # constructor default; materialise the real grid explicitly via the
+                        # shared helper (param_schema.materialise_timestep_grid) rather than
+                        # calling prepare() itself, which would also run embedding/noise setup
+                        # this build stage doesn't want yet. This is the same set_timesteps +
+                        # _SPACING_SAMPLERS override prepare() applies (pipeline.py's
+                        # prepare(), ~:612-620) — sharing the helper means the two can never
+                        # silently drift apart on what "spacing override" means.
+                        from .acceleration.tensorrt.fp8_quantize import _MAX_CALIB_ROWS
+
+                        materialise_timestep_grid(
+                            stream.scheduler,
+                            num_inference_steps,
+                            stream.sampler_type,
+                            stream.device,
+                            stream._get_spaced_timesteps,
+                        )
+                        _calib_t_indices = build_calibration_t_indices(
+                            t_index_list, num_inference_steps, budget=_MAX_CALIB_ROWS
+                        )
+                        _calib_timesteps = compute_sub_timesteps(stream.scheduler.timesteps, _calib_t_indices)
+                        # LCM's custom-timestep path requires strictly descending values
+                        # (venv scheduling_lcm.py ~:440-443); the grid is monotonically
+                        # decreasing in t_index, so sorting t_index ascending (as
+                        # build_calibration_t_indices returns) already yields this order.
+                        _unet_build_opts["fp8_calibration_timesteps"] = [int(t) for t in _calib_timesteps]
+                        _unet_build_opts["fp8_calibration_scheduler_ref"] = stream.scheduler
+                        # calibration_steps no longer selects the schedule (the explicit
+                        # timestep list above does, via capture_calibration_data's
+                        # timesteps=/scheduler_ref= params — Step 2d) — kept as the row count
+                        # for logging and as capture_calibration_data's num_inference_steps
+                        # fallback for the (should-be-unreachable-when-fp8) case where only
+                        # one of fp8_calibration_timesteps/fp8_calibration_scheduler_ref
+                        # makes it through.
+                        _unet_build_opts["calibration_steps"] = len(_calib_timesteps)
+                        logger.warning(
+                            f"[TRT] FP8 calibration schedule: t_index={_calib_t_indices}, "
+                            f"timesteps={_unet_build_opts['fp8_calibration_timesteps']}"
+                        )
                         _unet_build_opts["fp8_allow_fp16_fallback"] = self.fp8_allow_fp16_fallback
                         _unet_build_opts["fp8_mha_qdq"] = self.fp8_mha_qdq
+                        _unet_build_opts["fp8_scale_headroom"] = self.fp8_scale_headroom
+                        _unet_build_opts["fp8_exclude_attention"] = self.fp8_exclude_attention
+                        _unet_build_opts["fp8_exclude_ipadapter"] = self.fp8_exclude_ipadapter
                         _unet_build_opts["fp8_use_cached_attn"] = use_cached_attn
                         _unet_build_opts["fp8_use_feature_injection"] = use_feature_injection
                         _unet_build_opts["fp8_use_controlnet"] = use_controlnet_trt
                         _unet_build_opts["fp8_num_ip_layers"] = num_ip_layers if use_ipadapter_trt else 0
+                        # fp8-round-5-handoff Step 3: calibrate kvo/fio-adjacent scalar inputs
+                        # (fi_strength, fi_threshold, ipadapter_scale) on the deployment config's
+                        # actual values instead of the zeros/ones capture_calibration_data
+                        # previously synthesized — read from config, never hardcoded.
+                        _unet_build_opts["fp8_fi_strength"] = float(fi_strength) if use_feature_injection else 0.0
+                        _unet_build_opts["fp8_fi_threshold"] = float(fi_threshold) if use_feature_injection else 0.0
+                        _unet_build_opts["fp8_ipadapter_scale"] = (
+                            fp8_deploy_ipadapter_scale if use_ipadapter_trt else 1.0
+                        )
+                        # fp8-round-9 / fp8-round-9.1: feed real IP-Adapter projection tokens into
+                        # calibration's encoder_hidden_states reconciliation instead of
+                        # zero-padding — see capture_calibration_data's ipadapter_tokens docstring,
+                        # the fp8-round-9 plan's diagnosis, and _resolve_fp8_ipadapter_calibration_
+                        # tokens' docstring for why fp8-round-9.1 dispatches on proj shape rather
+                        # than adapter flavour (fp8-round-9's `is_faceid and not is_plus` gate left
+                        # `type: regular` — the shipped config — silently zero-padded). Never
+                        # allowed to hard-fail an engine build — any failure falls back to None.
+                        _fp8_deploy_ipadapter_tokens = None
+                        if use_ipadapter_trt:
+                            try:
+                                _ipa_module = getattr(stream, "_ipadapter_module", None)
+                                _ipa = getattr(_ipa_module, "ipadapter", None)
+                                _cached = None
+                                if _ipa is not None and _fp8_ipa_style_key and hasattr(stream, "_param_updater"):
+                                    _cached = stream._param_updater.get_cached_embeddings(_fp8_ipa_style_key)
+                                # fp8-round-9.1 §10: read the same resolved directory that
+                                # get_engine_path was given above (_fp8_calib_dir), not the raw
+                                # config value — the cache key and the load must agree on which
+                                # folder is in play.
+                                _fp8_style_images = _load_fp8_calibration_style_images(_fp8_calib_dir)
+                                _fp8_deploy_ipadapter_tokens, _fp8_tokens_method = (
+                                    _resolve_fp8_ipadapter_calibration_tokens(_ipa, _cached, _fp8_style_images)
+                                )
+                                if _fp8_tokens_method == "image":
+                                    # fp8-round-9.1 §10: some configured images may have been
+                                    # rejected by the adapter (e.g. a non-face image under
+                                    # type: faceid) and skipped rather than aborting the whole
+                                    # set — report kept-vs-configured explicitly.
+                                    _fp8_n_kept = (
+                                        _fp8_deploy_ipadapter_tokens.shape[0]
+                                        if _fp8_deploy_ipadapter_tokens is not None
+                                        else 0
+                                    )
+                                    logger.info(
+                                        f"[TRT] FP8 IPA calibration tokens: real style image(s) from "
+                                        f"{_fp8_calib_dir} (n={_fp8_n_kept} of {len(_fp8_style_images)})"
+                                    )
+                                elif _fp8_tokens_method == "cached":
+                                    logger.info("[TRT] FP8 IPA calibration tokens: real cached style embedding")
+                                elif _fp8_tokens_method == "surrogate":
+                                    logger.info(
+                                        "[TRT] FP8 IPA calibration tokens: image_proj_model(zeros) surrogate "
+                                        "(no cached style embedding — conservative-safe; see "
+                                        "_reconcile_calib_to_onnx_dims log for the appended region's |x|max)"
+                                    )
+                                else:
+                                    logger.info(
+                                        "[TRT] FP8 IPA calibration tokens: skipped (unrecognized "
+                                        "image_proj_model.proj shape) — falling back to zero-pad reconciliation"
+                                    )
+                            except Exception as e:
+                                logger.warning(
+                                    f"[TRT] FP8 IPA calibration token resolution failed "
+                                    f"({type(e).__name__}: {e}); falling back to zero-pad reconciliation."
+                                )
+                                _fp8_deploy_ipadapter_tokens = None
+                        _unet_build_opts["fp8_ipadapter_tokens"] = _fp8_deploy_ipadapter_tokens
                         logger.warning(
                             f"[TRT] FP8 build opts: turbo={_is_turbo}, "
-                            f"steps={_unet_build_opts['calibration_steps']}, "
-                            f"guidance={_unet_build_opts['fp8_guidance_scale']}"
+                            f"deploy_steps={len(t_index_list)}, "
+                            f"calib_rows={_unet_build_opts['calibration_steps']}, "
+                            f"guidance={_unet_build_opts['fp8_guidance_scale']}, "
+                            f"scale_headroom={self.fp8_scale_headroom}, "
+                            f"exclude_attention={self.fp8_exclude_attention}, "
+                            f"exclude_ipadapter={self.fp8_exclude_ipadapter}, "
+                            f"ipa_tokens={'real' if _fp8_deploy_ipadapter_tokens is not None else 'zero-pad'}"
                         )
 
                     # Compile and load UNet engine using EngineManager

--- a/tests/quality/test_fp8_calib_tile.py
+++ b/tests/quality/test_fp8_calib_tile.py
@@ -1,7 +1,11 @@
-"""Regression: per-input-aware calibration tiling for FP8 quantize.
+"""Regression: per-input-aware calibration row alignment for FP8 quantize.
 
 Reproduces the kvo_cache_in dim-0=2 vs synthesized dim-0=1 split mismatch
-hit by SDXL-Turbo + use_cached_attn + cfg_type=self configs.
+hit by SDXL-Turbo + use_cached_attn + cfg_type=self configs, and the later
+ipadapter_scale dim-0 drift (capture writes n_itr×num_ip_layers rows for a
+graph input whose ONNX dim 0 is dynamic; quantize used to resolve that same
+dim 0 to 1, inflating n_itr 70× and tiling every kvo/fio tensor into an
+~290 GiB attempted allocation).
 """
 
 import math
@@ -12,17 +16,20 @@ from onnx import TensorProto, helper
 
 
 def _make_min_onnx(path):
-    """Minimal 2-input ONNX: symbolic-batch 'sample' + static-dim0=2 'kvo_cache_in_0'."""
+    """Minimal 3-input ONNX: symbolic-batch 'sample', static-dim0=2
+    'kvo_cache_in_0', and dynamic-dim0 'ipadapter_scale' (mirrors the "L_ip"
+    axis at models/models.py:716)."""
     sample = helper.make_tensor_value_info("sample", TensorProto.FLOAT, ["2B", 4, 64, 64])
     kvo = helper.make_tensor_value_info("kvo_cache_in_0", TensorProto.FLOAT, [2, 4, "2B", 64, 64])
+    ipa_scale = helper.make_tensor_value_info("ipadapter_scale", TensorProto.FLOAT, ["L_ip"])
     out = helper.make_tensor_value_info("out", TensorProto.FLOAT, ["2B", 4, 64, 64])
     ident = helper.make_node("Identity", inputs=["sample"], outputs=["out"])
-    g = helper.make_graph([ident], "min", [sample, kvo], [out])
+    g = helper.make_graph([ident], "min", [sample, kvo, ipa_scale], [out])
     onnx.save(helper.make_model(g, opset_imports=[helper.make_opsetid("", 17)]), path)
 
 
 def test_per_input_tile_preserves_static_dim0(tmp_path):
-    """Per-input tile: sample stays at n_itr rows, kvo stays at 2×n_itr rows."""
+    """Row alignment: sample stays at n_itr rows, kvo stays at 2×n_itr rows."""
     onnx_path = str(tmp_path / "min.onnx")
     _make_min_onnx(onnx_path)
 
@@ -31,31 +38,280 @@ def test_per_input_tile_preserves_static_dim0(tmp_path):
         "kvo_cache_in_0": np.zeros((10, 4, 5, 64, 64), dtype=np.float32),
     }
 
-    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _read_onnx_input_specs
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _align_calibration_rows, _read_onnx_input_specs
 
     specs = _read_onnx_input_specs(onnx_path)
-
-    # Reproduce the fixed logic
-    resolved_dim0 = {name: max(1, (specs[name][1][0] or 1)) for name in calib}
-    n_itr = max(arr.shape[0] // resolved_dim0[name] for name, arr in calib.items())
-    n_itr = max(1, n_itr)
-    out = {}
-    for k, arr in calib.items():
-        target = n_itr * resolved_dim0[k]
-        if arr.shape[0] != target:
-            repeats = math.ceil(target / max(1, arr.shape[0]))
-            arr = np.tile(arr, (repeats,) + (1,) * (arr.ndim - 1))[:target]
-        out[k] = arr
+    out = _align_calibration_rows(calib, specs, num_ip_layers=0)
 
     # n_itr=5, resolved_dim0(sample)=1 → 5 rows; resolved_dim0(kvo)=2 → 10 rows
     assert out["sample"].shape == (5, 4, 64, 64)
     assert out["kvo_cache_in_0"].shape == (10, 4, 5, 64, 64)
 
     # Verify modelopt split math: n_itr chunks each of shape (resolved_dim0, ...)
+    n_itr = 5
     sample_chunks = np.array_split(out["sample"], n_itr, axis=0)
     kvo_chunks = np.array_split(out["kvo_cache_in_0"], n_itr, axis=0)
     assert sample_chunks[0].shape[0] == 1
     assert kvo_chunks[0].shape[0] == 2  # static dim 0 must be preserved
+
+
+def test_ipadapter_scale_does_not_inflate_n_itr(tmp_path):
+    """THE regression: ipadapter_scale's dynamic 'L_ip' dim must not drive n_itr
+    up. capture_calibration_data writes it at n_itr×num_ip_layers rows because
+    the traced graph hardcodes Gather(scale_vec, idx=0..num_ip_layers-1); the
+    quantize side must resolve the same per-chunk length or it elects a wildly
+    inflated n_itr and tiles every other input to match.
+    """
+    onnx_path = str(tmp_path / "min.onnx")
+    _make_min_onnx(onnx_path)
+
+    num_ip_layers = 70
+    n_itr = 8
+    calib = {
+        "sample": np.zeros((n_itr, 4, 64, 64), dtype=np.float32),
+        "kvo_cache_in_0": np.zeros((n_itr * 2, 4, 5, 64, 64), dtype=np.float32),
+        "ipadapter_scale": np.ones((n_itr * num_ip_layers,), dtype=np.float32),
+    }
+
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _align_calibration_rows, _read_onnx_input_specs
+
+    specs = _read_onnx_input_specs(onnx_path)
+    out = _align_calibration_rows(calib, specs, num_ip_layers=num_ip_layers)
+
+    # n_itr must stay 8 (not 560=8×70) — every input already matches its target,
+    # so _align_calibration_rows must return each array untouched (by identity).
+    assert out["sample"].shape[0] == 8
+    assert out["kvo_cache_in_0"].shape[0] == 16
+    assert out["ipadapter_scale"].shape[0] == 560
+    for k in calib:
+        assert out[k] is calib[k], f"'{k}' was needlessly tiled/copied"
+
+    chunks = np.array_split(out["ipadapter_scale"], n_itr, axis=0)
+    assert all(c.shape[0] == num_ip_layers for c in chunks)
+
+
+## FP8 Round 11 -- the two tests below document a *different* face of the same
+## ipadapter_scale divisibility confusion the test above pins for
+## _align_calibration_rows: here it's _select_calibration_calls's own
+## max_multiplier inference (fp8_quantize.py's own docstring/module comment
+## flags this as "not firing today" only because capture_calibration_data
+## synthesizes ipadapter_scale *after* calling _select_calibration_calls --
+## verified by direct read, not testable end-to-end without a live pipeline.
+## These document the hazard rather than lock down a "fix"; if either ever
+## starts failing because the two statements' order changed, that is a real
+## regression to investigate, not an assertion to update.
+
+
+def test_select_calibration_calls_ipadapter_scale_present_collapses_to_one_call():
+    """If ipadapter_scale (shape num_calls*70) were ever passed into
+    _select_calibration_calls, its multiplier (70) would dominate
+    max_multiplier and collapse calls_budget to max(1, 8 // 70) == 1 -- a
+    single-call collapse that would starve calibration to one prompt entirely.
+    See the module note above for why this does not fire in production."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _select_calibration_calls
+
+    num_calls = 8
+    distinct_timesteps = [699, 579, 459, 339, 219, 99, 979, 819]
+    num_ip_layers = 70
+    calib = {
+        "timestep": np.array(distinct_timesteps, dtype=np.float16).reshape(num_calls, 1),
+        "ipadapter_scale": np.ones((num_calls * num_ip_layers,), dtype=np.float32),
+    }
+
+    selected = _select_calibration_calls(calib, max_rows=8)
+
+    assert len(selected) == 1, (
+        "documents the ipadapter_scale multiplier trap collapsing calls_budget "
+        "to 1 -- see this test's docstring for why it does not fire in production"
+    )
+
+
+def test_select_calibration_calls_without_ipadapter_scale_yields_full_budget():
+    """Companion to the collapse test above: the real hook-captured key set
+    (timestep + sample + encoder_hidden_states -- never ipadapter_scale, which
+    is synthesized afterward) must yield the full 8-call budget, not the
+    collapsed 1-call budget the trap above would produce if the statement
+    ordering ever changed."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _select_calibration_calls
+
+    num_calls = 8
+    distinct_timesteps = [699, 579, 459, 339, 219, 99, 979, 819]
+    calib = {
+        "timestep": np.array(distinct_timesteps, dtype=np.float16).reshape(num_calls, 1),
+        "sample": np.arange(num_calls, dtype=np.float32).reshape(num_calls, 1),
+        "encoder_hidden_states": np.arange(num_calls, dtype=np.float32).reshape(num_calls, 1),
+    }
+
+    selected = _select_calibration_calls(calib, max_rows=8)
+    assert len(selected) == 8
+
+
+def _make_ehs_onnx(path, ehs_seq=81):
+    """Minimal ONNX with an encoder_hidden_states input declared at a static
+    seq_len (81 = 77 text tokens + 4 IP-Adapter image tokens, mirroring
+    UnifiedExportWrapper's concatenation) plus an unrelated already-matching
+    static-dim input, so _reconcile_calib_to_onnx_dims's "only touch what's
+    declared" behavior is exercised alongside the IP-Adapter special case
+    (fp8-round-9)."""
+    ehs = helper.make_tensor_value_info("encoder_hidden_states", TensorProto.FLOAT, ["B", ehs_seq, 2048])
+    fi = helper.make_tensor_value_info("fi_strength", TensorProto.FLOAT, ["B", 3])
+    out = helper.make_tensor_value_info("out", TensorProto.FLOAT, ["B", ehs_seq, 2048])
+    ident = helper.make_node("Identity", inputs=["encoder_hidden_states"], outputs=["out"])
+    g = helper.make_graph([ident], "min_ehs", [ehs, fi], [out])
+    onnx.save(helper.make_model(g, opset_imports=[helper.make_opsetid("", 17)]), path)
+
+
+def test_reconcile_fills_ipadapter_token_region_from_real_tokens(tmp_path):
+    """fp8-round-9: undersized encoder_hidden_states (77 captured text tokens vs.
+    81 ONNX-declared) concatenates real IP-Adapter projection tokens onto the
+    missing region instead of zero-padding — to_k_ip/to_v_ip are bias-free
+    nn.Linear layers, so a zero-padded region starves that branch's FP8
+    calibration entirely (the defect this fix corrects)."""
+    onnx_path = str(tmp_path / "ehs.onnx")
+    _make_ehs_onnx(onnx_path, ehs_seq=81)
+
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import (
+        _read_onnx_input_specs,
+        _reconcile_calib_to_onnx_dims,
+    )
+
+    specs = _read_onnx_input_specs(onnx_path)
+    n_rows = 3
+    calib = {
+        "encoder_hidden_states": np.random.default_rng(0).normal(size=(n_rows, 77, 2048)).astype(np.float32),
+    }
+    tokens = np.full((1, 4, 2048), 5.0, dtype=np.float32)  # nonzero stub tokens
+
+    out = _reconcile_calib_to_onnx_dims(calib, specs, ipadapter_tokens=tokens, num_ip_layers=70)
+
+    assert out["encoder_hidden_states"].shape == (n_rows, 81, 2048)
+    appended = out["encoder_hidden_states"][:, 77:, :]
+    assert np.abs(appended).max() > 0
+    np.testing.assert_allclose(appended, np.broadcast_to(tokens, (n_rows, 4, 2048)))
+    # Original 77-token region is untouched, and the input dict itself is not
+    # mutated in place (capture_calibration_data reassigns calib_data from the
+    # return value; a stray in-place mutation would silently double-apply).
+    np.testing.assert_array_equal(out["encoder_hidden_states"][:, :77, :], calib["encoder_hidden_states"])
+    assert calib["encoder_hidden_states"].shape == (n_rows, 77, 2048)
+
+
+def test_reconcile_tiles_multi_image_tokens_round_robin(tmp_path):
+    """fp8-round-9.1: N>1 ipadapter_tokens (multiple `fp8_calibration_style_image`
+    files) must tile round-robin across the calibration rows and trim to the
+    row count, not go through the N==1 `np.broadcast_to` path -- which only
+    accepts source dim 1 or equal to the target and raises ValueError on any
+    other N (unreachable before fp8-round-9.1, since every prior token source
+    was N==1: the zeros-surrogate or a single cached embedding). 2 images
+    across 8 rows must land as [img0, img1, img0, img1, ...] -- an
+    interleave, not img0 repeated 4x then img1 repeated 4x -- so both
+    images' activation ranges land in the same amax statistic throughout the
+    schedule rather than only the first half."""
+    onnx_path = str(tmp_path / "ehs.onnx")
+    _make_ehs_onnx(onnx_path, ehs_seq=81)
+
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import (
+        _read_onnx_input_specs,
+        _reconcile_calib_to_onnx_dims,
+    )
+
+    specs = _read_onnx_input_specs(onnx_path)
+    n_rows = 8
+    calib = {
+        "encoder_hidden_states": np.random.default_rng(0).normal(size=(n_rows, 77, 2048)).astype(np.float32),
+    }
+    # Two distinct, easily-distinguished per-image token blocks.
+    img0 = np.full((1, 4, 2048), 2.0, dtype=np.float32)
+    img1 = np.full((1, 4, 2048), 5.0, dtype=np.float32)
+    tokens = np.concatenate([img0, img1], axis=0)  # shape (2, 4, 2048)
+
+    out = _reconcile_calib_to_onnx_dims(calib, specs, ipadapter_tokens=tokens, num_ip_layers=70)
+
+    assert out["encoder_hidden_states"].shape == (n_rows, 81, 2048)
+    appended = out["encoder_hidden_states"][:, 77:, :]
+    assert np.abs(appended).max() > 0
+
+    for row in range(n_rows):
+        expected = img0[0] if row % 2 == 0 else img1[0]
+        np.testing.assert_array_equal(
+            appended[row], expected, err_msg=f"row {row} did not get the expected round-robin image token"
+        )
+
+    # Original 77-token region untouched, no in-place mutation of the input.
+    np.testing.assert_array_equal(out["encoder_hidden_states"][:, :77, :], calib["encoder_hidden_states"])
+
+
+def test_reconcile_falls_back_to_zero_pad_and_warns_without_tokens(tmp_path, caplog):
+    """No ipadapter_tokens given -> the prior zero-pad behavior still applies
+    (kvo/fio contract unchanged), plus the new zero-region warning fires:
+    num_ip_layers>0 with an all-zero appended region is exactly the
+    precondition that produced the original 420-uncalibrated-initializer
+    defect, and must never be silent again."""
+    onnx_path = str(tmp_path / "ehs.onnx")
+    _make_ehs_onnx(onnx_path, ehs_seq=81)
+
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import (
+        _read_onnx_input_specs,
+        _reconcile_calib_to_onnx_dims,
+    )
+
+    specs = _read_onnx_input_specs(onnx_path)
+    calib = {"encoder_hidden_states": np.ones((2, 77, 2048), dtype=np.float32)}
+
+    with caplog.at_level("WARNING", logger="streamdiffusion.acceleration.tensorrt.fp8_quantize"):
+        out = _reconcile_calib_to_onnx_dims(calib, specs, ipadapter_tokens=None, num_ip_layers=70)
+
+    assert out["encoder_hidden_states"].shape == (2, 81, 2048)
+    appended = out["encoder_hidden_states"][:, 77:, :]
+    assert np.abs(appended).max() == 0.0
+    assert any("identically zero" in r.message for r in caplog.records)
+
+
+def test_reconcile_no_warning_when_no_ipadapter_layers(tmp_path, caplog):
+    """num_ip_layers=0 (no IP-Adapter installed) must not warn about a zero
+    token region — the defect this guards against is IPA-specific, and every
+    other feature (kvo/fio/controlnet) legitimately zero-pads without it."""
+    onnx_path = str(tmp_path / "ehs.onnx")
+    _make_ehs_onnx(onnx_path, ehs_seq=81)
+
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import (
+        _read_onnx_input_specs,
+        _reconcile_calib_to_onnx_dims,
+    )
+
+    specs = _read_onnx_input_specs(onnx_path)
+    calib = {"encoder_hidden_states": np.ones((2, 77, 2048), dtype=np.float32)}
+
+    with caplog.at_level("WARNING", logger="streamdiffusion.acceleration.tensorrt.fp8_quantize"):
+        _reconcile_calib_to_onnx_dims(calib, specs, ipadapter_tokens=None, num_ip_layers=0)
+
+    assert not any("identically zero" in r.message for r in caplog.records)
+
+
+def test_reconcile_trims_oversized_and_leaves_matching_tensors_untouched(tmp_path):
+    """Oversized (85 -> 81) still trims — unaffected by the IP-Adapter special
+    case, which only applies to the undersized branch — and an unrelated
+    input that already matches its declared dims is left alone (same object,
+    not a needless copy)."""
+    onnx_path = str(tmp_path / "ehs.onnx")
+    _make_ehs_onnx(onnx_path, ehs_seq=81)
+
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import (
+        _read_onnx_input_specs,
+        _reconcile_calib_to_onnx_dims,
+    )
+
+    specs = _read_onnx_input_specs(onnx_path)
+    calib = {
+        "encoder_hidden_states": np.arange(2 * 85 * 2048, dtype=np.float32).reshape(2, 85, 2048),
+        "fi_strength": np.zeros((2, 3), dtype=np.float32),
+    }
+    tokens = np.full((1, 4, 2048), 9.0, dtype=np.float32)
+
+    out = _reconcile_calib_to_onnx_dims(calib, specs, ipadapter_tokens=tokens, num_ip_layers=70)
+
+    assert out["encoder_hidden_states"].shape == (2, 81, 2048)
+    np.testing.assert_array_equal(out["encoder_hidden_states"], calib["encoder_hidden_states"][:, :81, :])
+    assert out["fi_strength"] is calib["fi_strength"]
 
 
 def test_naive_max_rows_tile_would_break(tmp_path):
@@ -79,3 +335,440 @@ def test_naive_max_rows_tile_would_break(tmp_path):
     n_itr_bad = calib["sample"].shape[0]  # 10 (doubled by naïve tile)
     kvo_chunk = np.array_split(calib["kvo_cache_in_0"], n_itr_bad, axis=0)[0]
     assert kvo_chunk.shape[0] == 1  # this is the "Got 1 Expected 2" symptom
+
+
+## NOTE: the four tests that used to live here (test_naive_linspace_aliases_timesteps,
+## test_calibration_row_selection_covers_all_timesteps,
+## test_calibration_row_selection_two_rows_per_step,
+## test_calibration_row_selection_preserves_cross_key_alignment) were removed.
+## They covered a 4-step-schedule-specific stride fix that Step 1 of the
+## fp8-round-5-handoff plan reverted in favor of isolating the
+## enable_gemv_detection_for_trt variable. Step 2e below replaces row
+## selection wholesale with a band-based, call-aligned, stratified-over-
+## timesteps scheme (see _select_calibration_rows).
+
+
+def test_select_calibration_rows_covers_all_timesteps():
+    """Row selection must represent every distinct calibration timestep before
+    doubling any of them, unlike a naive row-index linspace stride, which can
+    alias onto the same handful of timestep phases across many prompts (the
+    original round-5 defect Step 1 of the plan isolated)."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _select_calibration_rows
+
+    distinct_timesteps = [699, 579, 459, 339, 219, 99, 979, 819]  # 8 distinct t values
+    num_prompts = 4
+    timestep_seq = distinct_timesteps * num_prompts  # prompt-major call order
+    num_calls = len(timestep_seq)
+
+    calib = {
+        "timestep": np.array(timestep_seq, dtype=np.float16).reshape(num_calls, 1),
+        "sample": np.arange(num_calls, dtype=np.float32).reshape(num_calls, 1, 1, 1),
+    }
+
+    out = _select_calibration_rows(calib, max_rows=8)
+
+    assert out["timestep"].shape[0] == 8
+    selected_values = sorted(set(out["timestep"].reshape(-1).tolist()))
+    assert selected_values == sorted(distinct_timesteps), (
+        "every distinct calibrated timestep must be represented in an 8-row budget "
+        "when exactly 8 distinct timesteps were captured"
+    )
+
+
+def test_select_calibration_rows_preserves_cross_key_alignment_under_cfg():
+    """CFG-doubled keys (sample, encoder_hidden_states) must stay aligned with
+    the 1-row-per-call 'timestep' key: a selected call's cond+uncond pair in a
+    doubled key must sit next to that same call's timestep row."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _select_calibration_rows
+
+    distinct_timesteps = [699, 579, 459, 339]
+    num_prompts = 6
+    timestep_seq = distinct_timesteps * num_prompts
+    num_calls = len(timestep_seq)  # 24
+
+    timestep_arr = np.array(timestep_seq, dtype=np.float16).reshape(num_calls, 1)
+    # 2 rows/call (CFG cond+uncond), each tagged call_idx*10 + {0: uncond, 1: cond}
+    # so the pairing can be recovered from data content, not just algorithm knowledge.
+    sample_arr = np.zeros((num_calls * 2, 1), dtype=np.float32)
+    for c in range(num_calls):
+        sample_arr[2 * c, 0] = c * 10 + 0
+        sample_arr[2 * c + 1, 0] = c * 10 + 1
+
+    calib = {"timestep": timestep_arr, "sample": sample_arr}
+    out = _select_calibration_rows(calib, max_rows=8)
+
+    # max_multiplier=2 -> calls_budget = 8 // 2 = 4 calls selected.
+    assert out["timestep"].shape[0] == 4
+    assert out["sample"].shape[0] == 8
+    assert sorted(out["timestep"].reshape(-1).tolist()) == sorted(distinct_timesteps)
+
+    for i in range(4):
+        uncond_tag, cond_tag = out["sample"][2 * i, 0], out["sample"][2 * i + 1, 0]
+        call_idx = int(uncond_tag // 10)
+        assert int(cond_tag // 10) == call_idx, "cond/uncond pair split apart across selection"
+        assert out["timestep"][i, 0] == timestep_seq[call_idx], (
+            "sample rows for a call must stay aligned with that call's timestep row"
+        )
+
+
+def test_select_calibration_rows_no_downsample_within_budget():
+    """When captured calls already fit the budget, nothing is dropped."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _select_calibration_rows
+
+    calib = {
+        "timestep": np.array([699, 579, 459], dtype=np.float16).reshape(3, 1),
+        "sample": np.arange(6, dtype=np.float32).reshape(6, 1),
+    }
+    out = _select_calibration_rows(calib, max_rows=8)
+    assert out["timestep"].shape[0] == 3
+    assert out["sample"].shape[0] == 6
+
+
+## FP8 Round 11 -- calibration-diversity stagger fix. _select_calibration_calls
+## used bucket[round_idx] for every distinct timestep in a round; whenever
+## calls_budget matched the distinct-timestep count (the common case: 8
+## timesteps, budget 8), only round 0 ever ran, and round 0 = occurrence 0 of
+## every timestep = the first pipe() batch, for all 8 selected calls. The tests
+## below pin the position-staggered replacement directly (not through
+## _select_calibration_rows, which only exposes the row-expanded result).
+
+
+def test_select_calibration_calls_stagger_spans_distinct_batches():
+    """The red-capable pin for FP8 Round 11 Item 2: with calls_budget matching
+    the distinct-timestep count, the pre-fix code selected occurrence 0 of
+    every timestep -- all 8 calls from the same (first) prompt batch. The
+    stagger fix must instead spread the 8 selected calls across as many
+    distinct batches as the capture holds occurrences for."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _select_calibration_calls
+
+    distinct_timesteps = [699, 579, 459, 339, 219, 99, 979, 819]  # 8 distinct
+    num_batches = 8
+    timestep_seq = distinct_timesteps * num_batches  # prompt-major call order,
+    # matching real capture: one pipe() batch walks every distinct timestep
+    # once, in the same order, before the next batch starts.
+    num_calls = len(timestep_seq)
+
+    calib = {"timestep": np.array(timestep_seq, dtype=np.float16).reshape(num_calls, 1)}
+    selected = _select_calibration_calls(calib, max_rows=8)
+
+    assert len(selected) == 8
+
+    def _batch_of(call_idx):
+        return call_idx // len(distinct_timesteps)
+
+    batches = {_batch_of(int(c)) for c in selected}
+    assert len(batches) == 8, (
+        f"expected all 8 batches represented, got batches={sorted(batches)} "
+        f"from selected calls={sorted(int(c) for c in selected)}"
+    )
+
+    # Every distinct timestep still represented exactly once before any repeat.
+    selected_timesteps = sorted(float(timestep_seq[int(c)]) for c in selected)
+    assert selected_timesteps == sorted(float(t) for t in distinct_timesteps)
+
+
+def test_select_calibration_calls_short_bucket_falls_back_without_dropping_timestep():
+    """A timestep with fewer occurrences than the round count needs (a "short
+    bucket") must still contribute at least once, and the stagger must never
+    select a duplicate call index or raise -- it falls back to the earliest
+    unused occurrence in that bucket instead of re-selecting one already taken,
+    and skips (not crashes) once a bucket is genuinely exhausted."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _select_calibration_calls
+
+    # 500 and 300 occur 3x each; 400 occurs only once -- short relative to the
+    # multiple rounds a 6-call budget over these 7 calls will need.
+    timestep_seq = [500, 400, 300, 500, 300, 500, 300]
+    calib = {"timestep": np.array(timestep_seq, dtype=np.float16).reshape(len(timestep_seq), 1)}
+
+    selected = _select_calibration_calls(calib, max_rows=6)
+
+    selected_list = [int(c) for c in selected]
+    assert len(selected_list) == len(set(selected_list)), "duplicate call index selected"
+    assert len(selected_list) <= 6
+    selected_timesteps = {timestep_seq[c] for c in selected_list}
+    assert selected_timesteps == {500, 400, 300}, (
+        "every distinct timestep must be represented at least once, including the short (single-occurrence) bucket"
+    )
+
+
+def test_pool_for_layer_skips_out_of_window_call_without_crashing():
+    """FP8 Round 11 Item 2/3: a selected call whose index isn't in `records`
+    (fell outside the K/V/FI recorder's kept window) must be skipped, not
+    raise, and reported into `missed_calls` -- not silently lost with no
+    visibility, per the WARNING _pool_for_layer's caller now logs."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _pool_for_layer
+
+    records = {
+        0: np.zeros((1, 4, 8), dtype=np.float32),
+        2: np.ones((1, 4, 8), dtype=np.float32),
+        # call 1 is "out of window" -- deliberately no entry
+    }
+    missed: set = set()
+
+    pool = _pool_for_layer(records, [0, 1, 2], missed)
+
+    assert len(pool) == 2  # calls 0 and 2 each contributed one row; call 1 skipped
+    assert missed == {1}
+
+
+def test_pool_for_layer_missed_calls_none_is_a_no_op():
+    """missed_calls is optional -- omitting it must not raise, matching a
+    caller that doesn't care about out-of-window visibility."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _pool_for_layer
+
+    records = {5: np.zeros((2, 4, 8), dtype=np.float32)}
+    pool = _pool_for_layer(records, [5, 6])
+    assert len(pool) == 2
+
+
+def test_fill_kvo_from_pool_cyclic_shift_with_mixed_provenance_pool():
+    """Verified-safe claim (FP8 Round 11): _fill_kvo_from_pool indexes its pool
+    cyclically by position, provenance-agnostic. Under the stagger fix the pool
+    now holds entries from scattered, non-adjacent calls (different prompt
+    batches) instead of a contiguous early-prefix run, including different real
+    captured seq lengths per entry. The cyclic src=(m+1)%pool_len tiling must
+    still produce a well-formed, correctly-shaped, real (non-degenerate)
+    array."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _fill_kvo_from_pool
+
+    # Mixed provenance: three pool entries with different real seq lengths,
+    # standing in for K/V rows recorded from three different prompt batches.
+    k_pool = [
+        np.full((3, 8), 1.0, dtype=np.float32),
+        np.full((5, 8), 2.0, dtype=np.float32),
+        np.full((2, 8), 3.0, dtype=np.float32),
+    ]
+    v_pool = [
+        np.full((3, 8), 10.0, dtype=np.float32),
+        np.full((5, 8), 20.0, dtype=np.float32),
+        np.full((2, 8), 30.0, dtype=np.float32),
+    ]
+
+    arr_shape = [2 * 4, 8, 8]  # n_itr=4 -> dim0 = 2*n_itr (K/V pair); seq_t=hidden_t=8
+    out = _fill_kvo_from_pool(k_pool, v_pool, arr_shape, np.float32)
+
+    assert out.shape == tuple(arr_shape)
+    assert not np.isnan(out).any()
+    # Frame-shift-by-one, cyclic: m=0 draws pool[1], not pool[0] (see
+    # _fill_kvo_from_pool's docstring on the deliberate neighbour-frame shift).
+    assert out[0, 0, 0] == 2.0  # K, m=0 -> src=(0+1)%3=1 -> k_pool[1] filled with 2.0
+    assert out[1, 0, 0] == 20.0  # V, m=0 -> same src -> v_pool[1] filled with 20.0
+
+
+## FP8 Round 14 -- predictive call recording. _MAX_CALIB_RECORD_CALLS (64) was
+## raised in Round 11 to hold a full 8-distinct-timestep x 8-batch stagger
+## pass, but the companion _MAX_CALIB_RECORD_BYTES (4 GiB) trips first at
+## ~33 of the 64 needed calls, silently dropping calls 36/45/54/63 and
+## halving kvo/fio calibration diversity (measured on disk: 8 distinct K
+## sources pre-Round-11, 4 post-Round-11, in both calv7 engines). The fix
+## inverts the recorder: predict which calls _select_calibration_calls will
+## keep *before* the capture loop runs, and gate the hooks on membership in
+## that predicted set instead of a call-count prefix.
+
+
+def test_predict_selected_calls_pins_production_case():
+    """Pins _predict_selected_calls's output against the real 640x384
+    verification build's calib_data.meta.json ("selected_calls":
+    [0, 9, 18, 27, 36, 45, 54, 63], for 32 prompts x 8 steps). A future
+    change to the stagger in _select_calibration_calls that silently changes
+    what gets predicted must fail here first."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _predict_selected_calls
+
+    predicted = _predict_selected_calls(schedule_len=8, num_batches=32, max_rows=8)
+
+    assert [int(c) for c in predicted] == [0, 9, 18, 27, 36, 45, 54, 63]
+
+
+def test_predict_selected_calls_is_superset_under_budget_shrink():
+    """The real post-hoc call inside capture_calibration_data passes the full
+    captured calib_data, whose CFG-doubled keys (e.g. `sample` at 2 rows/call
+    under guidance_scale > 1) shrink _select_calibration_calls's effective
+    calls_budget below _MAX_CALIB_ROWS -- see _predict_selected_calls's own
+    superset-guarantee docstring. That shrink must only ever truncate the
+    max-budget prediction to a prefix, never diverge from it."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import (
+        _MAX_CALIB_ROWS,
+        _predict_selected_calls,
+        _select_calibration_calls,
+    )
+
+    schedule_len, num_batches = 8, 32
+    predicted = frozenset(int(c) for c in _predict_selected_calls(schedule_len, num_batches, _MAX_CALIB_ROWS))
+
+    timestep_seq = np.tile(np.arange(schedule_len, dtype=np.float32)[::-1], num_batches)
+    num_calls = timestep_seq.shape[0]
+    calib_data = {
+        "timestep": timestep_seq.reshape(num_calls, 1),
+        "sample": np.zeros((num_calls * 2, 1), dtype=np.float32),  # CFG-doubled key -> 2x multiplier
+    }
+    actual = _select_calibration_calls(calib_data, max_rows=_MAX_CALIB_ROWS)
+    actual_set = {int(c) for c in actual}
+
+    assert actual_set.issubset(predicted)
+    assert len(actual_set) < len(predicted), (
+        "the 2x-multiplier key must actually shrink the budget for this test to "
+        "exercise the truncation path, not just the trivial equal-budget case"
+    )
+
+
+def test_fill_kvo_from_pool_eight_recorded_calls_yield_eight_distinct_sources():
+    """The direct regression this whole round fixes: when all 8 predicted
+    calls have a recording, _fill_kvo_from_pool's 8 n_itr chunks must draw
+    from 8 distinct sources -- matching the pre-Round-11 (calv6) on-disk
+    measurement. See the companion 4-record test below for the regressed
+    (calv7) behaviour this replaces."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _fill_kvo_from_pool, _pool_for_layer
+
+    selected_calls = [0, 9, 18, 27, 36, 45, 54, 63]
+    # One distinguishable marker value per call, single sub-row each.
+    records = {c: np.full((1, 2, 4), float(i), dtype=np.float32) for i, c in enumerate(selected_calls)}
+    missed: set = set()
+
+    k_pool = _pool_for_layer(records, selected_calls, missed)
+    v_pool = _pool_for_layer(records, selected_calls, missed)
+
+    assert missed == set(), "all 8 predicted calls have a recording -- nothing should be missed"
+    assert len(k_pool) == 8
+
+    n_itr = 8
+    arr_shape = [2 * n_itr, 2, 4]
+    out = _fill_kvo_from_pool(k_pool, v_pool, arr_shape, np.float32)
+
+    distinct_k_sources = {float(out[m * 2, 0, 0]) for m in range(n_itr)}
+    assert len(distinct_k_sources) == 8
+
+
+def test_fill_kvo_from_pool_four_recorded_calls_yield_four_distinct_sources():
+    """Companion regression-documentation case: only the first 4 of 8
+    predicted calls survive recording (calls 36/45/54/63 fell outside the
+    byte-capped recorder window, the exact calv7 defect) -- _pool_for_layer
+    reports them missed, and _fill_kvo_from_pool's cyclic src=(m+1)%pool_len
+    reuse collapses the 8 n_itr chunks onto only 4 distinct sources instead
+    of 8. This is the shipped calv7 behaviour this plan's fix (predictive
+    recording) corrects -- kept as documentation of what regressed."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _fill_kvo_from_pool, _pool_for_layer
+
+    selected_calls = [0, 9, 18, 27, 36, 45, 54, 63]
+    recorded_calls = selected_calls[:4]  # 36/45/54/63 never recorded
+    records = {c: np.full((1, 2, 4), float(i), dtype=np.float32) for i, c in enumerate(recorded_calls)}
+    missed: set = set()
+
+    k_pool = _pool_for_layer(records, selected_calls, missed)
+    v_pool = _pool_for_layer(records, selected_calls, missed)
+
+    assert missed == {36, 45, 54, 63}
+    assert len(k_pool) == 4
+
+    n_itr = 8
+    arr_shape = [2 * n_itr, 2, 4]
+    out = _fill_kvo_from_pool(k_pool, v_pool, arr_shape, np.float32)
+
+    distinct_k_sources = {float(out[m * 2, 0, 0]) for m in range(n_itr)}
+    assert len(distinct_k_sources) == 4
+
+
+def test_recorder_admits_call_falls_back_to_prefix_after_batch_failure():
+    """FP8 Round 14 batch-failure fallback: a mid-capture pipe() failure
+    shifts every subsequent call index and invalidates the predicted-calls
+    set (capture_calibration_data flips _predict_valid["ok"] to False in
+    that except-block). Once invalid, a call index outside the prediction
+    must still be admitted -- degrading to the pre-Round-14 call-count-prefix
+    rule -- rather than being silently dropped for the rest of the capture."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _recorder_admits_call
+
+    predicted_calls = frozenset([0, 9, 18, 27, 36, 45, 54, 63])
+    max_calls = 64
+
+    # While the prediction is trustworthy: only predicted calls are admitted.
+    assert _recorder_admits_call(9, True, predicted_calls, max_calls) is True
+    assert _recorder_admits_call(10, True, predicted_calls, max_calls) is False
+
+    # After a batch failure invalidates the prediction: call 10 (outside the
+    # predicted set) must now be admitted, bounded only by the call-count cap.
+    assert _recorder_admits_call(10, False, predicted_calls, max_calls) is True
+    assert _recorder_admits_call(64, False, predicted_calls, max_calls) is False
+
+
+## FP8 Round 11 -- attn_bmm_dq_fed (builder.py's engine-inspector-adjacent
+## evidence-record metric, not fp8_quantize.py, but exercised here alongside
+## the other calib-tile ONNX-graph tests since it shares this file's
+## _make_min_onnx-style synthetic-graph convention).
+
+
+def _make_attn_bmm_onnx(path):
+    """Synthetic graph covering all four cases _count_attn_bmm_dq_fed must
+    distinguish:
+    - '.../attn1/MatMul' fed by two DequantizeLinear outputs -> counted, DQ-fed
+    - '.../attn1/MatMul_1' fed by one non-DQ input -> counted, NOT DQ-fed
+    - '.../attn2/MatMul' with one initializer input -> a projection MatMul
+      (one operand is a weight), excluded from the count entirely despite the
+      name matching _ATTN_BMM_NAME_RE
+    - '.../to_q/MatMul' -> name doesn't match _ATTN_BMM_NAME_RE at all, excluded
+    """
+    q_i8 = helper.make_tensor_value_info("q_i8", TensorProto.FLOAT, [2, 8, 64])
+    q_scale = helper.make_tensor_value_info("q_scale", TensorProto.FLOAT, [])
+    k_i8 = helper.make_tensor_value_info("k_i8", TensorProto.FLOAT, [2, 8, 64])
+    k_scale = helper.make_tensor_value_info("k_scale", TensorProto.FLOAT, [])
+    v_raw = helper.make_tensor_value_info("v_raw", TensorProto.FLOAT, [2, 8, 64])
+    softmax_out = helper.make_tensor_value_info("softmax_out", TensorProto.FLOAT, [2, 8, 8])
+    some_act = helper.make_tensor_value_info("some_act", TensorProto.FLOAT, [2, 8, 64])
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [2, 8, 64])
+
+    w_proj = helper.make_tensor("w_proj", TensorProto.FLOAT, [64, 64], [0.0] * (64 * 64))
+    w_proj2 = helper.make_tensor("w_proj2", TensorProto.FLOAT, [64, 64], [0.0] * (64 * 64))
+
+    dq_q = helper.make_node("DequantizeLinear", ["q_i8", "q_scale"], ["q_dq"], name="dq_q")
+    dq_k = helper.make_node("DequantizeLinear", ["k_i8", "k_scale"], ["k_dq"], name="dq_k")
+    identity_v = helper.make_node("Identity", ["v_raw"], ["v_ident"], name="identity_v")
+
+    dq_fed_bmm = helper.make_node("MatMul", ["q_dq", "k_dq"], ["attn1_scores"], name="/blocks.0/attn1/MatMul")
+    non_dq_fed_bmm = helper.make_node(
+        "MatMul", ["softmax_out", "v_ident"], ["attn1_out"], name="/blocks.0/attn1/MatMul_1"
+    )
+    projection_matmul_matching_name = helper.make_node(
+        "MatMul", ["some_act", "w_proj"], ["proj_out"], name="/blocks.0/attn2/MatMul"
+    )
+    unrelated_matmul = helper.make_node("MatMul", ["x", "w_proj2"], ["to_q_out"], name="/blocks.0/to_q/MatMul")
+
+    outs = [
+        helper.make_tensor_value_info("attn1_scores", TensorProto.FLOAT, [2, 8, 8]),
+        helper.make_tensor_value_info("attn1_out", TensorProto.FLOAT, [2, 8, 64]),
+        helper.make_tensor_value_info("proj_out", TensorProto.FLOAT, [2, 8, 64]),
+        helper.make_tensor_value_info("to_q_out", TensorProto.FLOAT, [2, 8, 64]),
+    ]
+    g = helper.make_graph(
+        [dq_q, dq_k, identity_v, dq_fed_bmm, non_dq_fed_bmm, projection_matmul_matching_name, unrelated_matmul],
+        "attn_bmm",
+        [q_i8, q_scale, k_i8, k_scale, v_raw, softmax_out, some_act, x],
+        outs,
+        initializer=[w_proj, w_proj2],
+    )
+    onnx.save(helper.make_model(g, opset_imports=[helper.make_opsetid("", 17)]), path)
+
+
+def test_count_attn_bmm_dq_fed_distinguishes_dq_fed_from_non_dq_fed_and_projections(tmp_path):
+    """Pins the attn_bmm_dq_fed evidence-record metric (builder.py, FP8 Round
+    11): of the two real attention BMMs in the synthetic graph, only the one
+    fed by two DequantizeLinear outputs counts as dq_fed; the projection
+    MatMul (one operand a weight initializer) and the unrelated MatMul (name
+    doesn't match /attn[12]/MatMul) are excluded from both counts entirely --
+    466/466 on a real -mhaq build is this same (dq_fed, total) shape, just
+    larger."""
+    from streamdiffusion.acceleration.tensorrt.builder import _count_attn_bmm_dq_fed
+
+    onnx_path = str(tmp_path / "attn_bmm.onnx")
+    _make_attn_bmm_onnx(onnx_path)
+
+    result = _count_attn_bmm_dq_fed(onnx_path)
+
+    assert result == (1, 2)
+
+
+def test_count_attn_bmm_dq_fed_missing_path_returns_none(tmp_path):
+    """Best-effort posture matching the rest of the inspector block: a
+    nonexistent onnx_path must return None, not raise."""
+    from streamdiffusion.acceleration.tensorrt.builder import _count_attn_bmm_dq_fed
+
+    result = _count_attn_bmm_dq_fed(str(tmp_path / "does_not_exist.onnx"))
+
+    assert result is None

--- a/tests/unit/test_config_extraction_golden.py
+++ b/tests/unit/test_config_extraction_golden.py
@@ -20,6 +20,7 @@ MINIMAL_CONFIG = {"model_id": "stabilityai/sd-turbo"}
 EXPECTED_WRAPPER_PARAMS = {
     "model_id_or_path": "stabilityai/sd-turbo",
     "t_index_list": [0, 16, 32, 45],
+    "num_inference_steps": 50,
     "mode": "img2img",
     "output_type": "pil",
     "device": "cuda",
@@ -52,6 +53,9 @@ EXPECTED_WRAPPER_PARAMS = {
     "build_engines_if_missing": True,
     "fp8_allow_fp16_fallback": False,
     "fp8_mha_qdq": False,
+    "fp8_scale_headroom": 1.0,
+    "fp8_exclude_attention": False,
+    "fp8_exclude_ipadapter": False,
     "use_controlnet": False,
     "use_ipadapter": False,
     "use_cached_attn": False,

--- a/tests/unit/test_fp8_calib_provenance.py
+++ b/tests/unit/test_fp8_calib_provenance.py
@@ -1,0 +1,304 @@
+"""
+Regression tests for fp8-round-13's calibration provenance record.
+
+Before this round, a cached ``calib_data.npz`` hit
+(``builder.py``'s ``if os.path.exists(_calib_data_path):`` short-circuit) logged only
+the path -- nothing recorded how the npz was actually captured (resolution, prompt
+count, which calibration calls survived selection). Worse, a run that crashed
+mid-capture -- after ``capture_calibration_data`` finished writing the npz but before
+``builder.py`` reached the end-of-build ``_write_build_stats`` call -- left literally
+zero trace of having run at all: a correct, complete artifact with zero provenance
+(the fp8-round-10 ~07:14 aborted capture, found only by the npz's own mtime predating
+the engine it fed by roughly an hour).
+
+The fix is metadata-only (fp8_quantize.py's ``_build_calib_provenance`` /
+``_write_calib_provenance_sidecar`` / ``load_calib_provenance``, plus builder.py
+echoing the sidecar into ``build_stats.json`` on both the cached and built paths and
+flushing stats right after the capture stage resolves) -- it does not change what gets
+calibrated, so it never forks the ``calv*`` cache tag.
+
+Run with: pytest tests/unit/test_fp8_calib_provenance.py -v
+"""
+
+import json
+
+import numpy as np
+
+from streamdiffusion.acceleration.tensorrt.builder import _cleanup_intermediates, _write_build_stats
+from streamdiffusion.acceleration.tensorrt.fp8_quantize import (
+    _build_calib_provenance,
+    _write_calib_provenance_sidecar,
+    load_calib_provenance,
+)
+
+
+def _fake_calib_data():
+    return {
+        "sample": np.zeros((8, 4, 64, 64), dtype=np.float16),
+        "timestep": np.array([919, 779, 639, 559, 499, 359, 219, 79], dtype=np.float32),
+    }
+
+
+class TestBuildCalibProvenance:
+    """`_build_calib_provenance` is a pure function -- no disk I/O -- so these
+    exercise its payload shape directly."""
+
+    def test_payload_contains_expected_keys(self):
+        provenance = _build_calib_provenance(
+            _fake_calib_data(),
+            image_height=384,
+            image_width=640,
+            prompt_count=32,
+            num_inference_steps=4,
+            guidance_scale=1.0,
+            ipadapter_tokens_real=True,
+            selected_calls=np.array([3, 1, 7, 0]),
+            pool_missed_calls={5, 2},
+        )
+        expected_keys = {
+            "schema_version",
+            "captured_at_utc",
+            "image_height",
+            "image_width",
+            "prompt_count",
+            "num_inference_steps",
+            "guidance_scale",
+            "ipadapter_tokens_real",
+            "captured_timesteps",
+            "selected_timesteps",
+            "selected_calls",
+            "pool_missed_calls",
+            "row_count",
+        }
+        assert expected_keys <= set(provenance.keys())
+        assert provenance["image_height"] == 384
+        assert provenance["image_width"] == 640
+        assert provenance["row_count"] == 8
+        # selected_calls/pool_missed_calls are sorted for a deterministic, diffable file.
+        assert provenance["selected_calls"] == [0, 1, 3, 7]
+        assert provenance["pool_missed_calls"] == [2, 5]
+        assert provenance["captured_timesteps"] == sorted(provenance["captured_timesteps"], reverse=True)
+
+    def test_selected_calls_none_does_not_raise(self):
+        """`_selected_calls` is only assigned inside capture_calibration_data's
+        onnx_path/(use_cached_attn or use_controlnet or num_ip_layers) branch --
+        a plain UNet capture with none of those set never runs it, so the caller
+        passes None here. Must not raise (e.g. sorting a None)."""
+        provenance = _build_calib_provenance(
+            _fake_calib_data(),
+            image_height=512,
+            image_width=512,
+            selected_calls=None,
+            pool_missed_calls=None,
+        )
+        assert provenance["selected_calls"] is None
+        assert provenance["pool_missed_calls"] == []
+
+    def test_round_trips_through_json(self):
+        """Every value must be JSON-serializable as-is (no bare numpy scalars/arrays
+        leaking through) -- this is what _write_calib_provenance_sidecar's
+        json.dump would otherwise choke on."""
+        provenance = _build_calib_provenance(
+            _fake_calib_data(),
+            image_height=384,
+            image_width=640,
+            selected_calls=np.array([2, 0]),
+            pool_missed_calls={1},
+        )
+        round_tripped = json.loads(json.dumps(provenance))
+        assert round_tripped == provenance
+
+    def test_schema_v2_recorder_fields_present(self):
+        """FP8 Round 14 / schema v2: the K/V/FI recorder's own state (what was
+        predicted, what was actually kept, the caps it was bounded by, and the
+        resulting kvo pool length) must ride along in the sidecar so two builds
+        carrying an identical calv8 tag but different env-overridden recorder
+        caps (SDTD_FP8_CALIB_RECORD_CALLS/_BYTES, not part of the cache key)
+        have something on disk to tell them apart."""
+        provenance = _build_calib_provenance(
+            _fake_calib_data(),
+            image_height=384,
+            image_width=640,
+            selected_calls=np.array([0, 9, 18, 27, 36, 45, 54, 63]),
+            pool_missed_calls=set(),
+            predicted_calls=np.array([0, 9, 18, 27, 36, 45, 54, 63]),
+            record_calls_kept=8,
+            record_bytes=1_073_741_824,
+            record_max_calls=64,
+            record_max_bytes=4 * 1024**3,
+            kvo_pool_len=8,
+        )
+
+        assert provenance["schema_version"] == 2
+        assert provenance["predicted_calls"] == [0, 9, 18, 27, 36, 45, 54, 63]
+        assert provenance["record_calls_kept"] == 8
+        assert provenance["record_bytes"] == 1_073_741_824
+        assert provenance["record_max_calls"] == 64
+        assert provenance["record_max_bytes"] == 4 * 1024**3
+        assert provenance["kvo_pool_len"] == 8
+
+    def test_schema_v2_recorder_fields_default_empty_or_none(self):
+        """The ControlNet capture path (capture_calibration_data_controlnet) has
+        no K/V recorder at all, so its _build_calib_provenance call site omits
+        every v2 recorder kwarg -- must default to None/[] rather than raise or
+        require the caller to pass placeholders."""
+        provenance = _build_calib_provenance(
+            _fake_calib_data(),
+            image_height=512,
+            image_width=512,
+        )
+
+        assert provenance["predicted_calls"] == []
+        assert provenance["record_calls_kept"] is None
+        assert provenance["record_bytes"] is None
+        assert provenance["record_max_calls"] is None
+        assert provenance["record_max_bytes"] is None
+        assert provenance["kvo_pool_len"] is None
+
+
+class TestWriteCalibProvenanceSidecar:
+    def test_write_then_load_round_trips(self, tmp_path):
+        npz_path = str(tmp_path / "calib_data.npz")
+        # capture_calibration_data always writes the npz itself before calling the
+        # sidecar writer -- the sidecar naming (with_name(stem + ".meta.json")) does
+        # not depend on the npz actually existing, but write it anyway for realism.
+        np.savez(npz_path, sample=np.zeros((1,)))
+        provenance = _build_calib_provenance(_fake_calib_data(), image_height=512, image_width=512)
+
+        _write_calib_provenance_sidecar(npz_path, provenance)
+
+        meta_path = tmp_path / "calib_data.meta.json"
+        assert meta_path.exists()
+        loaded = load_calib_provenance(npz_path)
+        assert loaded == provenance
+
+    def test_missing_sidecar_returns_none_not_error(self, tmp_path):
+        """Every pre-fp8-round-13 engine dir has a calib_data.npz but no sidecar --
+        this must degrade to None, not raise, so builder.py's cached-branch can
+        fall back to the "provenance unavailable" message."""
+        npz_path = str(tmp_path / "calib_data.npz")
+        np.savez(npz_path, sample=np.zeros((1,)))
+        assert load_calib_provenance(npz_path) is None
+
+    def test_v1_sidecar_loads_without_raising(self, tmp_path):
+        """FP8 Round 14 bumped schema_version 1 -> 2 and added six recorder
+        fields. The 640x384 verification engine (hfb5ce64fea8d) already carries
+        a real v1 sidecar on disk -- load_calib_provenance reads the file as
+        plain JSON with no schema validation, so a v1 payload missing every new
+        key must still load, not raise or silently drop to None."""
+        npz_path = str(tmp_path / "calib_data.npz")
+        np.savez(npz_path, sample=np.zeros((1,)))
+        v1_payload = {
+            "schema_version": 1,
+            "captured_at_utc": "2026-08-11T13:51:53.480065+00:00",
+            "image_height": 384,
+            "image_width": 640,
+            "prompt_count": 32,
+            "num_inference_steps": 8,
+            "guidance_scale": 0.0,
+            "ipadapter_tokens_real": True,
+            "captured_timesteps": [919.0, 779.0, 699.0, 639.0, 499.0, 359.0, 219.0, 79.0],
+            "selected_timesteps": [919.0, 779.0, 699.0, 639.0, 499.0, 359.0, 219.0, 79.0],
+            "selected_calls": [0, 9, 18, 27, 36, 45, 54, 63],
+            "pool_missed_calls": [36, 45, 54, 63],
+            "row_count": 8,
+            # deliberately no predicted_calls/record_calls_kept/record_bytes/
+            # record_max_calls/record_max_bytes/kvo_pool_len -- those are v2-only.
+        }
+        meta_path = tmp_path / "calib_data.meta.json"
+        meta_path.write_text(json.dumps(v1_payload), encoding="utf-8")
+
+        loaded = load_calib_provenance(npz_path)
+
+        assert loaded == v1_payload
+        assert loaded["schema_version"] == 1
+        assert "predicted_calls" not in loaded
+
+    def test_write_failure_is_swallowed(self, tmp_path):
+        """A metadata write must never abort a capture that just spent up to
+        ~47 minutes producing the npz it describes -- point save_path at a
+        directory that does not exist so the write fails, and assert no
+        exception propagates."""
+        bad_path = str(tmp_path / "does_not_exist" / "calib_data.npz")
+        provenance = _build_calib_provenance(_fake_calib_data(), image_height=512, image_width=512)
+
+        _write_calib_provenance_sidecar(bad_path, provenance)  # must not raise
+
+        assert not (tmp_path / "does_not_exist").exists()
+
+
+class TestCleanupIntermediatesPreservesSidecar:
+    """The regression that would silently gut this feature: `_cleanup_intermediates`
+    runs from a `finally` block at the end of every build and deletes everything not
+    on its `_keep_exact`/`_keep_suffixes` allowlist -- a sidecar not on that list
+    would be destroyed at the end of the very build that wrote it."""
+
+    def test_calib_data_meta_json_survives_cleanup(self, tmp_path):
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        (engine_dir / "calib_data.meta.json").write_text("{}")
+        (engine_dir / "calib_data.npz").write_bytes(b"")
+        (engine_dir / "build_stats.json").write_text("{}")
+        (engine_dir / "unet.engine.onnx").write_bytes(b"")  # intermediate, must be deleted
+        (engine_dir / "unet.engine.opt.onnx").write_bytes(b"")  # intermediate, must be deleted
+
+        _cleanup_intermediates(str(engine_dir), fp8_ok=False)
+
+        assert (engine_dir / "calib_data.meta.json").exists()
+        assert (engine_dir / "calib_data.npz").exists()
+        assert (engine_dir / "build_stats.json").exists()
+        assert not (engine_dir / "unet.engine.onnx").exists()
+        assert not (engine_dir / "unet.engine.opt.onnx").exists()
+
+
+class TestWriteBuildStatsAppendGlobal:
+    """fp8-round-13's mid-build flush (builder.py, right after the capture stage
+    resolves) must not duplicate the build_log.jsonl line every successful build
+    already gets from the end-of-build _write_build_stats call."""
+
+    def _make_engine_path(self, tmp_path):
+        engines_root = tmp_path / "engines" / "td" / "stabilityai"
+        engine_dir = engines_root / "sdxl-turbo--fp8v4-mhaq--htest--res-384x640"
+        engine_dir.mkdir(parents=True)
+        return str(engine_dir / "unet.engine"), engines_root
+
+    def test_append_global_false_writes_stats_but_not_jsonl(self, tmp_path):
+        engine_path, engines_root = self._make_engine_path(tmp_path)
+        stats = {"engine_dir": "test", "stages": {"fp8_calib_capture": {"status": "built"}}}
+
+        _write_build_stats(engine_path, stats, append_global=False)
+
+        stats_file = engines_root / "sdxl-turbo--fp8v4-mhaq--htest--res-384x640" / "build_stats.json"
+        assert stats_file.exists()
+        assert json.loads(stats_file.read_text()) == stats
+        assert not (engines_root / "build_log.jsonl").exists()
+
+    def test_append_global_true_still_writes_jsonl(self, tmp_path):
+        """Default behavior (the pre-fp8-round-13 signature) is unchanged -- the
+        end-of-build call relies on this."""
+        engine_path, engines_root = self._make_engine_path(tmp_path)
+        stats = {"engine_dir": "test", "stages": {}}
+
+        _write_build_stats(engine_path, stats)
+
+        jsonl_path = engines_root / "build_log.jsonl"
+        assert jsonl_path.exists()
+        lines = jsonl_path.read_text().strip().splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0]) == stats
+
+    def test_mid_build_flush_then_final_write_appends_exactly_once(self, tmp_path):
+        """Simulates the real sequence: a mid-build flush (append_global=False)
+        followed by the end-of-build write (append_global=True, the default) --
+        build_log.jsonl must gain exactly one line, not two."""
+        engine_path, engines_root = self._make_engine_path(tmp_path)
+        stats = {"engine_dir": "test", "stages": {"fp8_calib_capture": {"status": "built"}}}
+
+        _write_build_stats(engine_path, stats, append_global=False)
+        stats["total_elapsed_s"] = 123.4
+        _write_build_stats(engine_path, stats)
+
+        jsonl_path = engines_root / "build_log.jsonl"
+        lines = jsonl_path.read_text().strip().splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["total_elapsed_s"] == 123.4

--- a/tests/unit/test_fp8_calib_provenance.py
+++ b/tests/unit/test_fp8_calib_provenance.py
@@ -24,7 +24,6 @@ import json
 
 import numpy as np
 
-from streamdiffusion.acceleration.tensorrt.builder import _cleanup_intermediates, _write_build_stats
 from streamdiffusion.acceleration.tensorrt.fp8_quantize import (
     _build_calib_provenance,
     _write_calib_provenance_sidecar,
@@ -227,78 +226,8 @@ class TestWriteCalibProvenanceSidecar:
         assert not (tmp_path / "does_not_exist").exists()
 
 
-class TestCleanupIntermediatesPreservesSidecar:
-    """The regression that would silently gut this feature: `_cleanup_intermediates`
-    runs from a `finally` block at the end of every build and deletes everything not
-    on its `_keep_exact`/`_keep_suffixes` allowlist -- a sidecar not on that list
-    would be destroyed at the end of the very build that wrote it."""
-
-    def test_calib_data_meta_json_survives_cleanup(self, tmp_path):
-        engine_dir = tmp_path / "engine"
-        engine_dir.mkdir()
-        (engine_dir / "calib_data.meta.json").write_text("{}")
-        (engine_dir / "calib_data.npz").write_bytes(b"")
-        (engine_dir / "build_stats.json").write_text("{}")
-        (engine_dir / "unet.engine.onnx").write_bytes(b"")  # intermediate, must be deleted
-        (engine_dir / "unet.engine.opt.onnx").write_bytes(b"")  # intermediate, must be deleted
-
-        _cleanup_intermediates(str(engine_dir), fp8_ok=False)
-
-        assert (engine_dir / "calib_data.meta.json").exists()
-        assert (engine_dir / "calib_data.npz").exists()
-        assert (engine_dir / "build_stats.json").exists()
-        assert not (engine_dir / "unet.engine.onnx").exists()
-        assert not (engine_dir / "unet.engine.opt.onnx").exists()
-
-
-class TestWriteBuildStatsAppendGlobal:
-    """fp8-round-13's mid-build flush (builder.py, right after the capture stage
-    resolves) must not duplicate the build_log.jsonl line every successful build
-    already gets from the end-of-build _write_build_stats call."""
-
-    def _make_engine_path(self, tmp_path):
-        engines_root = tmp_path / "engines" / "td" / "stabilityai"
-        engine_dir = engines_root / "sdxl-turbo--fp8v4-mhaq--htest--res-384x640"
-        engine_dir.mkdir(parents=True)
-        return str(engine_dir / "unet.engine"), engines_root
-
-    def test_append_global_false_writes_stats_but_not_jsonl(self, tmp_path):
-        engine_path, engines_root = self._make_engine_path(tmp_path)
-        stats = {"engine_dir": "test", "stages": {"fp8_calib_capture": {"status": "built"}}}
-
-        _write_build_stats(engine_path, stats, append_global=False)
-
-        stats_file = engines_root / "sdxl-turbo--fp8v4-mhaq--htest--res-384x640" / "build_stats.json"
-        assert stats_file.exists()
-        assert json.loads(stats_file.read_text()) == stats
-        assert not (engines_root / "build_log.jsonl").exists()
-
-    def test_append_global_true_still_writes_jsonl(self, tmp_path):
-        """Default behavior (the pre-fp8-round-13 signature) is unchanged -- the
-        end-of-build call relies on this."""
-        engine_path, engines_root = self._make_engine_path(tmp_path)
-        stats = {"engine_dir": "test", "stages": {}}
-
-        _write_build_stats(engine_path, stats)
-
-        jsonl_path = engines_root / "build_log.jsonl"
-        assert jsonl_path.exists()
-        lines = jsonl_path.read_text().strip().splitlines()
-        assert len(lines) == 1
-        assert json.loads(lines[0]) == stats
-
-    def test_mid_build_flush_then_final_write_appends_exactly_once(self, tmp_path):
-        """Simulates the real sequence: a mid-build flush (append_global=False)
-        followed by the end-of-build write (append_global=True, the default) --
-        build_log.jsonl must gain exactly one line, not two."""
-        engine_path, engines_root = self._make_engine_path(tmp_path)
-        stats = {"engine_dir": "test", "stages": {"fp8_calib_capture": {"status": "built"}}}
-
-        _write_build_stats(engine_path, stats, append_global=False)
-        stats["total_elapsed_s"] = 123.4
-        _write_build_stats(engine_path, stats)
-
-        jsonl_path = engines_root / "build_log.jsonl"
-        lines = jsonl_path.read_text().strip().splitlines()
-        assert len(lines) == 1
-        assert json.loads(lines[0])["total_elapsed_s"] == 123.4
+# `TestCleanupIntermediatesPreservesSidecar` / `TestWriteBuildStatsAppendGlobal`
+# (builder.py's `_cleanup_intermediates` / `_write_build_stats(..., append_global=...)`)
+# intentionally live in pr/trt-build-telemetry instead of here: this PR's cherry-pick
+# does not touch builder.py, so those tests would fail against a builder.py that
+# predates that PR's changes.

--- a/tests/unit/test_fp8_calibration_capture_resolution.py
+++ b/tests/unit/test_fp8_calibration_capture_resolution.py
@@ -1,0 +1,150 @@
+"""
+Regression tests for fp8-round-10's fix to capture_calibration_data's missing
+height/width threading -- without them, diffusers falls back to
+pipe.unet.config.sample_size (512 for SDXL-Turbo) regardless of the engine's
+actual build resolution, and nothing downstream can correct it because
+`sample`'s ONNX H/W axes are exported dynamic. The statically-declared
+kvo_cache_in_*/fio_cache_in_* inputs then get zero-padded by _reconcile_2d,
+with a real-vs-padded seq fraction of (512/R)^2 -- 25% real at 1024, 11% at
+1536. See fp8_quantize.py's _build_capture_call_kwargs /
+capture_calibration_data docstrings and the fp8-round-10 plan for the full
+derivation.
+
+These tests exercise _build_capture_call_kwargs directly -- a pure,
+module-level helper with no CUDA/pipeline/torch dependency -- rather than
+capture_calibration_data itself, which needs a real diffusers pipeline.
+
+Run with: pytest tests/unit/test_fp8_calibration_capture_resolution.py -v
+"""
+
+import pytest
+
+from streamdiffusion.acceleration.tensorrt.fp8_quantize import _build_capture_call_kwargs
+
+
+def test_no_resolution_matches_prior_behavior():
+    """Omitting image_height/image_width (the default, and every pre-fp8-round-10
+    caller's behavior) must not add height/width keys -- 512-native builds stay
+    byte-for-byte unaffected by this change."""
+    kwargs = _build_capture_call_kwargs(
+        batch=["a portrait"],
+        guidance_scale=7.5,
+        use_explicit_schedule=False,
+        timesteps=None,
+        num_inference_steps=20,
+    )
+    assert kwargs == {
+        "prompt": "a portrait",
+        "output_type": "latent",
+        "guidance_scale": 7.5,
+        "num_inference_steps": 20,
+    }
+    assert "height" not in kwargs
+    assert "width" not in kwargs
+
+
+@pytest.mark.parametrize("image_height, image_width", [(1024, None), (None, 1024)])
+def test_resolution_omitted_when_only_one_given(image_height, image_width):
+    """A lone height or width is ambiguous -- mirrors capture_calibration_data's
+    existing timesteps/scheduler_ref one-of-two handling. Neither key should
+    appear rather than guessing the missing dimension."""
+    kwargs = _build_capture_call_kwargs(
+        batch=["a portrait"],
+        guidance_scale=7.5,
+        use_explicit_schedule=False,
+        timesteps=None,
+        num_inference_steps=20,
+        image_height=image_height,
+        image_width=image_width,
+    )
+    assert "height" not in kwargs
+    assert "width" not in kwargs
+
+
+def test_resolution_included_when_both_given_non_square():
+    """Non-square case (1024x576): pins that the two axes thread through
+    independently rather than one silently mirroring the other."""
+    kwargs = _build_capture_call_kwargs(
+        batch=["a portrait"],
+        guidance_scale=7.5,
+        use_explicit_schedule=False,
+        timesteps=None,
+        num_inference_steps=20,
+        image_height=1024,
+        image_width=576,
+    )
+    assert kwargs["height"] == 1024
+    assert kwargs["width"] == 576
+
+
+def test_explicit_schedule_uses_timesteps_not_num_inference_steps():
+    kwargs = _build_capture_call_kwargs(
+        batch=["a portrait"],
+        guidance_scale=1.0,
+        use_explicit_schedule=True,
+        timesteps=[999, 761, 499],
+        num_inference_steps=999,  # must be ignored
+    )
+    assert kwargs["timesteps"] == [999, 761, 499]
+    assert "num_inference_steps" not in kwargs
+
+
+def test_non_explicit_schedule_uses_num_inference_steps_not_timesteps():
+    kwargs = _build_capture_call_kwargs(
+        batch=["a portrait"],
+        guidance_scale=1.0,
+        use_explicit_schedule=False,
+        timesteps=[999, 761, 499],  # must be ignored
+        num_inference_steps=20,
+    )
+    assert kwargs["num_inference_steps"] == 20
+    assert "timesteps" not in kwargs
+
+
+@pytest.mark.parametrize("use_explicit_schedule", [True, False])
+def test_resolution_orthogonal_to_schedule_branch(use_explicit_schedule):
+    """height/width must thread through regardless of which of the two
+    mutually-exclusive schedule branches (timesteps vs num_inference_steps) is
+    active -- they are independent axes of the same call, so the resolution fix
+    must not depend on which schedule mode a given build uses."""
+    kwargs = _build_capture_call_kwargs(
+        batch=["a portrait"],
+        guidance_scale=1.0,
+        use_explicit_schedule=use_explicit_schedule,
+        timesteps=[999, 761],
+        num_inference_steps=20,
+        image_height=1024,
+        image_width=1024,
+    )
+    assert kwargs["height"] == 1024
+    assert kwargs["width"] == 1024
+    if use_explicit_schedule:
+        assert kwargs["timesteps"] == [999, 761]
+        assert "num_inference_steps" not in kwargs
+    else:
+        assert kwargs["num_inference_steps"] == 20
+        assert "timesteps" not in kwargs
+
+
+def test_batch_of_multiple_prompts_passed_as_list():
+    """batch_size > 1: prompt must be the full list, not just batch[0] (existing
+    pre-fp8-round-10 behavior, pinned here since it moved into the new helper)."""
+    kwargs = _build_capture_call_kwargs(
+        batch=["prompt a", "prompt b"],
+        guidance_scale=7.5,
+        use_explicit_schedule=False,
+        timesteps=None,
+        num_inference_steps=20,
+    )
+    assert kwargs["prompt"] == ["prompt a", "prompt b"]
+
+
+def test_batch_of_single_prompt_passed_as_string():
+    kwargs = _build_capture_call_kwargs(
+        batch=["prompt a"],
+        guidance_scale=7.5,
+        use_explicit_schedule=False,
+        timesteps=None,
+        num_inference_steps=20,
+    )
+    assert kwargs["prompt"] == "prompt a"

--- a/tests/unit/test_fp8_calibration_mode_dirs.py
+++ b/tests/unit/test_fp8_calibration_mode_dirs.py
@@ -1,0 +1,165 @@
+"""
+Regression tests for adapter-mode-aware FP8 calibration image resolution
+(fp8-round-9.1 §10, wrapper.py / fp8_quantize.py / engine_manager.py).
+
+fp8-round-9.1 wired real calibration images into FP8 IP-Adapter token
+resolution, but a single flat folder is subject-constrained the moment the
+config switches to `type: faceid`: InsightFace/ArcFace raises on any image
+with no detectable face (diffusers_ipadapter/ip_adapter/face_utils.py's
+extract_face_embeddings), and get_image_embeds is all-or-nothing, so one
+non-face image in a shared folder would delete every other image's
+contribution too and silently degrade the whole calibration set to zero-pad.
+
+§10's fix is two folders keyed on encoder *modality* -- `general/` for
+CLIP-based adapters (regular/plus), `faces/` for FaceID -- resolved once by
+`_resolve_fp8_calibration_dir` and threaded into both the `--ci<hash>`
+cache-key call and the actual image loader, so the two can never disagree
+about which folder is in play. This file pins that resolver, plus the
+`_list_calibration_images` helper now shared by the loader, the resolver,
+and `EngineManager._calibration_image_signature`.
+"""
+
+import hashlib
+import logging
+from pathlib import Path
+
+from PIL import Image
+
+from streamdiffusion.acceleration.tensorrt.engine_manager import EngineManager
+from streamdiffusion.acceleration.tensorrt.fp8_quantize import _list_calibration_images
+from streamdiffusion.wrapper import _load_fp8_calibration_style_images, _resolve_fp8_calibration_dir
+
+
+def _write_tiny_image(path: Path, fill=(10, 20, 30)) -> None:
+    Image.new("RGB", (2, 2), color=fill).save(path)
+
+
+def _make_engine_manager(engine_dir: str) -> EngineManager:
+    """Build an EngineManager without running __init__'s heavy compile-fn
+    imports -- same pattern as test_engine_path_ipadapter_suffixes.py.
+    `_calibration_image_signature` only touches Path/hashlib, so `_configs`
+    is never needed here."""
+    em = EngineManager.__new__(EngineManager)
+    em.engine_dir = Path(engine_dir)
+    return em
+
+
+class TestResolveFp8CalibrationDir:
+    def test_regular_and_plus_resolve_to_general_faceid_resolves_to_faces(self, tmp_path):
+        root = tmp_path / "calibration"
+        general = root / "general"
+        faces = root / "faces"
+        general.mkdir(parents=True)
+        faces.mkdir(parents=True)
+        _write_tiny_image(general / "a.png")
+        _write_tiny_image(faces / "b.png")
+
+        assert _resolve_fp8_calibration_dir(str(root), "regular") == str(general)
+        assert _resolve_fp8_calibration_dir(str(root), "plus") == str(general)
+        assert _resolve_fp8_calibration_dir(str(root), "faceid") == str(faces)
+
+    def test_unrecognized_type_defaults_to_general(self, tmp_path):
+        """A type string this table doesn't know about must not crash --
+        default to the CLIP-based folder, same as None/unset."""
+        root = tmp_path / "calibration"
+        general = root / "general"
+        general.mkdir(parents=True)
+        _write_tiny_image(general / "a.png")
+
+        assert _resolve_fp8_calibration_dir(str(root), "some_future_type") == str(general)
+        assert _resolve_fp8_calibration_dir(str(root), None) == str(general)
+
+    def test_missing_subfolder_returns_original_path_unchanged_with_warning(self, tmp_path, caplog):
+        root = tmp_path / "calibration"
+        root.mkdir()
+        _write_tiny_image(root / "flat.png")  # no faces/ subfolder under root
+
+        with caplog.at_level(logging.WARNING, logger="streamdiffusion.wrapper"):
+            result = _resolve_fp8_calibration_dir(str(root), "faceid")
+
+        assert result == str(root)
+        assert any("faces" in r.message and "faceid" in r.message for r in caplog.records)
+
+    def test_empty_subfolder_treated_as_missing(self, tmp_path):
+        """The subfolder exists but has no recognized-extension file in it --
+        must fall back exactly like a missing subfolder, not return an
+        empty directory the loader would then find nothing in."""
+        root = tmp_path / "calibration"
+        faces = root / "faces"
+        faces.mkdir(parents=True)
+        _write_tiny_image(root / "flat.png")
+
+        result = _resolve_fp8_calibration_dir(str(root), "faceid")
+
+        assert result == str(root)
+
+    def test_single_file_path_returned_unchanged_no_mode_logic(self, tmp_path):
+        f = tmp_path / "style.png"
+        _write_tiny_image(f)
+
+        assert _resolve_fp8_calibration_dir(str(f), "faceid") == str(f)
+        assert _resolve_fp8_calibration_dir(str(f), "regular") == str(f)
+
+    def test_none_path_returns_none(self):
+        assert _resolve_fp8_calibration_dir(None, "faceid") is None
+
+    def test_nonexistent_path_returns_unchanged(self, tmp_path):
+        missing = tmp_path / "does_not_exist"
+
+        assert _resolve_fp8_calibration_dir(str(missing), "faceid") == str(missing)
+
+
+class TestListLoadHashAgreement:
+    """The three call sites (`_list_calibration_images`,
+    `_load_fp8_calibration_style_images`, `EngineManager.
+    _calibration_image_signature`) must always agree on which files count --
+    a disagreement would mean the `--ci<hash>` cache key could name a
+    different image set than the one actually loaded into calibration."""
+
+    def test_loader_lister_and_hasher_agree_on_which_files_count(self, tmp_path):
+        root = tmp_path / "calibration" / "general"
+        root.mkdir(parents=True)
+        _write_tiny_image(root / "a.png")
+        _write_tiny_image(root / "b.png")
+        em = _make_engine_manager(str(tmp_path / "engines"))
+
+        listed_before = _list_calibration_images(str(root))
+        loaded_before = _load_fp8_calibration_style_images(str(root))
+        sig_before = em._calibration_image_signature(str(root))
+
+        assert len(listed_before) == 2
+        assert loaded_before is not None and len(loaded_before) == 2
+        assert sig_before is not None
+
+        # An unrecognized extension must be invisible to all three -- proves
+        # they're all working from the same file set, not just the same count.
+        (root / "notes.txt").write_text("not an image")
+
+        listed_after = _list_calibration_images(str(root))
+        loaded_after = _load_fp8_calibration_style_images(str(root))
+        sig_after = em._calibration_image_signature(str(root))
+
+        assert len(listed_after) == len(listed_before)
+        assert loaded_after is not None and len(loaded_after) == len(loaded_before)
+        assert sig_after == sig_before
+
+    def test_nested_subdirectory_image_is_invisible_to_all_three(self, tmp_path):
+        """Deliberately non-recursive: a mode-folder split one level below
+        `path` (§10.1's `general/`/`faces/`) must not itself be picked up by
+        a listing rooted at `path`'s parent, and any other accidental
+        nesting must stay invisible too."""
+        root = tmp_path / "calibration" / "general"
+        nested = root / "nested"
+        nested.mkdir(parents=True)
+        _write_tiny_image(root / "a.png")
+        _write_tiny_image(nested / "hidden.png")
+        em = _make_engine_manager(str(tmp_path / "engines"))
+
+        listed = _list_calibration_images(str(root))
+        loaded = _load_fp8_calibration_style_images(str(root))
+        sig = em._calibration_image_signature(str(root))
+
+        assert len(listed) == 1
+        assert loaded is not None and len(loaded) == 1
+        expected_sig = hashlib.sha1((root / "a.png").read_bytes()).hexdigest()[:6]
+        assert sig == expected_sig

--- a/tests/unit/test_fp8_calibration_mode_dirs.py
+++ b/tests/unit/test_fp8_calibration_mode_dirs.py
@@ -14,34 +14,25 @@ contribution too and silently degrade the whole calibration set to zero-pad.
 CLIP-based adapters (regular/plus), `faces/` for FaceID -- resolved once by
 `_resolve_fp8_calibration_dir` and threaded into both the `--ci<hash>`
 cache-key call and the actual image loader, so the two can never disagree
-about which folder is in play. This file pins that resolver, plus the
-`_list_calibration_images` helper now shared by the loader, the resolver,
-and `EngineManager._calibration_image_signature`.
+about which folder is in play. This file pins that resolver.
+
+The companion `_list_calibration_images` helper shared by the loader, the
+resolver, and `EngineManager._calibration_image_signature` is pinned in
+pr/trt-engine-cache-tags instead of here: this PR's cherry-pick does not
+touch engine_manager.py, so a three-way agreement test against it would
+fail against an engine_manager.py that predates that PR's changes.
 """
 
-import hashlib
 import logging
 from pathlib import Path
 
 from PIL import Image
 
-from streamdiffusion.acceleration.tensorrt.engine_manager import EngineManager
-from streamdiffusion.acceleration.tensorrt.fp8_quantize import _list_calibration_images
-from streamdiffusion.wrapper import _load_fp8_calibration_style_images, _resolve_fp8_calibration_dir
+from streamdiffusion.wrapper import _resolve_fp8_calibration_dir
 
 
 def _write_tiny_image(path: Path, fill=(10, 20, 30)) -> None:
     Image.new("RGB", (2, 2), color=fill).save(path)
-
-
-def _make_engine_manager(engine_dir: str) -> EngineManager:
-    """Build an EngineManager without running __init__'s heavy compile-fn
-    imports -- same pattern as test_engine_path_ipadapter_suffixes.py.
-    `_calibration_image_signature` only touches Path/hashlib, so `_configs`
-    is never needed here."""
-    em = EngineManager.__new__(EngineManager)
-    em.engine_dir = Path(engine_dir)
-    return em
 
 
 class TestResolveFp8CalibrationDir:
@@ -107,59 +98,3 @@ class TestResolveFp8CalibrationDir:
         missing = tmp_path / "does_not_exist"
 
         assert _resolve_fp8_calibration_dir(str(missing), "faceid") == str(missing)
-
-
-class TestListLoadHashAgreement:
-    """The three call sites (`_list_calibration_images`,
-    `_load_fp8_calibration_style_images`, `EngineManager.
-    _calibration_image_signature`) must always agree on which files count --
-    a disagreement would mean the `--ci<hash>` cache key could name a
-    different image set than the one actually loaded into calibration."""
-
-    def test_loader_lister_and_hasher_agree_on_which_files_count(self, tmp_path):
-        root = tmp_path / "calibration" / "general"
-        root.mkdir(parents=True)
-        _write_tiny_image(root / "a.png")
-        _write_tiny_image(root / "b.png")
-        em = _make_engine_manager(str(tmp_path / "engines"))
-
-        listed_before = _list_calibration_images(str(root))
-        loaded_before = _load_fp8_calibration_style_images(str(root))
-        sig_before = em._calibration_image_signature(str(root))
-
-        assert len(listed_before) == 2
-        assert loaded_before is not None and len(loaded_before) == 2
-        assert sig_before is not None
-
-        # An unrecognized extension must be invisible to all three -- proves
-        # they're all working from the same file set, not just the same count.
-        (root / "notes.txt").write_text("not an image")
-
-        listed_after = _list_calibration_images(str(root))
-        loaded_after = _load_fp8_calibration_style_images(str(root))
-        sig_after = em._calibration_image_signature(str(root))
-
-        assert len(listed_after) == len(listed_before)
-        assert loaded_after is not None and len(loaded_after) == len(loaded_before)
-        assert sig_after == sig_before
-
-    def test_nested_subdirectory_image_is_invisible_to_all_three(self, tmp_path):
-        """Deliberately non-recursive: a mode-folder split one level below
-        `path` (§10.1's `general/`/`faces/`) must not itself be picked up by
-        a listing rooted at `path`'s parent, and any other accidental
-        nesting must stay invisible too."""
-        root = tmp_path / "calibration" / "general"
-        nested = root / "nested"
-        nested.mkdir(parents=True)
-        _write_tiny_image(root / "a.png")
-        _write_tiny_image(nested / "hidden.png")
-        em = _make_engine_manager(str(tmp_path / "engines"))
-
-        listed = _list_calibration_images(str(root))
-        loaded = _load_fp8_calibration_style_images(str(root))
-        sig = em._calibration_image_signature(str(root))
-
-        assert len(listed) == 1
-        assert loaded is not None and len(loaded) == 1
-        expected_sig = hashlib.sha1((root / "a.png").read_bytes()).hexdigest()[:6]
-        assert sig == expected_sig

--- a/tests/unit/test_fp8_ipadapter_calibration_token_resolver.py
+++ b/tests/unit/test_fp8_ipadapter_calibration_token_resolver.py
@@ -1,0 +1,354 @@
+"""
+Regression tests for `_resolve_fp8_ipadapter_calibration_tokens`
+(fp8-round-9.1, wrapper.py).
+
+fp8-round-9 gated the real-token calibration path on adapter flavour
+(`is_faceid and not is_plus`), which was measured against a FaceID config but
+left every other adapter type -- including the shipped `type: regular`
+config -- silently zero-padded. A rebuild after the fix produced a
+byte-identical `fp8_uncalibrated_scales: 420` census, proving the fix was
+dead code for `type: regular`.
+
+fp8-round-9.1 extracts the token resolution into a pure, importable function
+that dispatches on `image_proj_model.proj`'s actual shape instead of adapter
+flavour:
+
+- `proj` is an `nn.Sequential` (FaceIDProjectionModel) -> `proj[0].in_features`
+  (id_embeddings_dim), pinning the path fp8-round-9 already measured.
+- `proj` is a bare `nn.Linear` (ImageProjModel, regular adapters) ->
+  `proj.in_features` (clip_embeddings_dim) -- previously unreachable.
+- Anything else (Plus / Resampler / FaceID-Plus-v2) -> skip, zero-pad
+  fallback, unchanged from fp8-round-9.
+
+The producer had zero test coverage before this -- the consumer
+(`_reconcile_calib_to_onnx_dims`, tests/quality/test_fp8_calib_tile.py) was
+well-tested, but nothing pinned the resolver that decides what token to feed
+it. This is the seam fp8-round-9.1 makes testable.
+"""
+
+import numpy as np
+import torch
+
+from streamdiffusion.wrapper import _resolve_fp8_ipadapter_calibration_tokens
+
+# ---------------------------------------------------------------------------
+# Minimal stand-ins for the two vendored diffusers_ipadapter projection
+# models (ip_adapter/projection_models.py::FaceIDProjectionModel,
+# ip_adapter/ip_adapter.py::ImageProjModel) -- same proj-structure contract,
+# without depending on the vendored package's exact __init__ signature.
+# ---------------------------------------------------------------------------
+
+
+class _FakeFaceIDProjectionModel(torch.nn.Module):
+    """`proj` is an nn.Sequential -- mirrors FaceIDProjectionModel."""
+
+    def __init__(self, id_embeddings_dim=512, cross_attention_dim=2048, num_tokens=4):
+        super().__init__()
+        self.proj = torch.nn.Sequential(
+            torch.nn.Linear(id_embeddings_dim, id_embeddings_dim * 2),
+            torch.nn.GELU(),
+            torch.nn.Linear(id_embeddings_dim * 2, cross_attention_dim * num_tokens),
+        )
+        self.norm = torch.nn.LayerNorm(cross_attention_dim)
+        self._num_tokens = num_tokens
+        self._cross_attention_dim = cross_attention_dim
+
+    def forward(self, id_embeds):
+        out = self.proj(id_embeds).reshape(-1, self._num_tokens, self._cross_attention_dim)
+        return self.norm(out)
+
+
+class _FakeImageProjModel(torch.nn.Module):
+    """`proj` is a bare nn.Linear -- mirrors ImageProjModel (regular adapters)."""
+
+    def __init__(self, clip_embeddings_dim=1024, cross_attention_dim=2048, clip_extra_context_tokens=4):
+        super().__init__()
+        self.proj = torch.nn.Linear(clip_embeddings_dim, clip_extra_context_tokens * cross_attention_dim)
+        self.norm = torch.nn.LayerNorm(cross_attention_dim)
+        self._clip_extra_context_tokens = clip_extra_context_tokens
+        self._cross_attention_dim = cross_attention_dim
+
+    def forward(self, image_embeds):
+        out = self.proj(image_embeds).reshape(-1, self._clip_extra_context_tokens, self._cross_attention_dim)
+        return self.norm(out)
+
+
+class _FakeUnrecognizedProjModel(torch.nn.Module):
+    """`proj` is neither Sequential nor Linear -- e.g. IP-Adapter Plus's
+    Resampler. Call signature unmeasured -- must stay skipped."""
+
+    def __init__(self):
+        super().__init__()
+        self.proj = torch.nn.Conv1d(4, 4, 1)
+
+
+class _FakeIPA:
+    def __init__(
+        self,
+        image_proj_model,
+        device="cpu",
+        dtype=torch.float32,
+        image_embeds=None,
+        num_tokens=4,
+        raise_on_get_image_embeds=None,
+        fail_images=None,
+    ):
+        self.image_proj_model = image_proj_model
+        self.device = torch.device(device)
+        self.dtype = dtype
+        # fp8-round-9.1: stand-ins for the real ip_adapter.py contract this
+        # resolver's "image" branch depends on -- get_image_embeds(images=...)
+        # returns (image_prompt_embeds, negative_embeds) and has the
+        # set_tokens(N) side effect the resolver must restore afterward.
+        self._image_embeds = image_embeds
+        self.num_tokens = num_tokens
+        self._raise_on_get_image_embeds = raise_on_get_image_embeds
+        # fp8-round-9.1 §10: maps an image identifier -> the exception to
+        # raise whenever that identifier appears in a get_image_embeds()
+        # call's `images` list. Lets tests pin
+        # _encode_fp8_calibration_images' batch-fails/per-image-retry
+        # behaviour precisely (one bad image among good ones), unlike
+        # raise_on_get_image_embeds's unconditional "every call raises".
+        self._fail_images = fail_images or {}
+        self.get_image_embeds_calls = []
+        self.set_tokens_calls = []
+
+    def get_image_embeds(self, images):
+        self.get_image_embeds_calls.append(list(images))
+        if self._raise_on_get_image_embeds is not None:
+            raise self._raise_on_get_image_embeds
+        for image in images:
+            if image in self._fail_images:
+                raise self._fail_images[image]
+        embeds = self._image_embeds
+        if embeds is None:
+            embeds = torch.full((len(images), 4, 2048), 7.0)
+        # Mirrors ip_adapter.py's real side effect: num_tokens scales with
+        # how many images were just encoded, not the per-image invariant.
+        self.set_tokens(embeds.shape[0] * self.num_tokens)
+        return embeds, torch.zeros_like(embeds)
+
+    def set_tokens(self, num_tokens):
+        self.set_tokens_calls.append(num_tokens)
+
+
+class TestResolveFp8IpadapterCalibrationTokens:
+    def test_regular_adapter_linear_proj_yields_non_zero_surrogate(self):
+        """The previously-unreachable path: `type: regular` config, bare
+        nn.Linear proj. Must produce a non-degenerate (1, 4, 2048) surrogate,
+        not the TypeError that `proj[0]` would raise on a non-indexable
+        Linear, and not a silent zero-pad skip."""
+        ipa = _FakeIPA(_FakeImageProjModel(clip_embeddings_dim=1024, cross_attention_dim=2048))
+
+        tokens, method = _resolve_fp8_ipadapter_calibration_tokens(ipa, cached_embeddings=None)
+
+        assert method == "surrogate"
+        assert tokens is not None
+        assert tokens.shape == (1, 4, 2048)
+        # LayerNorm's bias on a zeros input is non-degenerate -- this is the
+        # whole point of the surrogate (a real, non-zero signal for FP8
+        # calibration to see), not an all-zero region indistinguishable from
+        # the old zero-pad fallback.
+        assert np.abs(tokens).max() > 0.0
+
+    def test_faceid_sequential_proj_still_works(self):
+        """Pins the path fp8-round-9 already measured and shipped."""
+        ipa = _FakeIPA(_FakeFaceIDProjectionModel(id_embeddings_dim=512, cross_attention_dim=2048))
+
+        tokens, method = _resolve_fp8_ipadapter_calibration_tokens(ipa, cached_embeddings=None)
+
+        assert method == "surrogate"
+        assert tokens is not None
+        assert tokens.shape == (1, 4, 2048)
+        assert np.abs(tokens).max() > 0.0
+
+    def test_unrecognized_proj_shape_skips_to_zero_pad(self):
+        """Plus/Resampler-shaped adapters are unmeasured -- must not attempt
+        a blind zeros() call against an unknown forward signature."""
+        ipa = _FakeIPA(_FakeUnrecognizedProjModel())
+
+        tokens, method = _resolve_fp8_ipadapter_calibration_tokens(ipa, cached_embeddings=None)
+
+        assert tokens is None
+        assert method == "skipped"
+
+    def test_ipa_none_skips_to_zero_pad(self):
+        tokens, method = _resolve_fp8_ipadapter_calibration_tokens(None, cached_embeddings=None)
+
+        assert tokens is None
+        assert method == "skipped"
+
+    def test_cached_embeddings_preferred_over_surrogate(self):
+        """A real cached style embedding must win even when the surrogate
+        path is also available and well-formed."""
+        ipa = _FakeIPA(_FakeImageProjModel())
+        cached_tensor = torch.full((1, 4, 2048), 3.5)
+        cached_embeddings = (cached_tensor, torch.zeros(1))
+
+        tokens, method = _resolve_fp8_ipadapter_calibration_tokens(ipa, cached_embeddings=cached_embeddings)
+
+        assert method == "cached"
+        assert tokens is not None
+        np.testing.assert_array_equal(tokens, cached_tensor.numpy())
+
+    def test_missing_image_proj_model_skips_to_zero_pad(self):
+        """An ipa object with no image_proj_model attribute at all (e.g. a
+        stub/mock in another test) must degrade gracefully, not raise
+        AttributeError."""
+        ipa = _FakeIPA(image_proj_model=None)
+
+        tokens, method = _resolve_fp8_ipadapter_calibration_tokens(ipa, cached_embeddings=None)
+
+        assert tokens is None
+        assert method == "skipped"
+
+    def test_style_images_produce_image_method_tokens(self):
+        """fp8-round-9.1's new highest-priority source: real
+        `fp8_calibration_style_image` file(s), encoded through
+        `ipa.get_image_embeds` -- the same call the runtime
+        IPAdapterEmbeddingPreprocessor uses. Must report method="image" and
+        return exactly what get_image_embeds produced, not a surrogate."""
+        embeds = torch.full((2, 4, 2048), 3.0)
+        ipa = _FakeIPA(_FakeImageProjModel(), image_embeds=embeds)
+        style_images = ["fake_pil_image_0", "fake_pil_image_1"]
+
+        tokens, method = _resolve_fp8_ipadapter_calibration_tokens(
+            ipa, cached_embeddings=None, style_images=style_images
+        )
+
+        assert method == "image"
+        assert tokens is not None
+        np.testing.assert_array_equal(tokens, embeds.numpy())
+        assert ipa.get_image_embeds_calls == [style_images]
+
+    def test_style_images_preferred_over_cached_and_surrogate(self):
+        """An operator who deliberately configures calibration images
+        expects them used, not silently superseded by an incidentally
+        cached runtime embedding (or the zeros-surrogate)."""
+        embeds = torch.full((1, 4, 2048), 9.0)
+        ipa = _FakeIPA(_FakeImageProjModel(), image_embeds=embeds)
+        cached_tensor = torch.full((1, 4, 2048), 3.5)
+        cached_embeddings = (cached_tensor, torch.zeros(1))
+
+        tokens, method = _resolve_fp8_ipadapter_calibration_tokens(
+            ipa, cached_embeddings=cached_embeddings, style_images=["fake_pil_image"]
+        )
+
+        assert method == "image"
+        np.testing.assert_array_equal(tokens, embeds.numpy())
+
+    def test_style_images_restores_num_tokens_after_multi_image_encode(self):
+        """Defect found during fp8-round-9.1 implementation: get_image_embeds's
+        set_tokens(N) side effect mutates live IPAttnProcessor.num_tokens on
+        the SAME ipa object used at runtime. With N=2 calibration images this
+        would leave num_tokens=8 stuck on live state meant for single-frame
+        (num_tokens=4) runtime calls. The resolver must restore
+        ipa.set_tokens(ipa.num_tokens) in a finally after the encode."""
+        embeds = torch.full((2, 4, 2048), 1.0)
+        ipa = _FakeIPA(_FakeImageProjModel(), image_embeds=embeds, num_tokens=4)
+
+        _resolve_fp8_ipadapter_calibration_tokens(
+            ipa, cached_embeddings=None, style_images=["fake_pil_image_0", "fake_pil_image_1"]
+        )
+
+        # get_image_embeds's own side effect sets it to N * num_tokens = 8,
+        # then the resolver's finally restores it to the per-image
+        # invariant (4) -- both calls must be observed, in that order.
+        assert ipa.set_tokens_calls == [8, 4]
+
+    def test_style_images_single_image_failure_falls_through_without_retry(self):
+        """fp8-round-9.1 §10: a single-image "batch" that fails is not
+        retried (nothing smaller to retry with) -- falls straight through to
+        the surrogate, and the exception does not propagate. Restoration
+        (the `finally`) still runs regardless. Supersedes the pre-§10
+        contract where this raised RuntimeError."""
+        ipa = _FakeIPA(
+            _FakeImageProjModel(),
+            num_tokens=4,
+            raise_on_get_image_embeds=RuntimeError("encode failed"),
+        )
+
+        tokens, method = _resolve_fp8_ipadapter_calibration_tokens(
+            ipa, cached_embeddings=None, style_images=["fake_pil_image"]
+        )
+
+        assert method == "surrogate"
+        assert tokens is not None
+        assert ipa.set_tokens_calls == [4]
+        assert ipa.get_image_embeds_calls == [["fake_pil_image"]]
+
+    def test_style_images_partial_encode_failure_keeps_survivors(self):
+        """§10: a batch encode that fails because one image among several is
+        bad (e.g. FaceID rejecting a face-less image) must not cost the
+        other images' contribution -- retries individually and keeps
+        whatever survives."""
+        ipa = _FakeIPA(
+            _FakeImageProjModel(),
+            num_tokens=4,
+            fail_images={"bad": ValueError("No face detected in image 1")},
+        )
+        style_images = ["good_0", "bad", "good_1"]
+
+        tokens, method = _resolve_fp8_ipadapter_calibration_tokens(
+            ipa, cached_embeddings=None, style_images=style_images
+        )
+
+        assert method == "image"
+        assert tokens is not None
+        assert tokens.shape[0] == 2
+        # Batch attempt (all 3, raises) then per-image retries (3 singles,
+        # "bad" raises too) -- restore call closes it out at the per-image
+        # invariant (4) regardless of how many images were actually kept.
+        assert ipa.get_image_embeds_calls == [style_images, ["good_0"], ["bad"], ["good_1"]]
+        assert ipa.set_tokens_calls[-1] == 4
+
+    def test_style_images_all_encode_failures_fall_through_to_surrogate(self):
+        """§10: every configured image rejected -- no cached embedding
+        available -- must fall through to the surrogate rather than raising
+        or returning a degenerate all-zero result."""
+        ipa = _FakeIPA(
+            _FakeImageProjModel(),
+            num_tokens=4,
+            fail_images={
+                "bad_0": ValueError("No face detected in image 0"),
+                "bad_1": ValueError("No face detected in image 1"),
+            },
+        )
+
+        tokens, method = _resolve_fp8_ipadapter_calibration_tokens(
+            ipa, cached_embeddings=None, style_images=["bad_0", "bad_1"]
+        )
+
+        assert method == "surrogate"
+        assert tokens is not None
+        assert np.abs(tokens).max() > 0.0
+
+    def test_style_images_all_encode_failures_fall_through_to_cached(self):
+        """§10: every configured image rejected, but a real cached embedding
+        is available -- cached must win over the surrogate, matching the
+        resolver's normal (non-image) priority order."""
+        ipa = _FakeIPA(
+            _FakeImageProjModel(),
+            num_tokens=4,
+            fail_images={"bad": ValueError("No face detected in image 0")},
+        )
+        cached_tensor = torch.full((1, 4, 2048), 3.5)
+        cached_embeddings = (cached_tensor, torch.zeros(1))
+
+        tokens, method = _resolve_fp8_ipadapter_calibration_tokens(
+            ipa, cached_embeddings=cached_embeddings, style_images=["bad"]
+        )
+
+        assert method == "cached"
+        np.testing.assert_array_equal(tokens, cached_tensor.numpy())
+
+    def test_empty_style_images_list_falls_through_to_surrogate(self):
+        """An empty list (e.g. `_load_fp8_calibration_style_images` found no
+        loadable files) must behave like "not configured", not attempt to
+        call get_image_embeds([]) -- falls through to the surrogate path."""
+        ipa = _FakeIPA(_FakeImageProjModel())
+
+        tokens, method = _resolve_fp8_ipadapter_calibration_tokens(ipa, cached_embeddings=None, style_images=[])
+
+        assert method == "surrogate"
+        assert ipa.get_image_embeds_calls == []

--- a/tests/unit/test_fp8_rescale.py
+++ b/tests/unit/test_fp8_rescale.py
@@ -1,0 +1,247 @@
+"""
+Regression tests for fp8-round-8's correction of modelopt's inverted INT8->FP8
+scale-conversion factor.
+
+modelopt/onnx/quantization/fp8.py's _int8_scale_to_fp8_scale computes
+    np_fp8_scale = (np_scale * 448.0) / 127.0
+where np_scale is the *INT8* scale (amax / 127) -- the correct FP8 scale is
+amax / 448 = np_scale * 127 / 448. modelopt applies the reciprocal factor instead,
+so every calibrated amax lands at 127**2/448 = 36.0 in E4M3 space instead of 448.0,
+a uniform 12.4437x under-utilization that manifests as blur in high-dynamic-range
+tensors (attention softmax outputs). See fp8_quantize.py::_rescale_fp8_qdq_scales
+and the fp8-round-8 plan for the full derivation.
+
+These fixtures build minimal QuantizeLinear/DequantizeLinear graphs by hand rather
+than running real modelopt quantization (no GPU/modelopt/TensorRT dependency), with
+scale values computed via the *same* (buggy) formula modelopt actually emits, so the
+tests exercise the real correction math end to end.
+
+Run with: pytest tests/unit/test_fp8_rescale.py -v
+"""
+
+import re
+
+import numpy as np
+import onnx
+import pytest
+from onnx import TensorProto, helper
+
+
+def _modelopt_scale(amax: float) -> float:
+    """Reproduce modelopt's actual (inverted-factor) int8->fp8 conversion for a
+    calibrated amax, so fixtures start from the same as-shipped numbers
+    _rescale_fp8_qdq_scales is meant to correct (fp8.py:70-74)."""
+    np_scale = amax / 127.0
+    return float(np.float16((np_scale * 448.0) / 127.0))
+
+
+def _build_qdq_model(weight_amax=10.0, scale_value=None, scale_name="s", weight_name="w"):
+    """A weight initializer feeding a QuantizeLinear/DequantizeLinear pair that
+    *share* one scale initializer -- mirrors modelopt's own processed_tensor guard
+    (fp8.py:85-96) closely enough to exercise the dedupe requirement.
+
+    scale_value defaults to modelopt's as-shipped conversion of weight_amax; pass an
+    explicit value to plant other scale states (e.g. the uncalibrated default).
+    """
+    if scale_value is None:
+        scale_value = _modelopt_scale(weight_amax)
+    w = np.array([weight_amax, -weight_amax * 0.5, 0.1], dtype=np.float16)
+    s = np.array([scale_value], dtype=np.float16)
+    w_init = helper.make_tensor(weight_name, TensorProto.FLOAT16, [3], w.tobytes(), raw=True)
+    s_init = helper.make_tensor(scale_name, TensorProto.FLOAT16, [], s.tobytes(), raw=True)
+    q = helper.make_node("QuantizeLinear", inputs=[weight_name, scale_name], outputs=["q"], axis=0)
+    dq = helper.make_node("DequantizeLinear", inputs=["q", scale_name], outputs=["out"], axis=0)
+    out = helper.make_tensor_value_info("out", TensorProto.FLOAT16, [3])
+    g = helper.make_graph([q, dq], "min", [], [out], initializer=[w_init, s_init])
+    return helper.make_model(g, opset_imports=[helper.make_opsetid("", 17)])
+
+
+def _make_qdq_onnx(path, **kwargs):
+    onnx.save(_build_qdq_model(**kwargs), path)
+
+
+def _realized_peak(onnx_path, weight_name="w", scale_name="s"):
+    model = onnx.load(onnx_path)
+    w = next(i for i in model.graph.initializer if i.name == weight_name)
+    s = next(i for i in model.graph.initializer if i.name == scale_name)
+    wa = onnx.numpy_helper.to_array(w).astype(np.float32)
+    sa = onnx.numpy_helper.to_array(s).astype(np.float32).reshape(-1)
+    return float(np.abs(wa).max() / sa[0])
+
+
+def test_fp8_rescale_factor(tmp_path):
+    """After correction, max|w|/scale must land at the full E4M3 range (448.0), not
+    modelopt's as-shipped 36.0 -- and scale with headroom (224.0 at headroom=2.0)."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _rescale_fp8_qdq_scales
+
+    p1 = str(tmp_path / "headroom1.fp8.onnx")
+    _make_qdq_onnx(p1, weight_amax=10.0)
+    peak_before = _realized_peak(p1)
+    assert peak_before == pytest.approx(36.0, rel=0.02), (
+        f"fixture sanity: as-shipped peak should be ~36.0, got {peak_before}"
+    )
+
+    report1 = _rescale_fp8_qdq_scales(p1, headroom=1.0)
+    assert report1["scales_corrected"] == 1
+    assert _realized_peak(p1) == pytest.approx(448.0, rel=0.02)
+
+    p2 = str(tmp_path / "headroom2.fp8.onnx")
+    _make_qdq_onnx(p2, weight_amax=10.0)
+    _rescale_fp8_qdq_scales(p2, headroom=2.0)
+    assert _realized_peak(p2) == pytest.approx(224.0, rel=0.02)
+
+
+def test_fp8_rescale_applied_once_per_shared_scale(tmp_path):
+    """A Q and its paired DQ reference the *same* scale initializer -- the rescale
+    pass must dedupe by name and correct it once, not twice. Applying k twice would
+    silently produce a ~12.4x error in the wrong direction (peak ~5575 instead of 448),
+    which test_fp8_rescale_factor's tolerance would also catch, but this test pins the
+    dedupe count directly so a regression here fails close to its actual cause."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _rescale_fp8_qdq_scales
+
+    onnx_path = str(tmp_path / "shared.fp8.onnx")
+    _make_qdq_onnx(onnx_path, weight_amax=10.0)
+
+    report = _rescale_fp8_qdq_scales(onnx_path, headroom=1.0)
+
+    assert report["scales_seen"] == 1
+    assert report["scales_corrected"] == 1
+
+
+def test_fp8_rescale_external_data_roundtrip(tmp_path):
+    """A scale stored in external data must be patched in place at its existing
+    offset/length (never re-serialized wholesale) -- reload after the pass must yield
+    the corrected value, and the backing data file must not change size."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _rescale_fp8_qdq_scales
+
+    onnx_path = tmp_path / "ext.fp8.onnx"
+    model = _build_qdq_model(weight_amax=10.0)
+    onnx.save_model(
+        model,
+        str(onnx_path),
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location="ext.fp8.onnx_data",
+        size_threshold=0,  # force even these tiny tensors external
+    )
+    data_path = tmp_path / "ext.fp8.onnx_data"
+    assert data_path.exists(), "fixture sanity: tensors should have externalized"
+    size_before = data_path.stat().st_size
+
+    report = _rescale_fp8_qdq_scales(str(onnx_path), headroom=1.0)
+
+    assert report["scales_corrected"] == 1
+    assert data_path.stat().st_size == size_before, "in-place patch must not resize the external data file"
+    assert _realized_peak(str(onnx_path)) == pytest.approx(448.0, rel=0.02)
+
+
+def test_fp8_rescale_reports_uncalibrated(tmp_path):
+    """A scale planted at exactly FP16(448/127) -- ORT's default when calibration
+    recorded no range (INT8 amax == 127.0 exactly) -- must be counted and named,
+    not silently corrected as if it were a real calibrated value."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _rescale_fp8_qdq_scales
+
+    onnx_path = str(tmp_path / "uncalibrated.fp8.onnx")
+    uncalibrated_scale = 448.0 / 127.0
+    _make_qdq_onnx(
+        onnx_path,
+        weight_amax=1.0,
+        scale_value=uncalibrated_scale,
+        scale_name="attn2_never_calibrated_scale",
+    )
+
+    report = _rescale_fp8_qdq_scales(onnx_path, headroom=1.0)
+
+    assert report["uncalibrated_count"] == 1
+    assert "attn2_never_calibrated_scale" in report["uncalibrated_samples"]
+
+
+def test_fp8_exclude_attention_patterns():
+    """_ATTENTION_EXCLUDE_PATTERNS must catch the two attention BMMs (QK^T,
+    softmax@V) -- attn{1,2}/MatMul and its _N siblings -- while sparing the
+    projection MatMuls (to_q/to_k/to_v/to_out/to_k_ip/...), which are correctly
+    calibrated and must stay FP8. modelopt matches these via re.match (anchored at
+    start only, graph_utils.py:1018), so the pattern's trailing '$' is load-bearing:
+    without it, '.*attn1.*' would also catch every projection MatMul."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import _ATTENTION_EXCLUDE_PATTERNS
+
+    assert len(_ATTENTION_EXCLUDE_PATTERNS) == 1
+    pattern = _ATTENTION_EXCLUDE_PATTERNS[0]
+
+    should_match = [
+        "/unet/down_blocks.1/attentions.0/transformer_blocks.0/attn1/MatMul",
+        "/unet/down_blocks.1/attentions.0/transformer_blocks.0/attn1/MatMul_1",
+        "/unet/down_blocks.1/attentions.0/transformer_blocks.0/attn2/MatMul_2",
+        "/unet/down_blocks.1/attentions.0/transformer_blocks.0/attn2/MatMul_3",
+    ]
+    should_not_match = [
+        "/unet/down_blocks.1/attentions.0/transformer_blocks.0/attn1/to_q/MatMul",
+        "/unet/down_blocks.1/attentions.0/transformer_blocks.0/attn2/to_out.0/MatMul",
+        "/unet/down_blocks.1/attentions.0/transformer_blocks.0/attn2/to_k_ip/MatMul",
+        "/unet/down_blocks.1/attentions.0/transformer_blocks.0/attn1/MatMul_1_extra",
+    ]
+
+    for name in should_match:
+        assert re.match(pattern, name), f"expected match: {name}"
+    for name in should_not_match:
+        assert not re.match(pattern, name), f"expected no match: {name}"
+
+
+def test_fp8_exclude_ipadapter_patterns():
+    """fp8-round-9: _IPADAPTER_ACTIVATION_EXCLUDE_PATTERNS must catch only the three
+    IP-Adapter activation tensors that fed the 420-uncalibrated-initializer defect
+    (Mul_4 = k_ip, Transpose_4 = v_ip, Mul_5 = scale*ip_out) -- not the already-FP16
+    to_k_ip/to_v_ip projections, not the shared-query Mul_3, and not attn1's
+    unrelated Mul_4 (attn1 has no IP-Adapter branch, so a pattern that dropped the
+    '/attn2/' anchor would over-match there). Anchored like
+    _ATTENTION_EXCLUDE_PATTERNS: modelopt's expand_node_names_from_patterns uses
+    re.match (start-anchored only), so the trailing '$' is load-bearing here too."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import (
+        _IPADAPTER_ACTIVATION_EXCLUDE_PATTERNS,
+    )
+
+    assert len(_IPADAPTER_ACTIVATION_EXCLUDE_PATTERNS) == 1
+    pattern = _IPADAPTER_ACTIVATION_EXCLUDE_PATTERNS[0]
+
+    should_match = [
+        "/unet/down_blocks.2/attentions.0/transformer_blocks.0/attn2/Mul_4",
+        "/unet/down_blocks.2/attentions.0/transformer_blocks.0/attn2/Mul_5",
+        "/unet/down_blocks.2/attentions.0/transformer_blocks.0/attn2/Transpose_4",
+    ]
+    should_not_match = [
+        "/unet/down_blocks.2/attentions.0/transformer_blocks.0/attn2/to_k_ip/MatMul",
+        "/unet/down_blocks.2/attentions.0/transformer_blocks.0/attn2/to_v_ip/MatMul",
+        "/unet/down_blocks.2/attentions.0/transformer_blocks.0/attn2/Mul_3",
+        "/unet/down_blocks.2/attentions.0/transformer_blocks.0/attn1/Mul_4",
+        "/unet/down_blocks.2/attentions.0/transformer_blocks.0/attn2/Mul_4_output_0",
+        "/unet/down_blocks.2/attentions.0/transformer_blocks.0/attn2/Mul_40",
+    ]
+
+    for name in should_match:
+        assert re.match(pattern, name), f"expected match: {name}"
+    for name in should_not_match:
+        assert not re.match(pattern, name), f"expected no match: {name}"
+
+
+def test_fp8_ipadapter_bmms_covered_by_attention_patterns_not_ipadapter_patterns():
+    """Division of labour pinned by the plan: the two IP-Adapter BMMs
+    (attn2/MatMul_2 = k_ip^T @ q, attn2/MatMul_3 = softmax @ v_ip) are already
+    excluded by _ATTENTION_EXCLUDE_PATTERNS (same family as the text-branch BMMs)
+    -- fp8_exclude_ipadapter must not duplicate them, or the two flags would
+    silently overlap and double-count in nodes_to_exclude."""
+    from streamdiffusion.acceleration.tensorrt.fp8_quantize import (
+        _ATTENTION_EXCLUDE_PATTERNS,
+        _IPADAPTER_ACTIVATION_EXCLUDE_PATTERNS,
+    )
+
+    ipa_bmms = [
+        "/unet/down_blocks.2/attentions.0/transformer_blocks.0/attn2/MatMul_2",
+        "/unet/down_blocks.2/attentions.0/transformer_blocks.0/attn2/MatMul_3",
+    ]
+    for name in ipa_bmms:
+        assert any(re.match(p, name) for p in _ATTENTION_EXCLUDE_PATTERNS), (
+            f"expected _ATTENTION_EXCLUDE_PATTERNS to cover: {name}"
+        )
+        assert not any(re.match(p, name) for p in _IPADAPTER_ACTIVATION_EXCLUDE_PATTERNS), (
+            f"expected _IPADAPTER_ACTIVATION_EXCLUDE_PATTERNS to NOT cover: {name}"
+        )

--- a/tests/unit/test_modelopt_arena_patch.py
+++ b/tests/unit/test_modelopt_arena_patch.py
@@ -1,0 +1,282 @@
+"""
+Regression test for the FP8 quantization VRAM-spill fix
+(``streamdiffusion._patches.modelopt_arena_patch``).
+
+nvidia-modelopt's ONNX static calibration hardcodes ``arena_extend_strategy=
+"kSameAsRequested"`` on CPU/CUDA providers, which makes ORT's CUDA BFC arena degenerate (see
+the module docstring in ``modelopt_arena_patch.py`` for the full mechanism, including why an
+earlier round's attempt to fix a *second*, related bug — a discarded arena-shrinkage
+``RunOptions`` — turned out to be unfixable: ORT rejects the shrink list outright on this
+stack). The fix replaces one function in modelopt's ``ort_patching`` module for the duration
+of one quantize call.
+
+This is a copied third-party internal, not a call through a public API — the riskiest kind of
+patch in this codebase — so what actually needs testing is the *patch mechanism itself*:
+does it replace the right thing, is it idempotent, does revert() restore the original exactly,
+and — the part that matters most — does a version mismatch or a missing/renamed attribute
+produce a loud warning and *no* changes, rather than a silent no-op or a half-apply. None of
+this requires modelopt's real CUDA calibration path, a GPU, or the 5+ GB UNet ONNX: a minimal
+fake ``modelopt.onnx.quantization.ort_patching`` module, built the same way
+``test_faceid_bgr_patch.py`` fakes ``diffusers_ipadapter``, is enough to exercise it.
+
+Run with: pytest tests/unit/test_modelopt_arena_patch.py -v
+"""
+
+import logging
+import sys
+import types
+
+import pytest
+
+
+def _install_fake_modelopt(version: str = "0.43.0"):
+    """Build a minimal fake ``modelopt.onnx.quantization.ort_patching`` module tree and
+    register it in sys.modules, so ``modelopt_arena_patch`` can ``import`` it normally.
+
+    Unlike ``test_faceid_bgr_patch.py``'s fixture, the parent->child attributes
+    (``modelopt.onnx``, ``onnx.quantization``, ``quantization.ort_patching``) are wired
+    explicitly rather than relying on ``sys.modules`` alone: a bare ``from modelopt.onnx.
+    quantization import ort_patching`` against modules that were never loaded through a real
+    ``import`` statement can raise ``AttributeError`` inside CPython's fromlist handling,
+    because sys.modules being pre-populated short-circuits the step that normally sets each
+    submodule as an attribute of its parent package.
+
+    ``_collect_data_minmax_calibrator`` is included as an *unpatched* attribute — the patch
+    no longer touches it (see the module docstring: that fix turned out to be unfixable, ORT
+    rejects the arena shrink list outright on this stack) — so tests can assert it is left
+    alone, which is what makes ``test_missing_attribute_warns_and_skips_without_half_apply``
+    meaningful with only one real patch target.
+    """
+    modelopt_mod = types.ModuleType("modelopt")
+    modelopt_mod.__version__ = version
+    onnx_mod = types.ModuleType("modelopt.onnx")
+    quantization_mod = types.ModuleType("modelopt.onnx.quantization")
+    ort_patching_mod = types.ModuleType("modelopt.onnx.quantization.ort_patching")
+
+    def _orig_collect(*args, **kwargs):
+        return "orig_collect_data_minmax_calibrator"
+
+    def _orig_create_session(*args, **kwargs):
+        return "orig_create_inference_session_with_ep_config"
+
+    ort_patching_mod._collect_data_minmax_calibrator = _orig_collect
+    ort_patching_mod._create_inference_session_with_ep_config = _orig_create_session
+
+    modelopt_mod.onnx = onnx_mod
+    onnx_mod.quantization = quantization_mod
+    quantization_mod.ort_patching = ort_patching_mod
+
+    sys.modules["modelopt"] = modelopt_mod
+    sys.modules["modelopt.onnx"] = onnx_mod
+    sys.modules["modelopt.onnx.quantization"] = quantization_mod
+    sys.modules["modelopt.onnx.quantization.ort_patching"] = ort_patching_mod
+
+    return modelopt_mod, ort_patching_mod, (_orig_collect, _orig_create_session)
+
+
+@pytest.fixture
+def fake_modelopt(monkeypatch):
+    """Install a fresh fake modelopt tree for the duration of one test and always clean up
+    sys.modules afterward, so the real (or a different test's fake) modelopt is unaffected.
+    """
+    _MODELOPT_MODULE_NAMES = (
+        "modelopt",
+        "modelopt.onnx",
+        "modelopt.onnx.quantization",
+        "modelopt.onnx.quantization.ort_patching",
+    )
+    for name in _MODELOPT_MODULE_NAMES:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    def _make(version: str = "0.43.0"):
+        return _install_fake_modelopt(version)
+
+    yield _make
+
+    for name in _MODELOPT_MODULE_NAMES:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_arena_patch_state():
+    """Safety net: modelopt_arena_patch's apply/revert state is module-global. If a test
+    fails mid-assert without reaching its own revert() call, force it back to unpatched so
+    later tests never start from unexpected state.
+    """
+    yield
+    from streamdiffusion._patches import modelopt_arena_patch as arena_patch
+
+    arena_patch._PATCHED = False
+    arena_patch._ORIGINALS.clear()
+
+
+class TestModeloptArenaPatch:
+    def test_apply_replaces_the_attribute_on_matching_version(self, fake_modelopt):
+        from streamdiffusion._patches import modelopt_arena_patch as arena_patch
+
+        _modelopt_mod, ort_patching_mod, (orig_collect, orig_create) = fake_modelopt()
+        assert not arena_patch._PATCHED
+
+        arena_patch.apply()
+
+        assert arena_patch._PATCHED
+        assert (
+            ort_patching_mod._create_inference_session_with_ep_config
+            is arena_patch._fixed_create_inference_session_with_ep_config
+        )
+        assert ort_patching_mod._create_inference_session_with_ep_config is not orig_create
+        # Not a patch target — must be left exactly as installed.
+        assert ort_patching_mod._collect_data_minmax_calibrator is orig_collect
+
+        arena_patch.revert()
+
+    def test_apply_is_idempotent(self, fake_modelopt):
+        from streamdiffusion._patches import modelopt_arena_patch as arena_patch
+
+        _modelopt_mod, ort_patching_mod, _originals = fake_modelopt()
+
+        arena_patch.apply()
+        once_create = ort_patching_mod._create_inference_session_with_ep_config
+
+        arena_patch.apply()  # second call must be a no-op, not a double-wrap
+        twice_create = ort_patching_mod._create_inference_session_with_ep_config
+
+        assert once_create is twice_create
+
+        arena_patch.revert()
+
+    def test_revert_restores_originals_exactly(self, fake_modelopt):
+        from streamdiffusion._patches import modelopt_arena_patch as arena_patch
+
+        _modelopt_mod, ort_patching_mod, (orig_collect, orig_create) = fake_modelopt()
+
+        arena_patch.apply()
+        arena_patch.revert()
+
+        assert ort_patching_mod._create_inference_session_with_ep_config is orig_create
+        assert not arena_patch._PATCHED
+
+    def test_revert_without_apply_is_a_no_op(self, fake_modelopt):
+        from streamdiffusion._patches import modelopt_arena_patch as arena_patch
+
+        _modelopt_mod, ort_patching_mod, (orig_collect, orig_create) = fake_modelopt()
+
+        assert not arena_patch._PATCHED
+        arena_patch.revert()  # must not raise, must not touch anything
+        assert ort_patching_mod._create_inference_session_with_ep_config is orig_create
+
+    def test_mismatched_version_warns_and_skips(self, fake_modelopt, caplog):
+        from streamdiffusion._patches import modelopt_arena_patch as arena_patch
+
+        _modelopt_mod, ort_patching_mod, (orig_collect, orig_create) = fake_modelopt(version="0.99.0")
+
+        with caplog.at_level(logging.WARNING):
+            arena_patch.apply()
+
+        assert not arena_patch._PATCHED
+        assert ort_patching_mod._collect_data_minmax_calibrator is orig_collect
+        assert ort_patching_mod._create_inference_session_with_ep_config is orig_create
+        assert "not one of the versions" in caplog.text
+
+    def test_missing_attribute_warns_and_skips_without_half_apply(self, fake_modelopt, caplog):
+        """A renamed/removed target attribute must skip the patch entirely — no half-apply,
+        ever. ``_collect_data_minmax_calibrator`` (present but not a patch target) must be
+        left alone too, proving apply() didn't touch anything else on the module.
+        """
+        from streamdiffusion._patches import modelopt_arena_patch as arena_patch
+
+        _modelopt_mod, ort_patching_mod, (orig_collect, orig_create) = fake_modelopt()
+        del ort_patching_mod._create_inference_session_with_ep_config
+
+        with caplog.at_level(logging.WARNING):
+            arena_patch.apply()
+
+        assert not arena_patch._PATCHED
+        # The attribute that DOES still exist on the fake module must be untouched too.
+        assert ort_patching_mod._collect_data_minmax_calibrator is orig_collect
+        assert not hasattr(ort_patching_mod, "_create_inference_session_with_ep_config")
+        assert "not found on modelopt" in caplog.text
+
+    def test_fixed_function_sets_group_qdq_tensors(self, monkeypatch):
+        """Regression test for a real bug: an earlier version of the patched copy stopped
+        right after building ``calibrator.infer_session`` and silently dropped upstream's
+        trailing ``calibrator.group_qdq_tensors = kwargs.get(...)`` assignment (see
+        ort_patching.py:350-353). Every ``MinMaxCalibrater`` then reached ``compute_data()``
+        without the attribute at all, raising ``AttributeError`` three minutes into a real
+        calibration run -- far too late for the fake-module tests above (which only check
+        *which* attribute gets swapped, never what the replacement body actually does) to
+        catch it. This test calls the replacement directly and asserts the attribute lands,
+        both when modelopt passes a truthy ``group_qdq_tensors`` kwarg and when it doesn't.
+        """
+        from streamdiffusion._patches import modelopt_arena_patch as arena_patch
+
+        class _FakeCalibrator:
+            pass
+
+        class _FakeSessionOptions:
+            def __init__(self):
+                self.graph_optimization_level = None
+                self.enable_cpu_mem_arena = None
+
+            def add_session_config_entry(self, *args, **kwargs):
+                pass
+
+        class _FakeInferenceSession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        fake_ort = types.SimpleNamespace(
+            SessionOptions=_FakeSessionOptions,
+            GraphOptimizationLevel=types.SimpleNamespace(ORT_DISABLE_ALL=0),
+            InferenceSession=_FakeInferenceSession,
+            get_available_providers=lambda: [],
+        )
+        monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
+
+        # Wire the modelopt/modelopt.onnx parent packages explicitly, not just the leaf
+        # module -- see _install_fake_modelopt's docstring above for why pre-populating
+        # sys.modules alone (without setting each submodule as an attribute of its parent)
+        # can make CPython's fromlist handling raise AttributeError instead of resolving.
+        fake_modelopt_pkg = types.ModuleType("modelopt")
+        fake_modelopt_onnx_pkg = types.ModuleType("modelopt.onnx")
+        fake_logging_config = types.ModuleType("modelopt.onnx.logging_config")
+        fake_logging_config.logger = logging.getLogger("fake_modelopt_logger")
+        fake_modelopt_pkg.onnx = fake_modelopt_onnx_pkg
+        fake_modelopt_onnx_pkg.logging_config = fake_logging_config
+        monkeypatch.setitem(sys.modules, "modelopt", fake_modelopt_pkg)
+        monkeypatch.setitem(sys.modules, "modelopt.onnx", fake_modelopt_onnx_pkg)
+        monkeypatch.setitem(sys.modules, "modelopt.onnx.logging_config", fake_logging_config)
+
+        # kwarg present and truthy -> attribute must be set to that value.
+        calibrator_with = _FakeCalibrator()
+        arena_patch._fixed_create_inference_session_with_ep_config(
+            calibrator_with,
+            model_path="fake.onnx",
+            execution_providers=[],
+            group_qdq_tensors={"a": ["b"]},
+        )
+        assert calibrator_with.group_qdq_tensors == {"a": ["b"]}
+
+        # kwarg absent -> attribute must still exist, as None (the common case: fp8.py only
+        # includes group_qdq_tensors in trt_guided_options when it's truthy).
+        calibrator_without = _FakeCalibrator()
+        arena_patch._fixed_create_inference_session_with_ep_config(
+            calibrator_without,
+            model_path="fake.onnx",
+            execution_providers=[],
+        )
+        assert hasattr(calibrator_without, "group_qdq_tensors")
+        assert calibrator_without.group_qdq_tensors is None
+
+    def test_modelopt_not_importable_skips_quietly(self, monkeypatch):
+        """No modelopt installed at all (e.g. FP8 extras not present) must not raise —
+        quantize_onnx_fp8's own ImportError guard runs first in practice, but apply() must
+        be safe standalone too.
+        """
+        monkeypatch.delitem(sys.modules, "modelopt", raising=False)
+        monkeypatch.setitem(sys.modules, "modelopt", None)  # forces ImportError on `import modelopt`
+
+        from streamdiffusion._patches import modelopt_arena_patch as arena_patch
+
+        arena_patch.apply()  # must not raise
+        assert not arena_patch._PATCHED

--- a/tests/unit/test_param_schema.py
+++ b/tests/unit/test_param_schema.py
@@ -22,7 +22,9 @@ from streamdiffusion.param_schema import (
     DEFAULTS,
     PARAM_NAMES,
     UPDATER_PARAM_NAMES,
+    build_calibration_t_indices,
     clamp_delta,
+    compute_sub_timesteps,
     delta_noise_cancellation_ceiling,
     floor_num_inference_steps,
     rescale_t_index_list,
@@ -101,7 +103,7 @@ class TestDefaultsGolden:
 
     def test_interpolation_method_defaults(self):
         assert DEFAULTS["prompt_interpolation_method"] == "slerp"
-        assert DEFAULTS["seed_interpolation_method"] == "linear"
+        assert DEFAULTS["seed_interpolation_method"] == "average"
 
     def test_config_only_params_default_none(self):
         for name in (
@@ -169,6 +171,148 @@ class TestDeltaCeiling:
         # At gamma <= 1 the uncond term never enters the combine — no ceiling.
         assert delta_noise_cancellation_ceiling(1.0) == float("inf")
         assert delta_noise_cancellation_ceiling(0.5) == float("inf")
+
+
+class TestComputeSubTimesteps:
+    def test_indexes_by_position(self):
+        assert compute_sub_timesteps([10, 20, 30, 40], [0, 2, 3]) == [10, 30, 40]
+
+    def test_reproduces_known_lcm_grid(self):
+        """timesteps[j] = 999 - 20j for num_inference_steps=50,
+        original_inference_steps=100 (confirmed by direct computation against
+        diffusers' LCMScheduler.set_timesteps -- see the fp8-round-5-handoff
+        plan). Deployment t_index_list [15, 21, 27] must map to raw UNet
+        timesteps 699 / 579 / 459, not the turbo-schedule 999/499/249 that
+        4-step calibration used to sample."""
+        timesteps = [999 - 20 * j for j in range(50)]
+        assert compute_sub_timesteps(timesteps, [15, 21, 27]) == [699, 579, 459]
+
+
+class TestBuildCalibrationTIndices:
+    """Band spec (user's decade rule): the k-th configured t_index_list entry
+    anchors band [k*10, (k+1)*10). Verified against the production config
+    (t_index_list=[15,21,27], num_inference_steps=50) throughout."""
+
+    def test_always_includes_configured_t_index_list(self):
+        result = build_calibration_t_indices([15, 21, 27], num_inference_steps=50, budget=8)
+        assert {15, 21, 27} <= set(result)
+
+    def test_result_is_sorted_and_deduplicated(self):
+        result = build_calibration_t_indices([15, 21, 27], num_inference_steps=50, budget=8)
+        assert result == sorted(set(result))
+
+    def test_covers_every_band(self):
+        """[15,21,27] sits in bands 1,2,2 (not 0,1,2) -- band 0 ([0,10]) has
+        no configured point in it at all, so band coverage only holds if the
+        remaining budget is genuinely spread across every band, not just
+        parked next to the configured values."""
+        result = build_calibration_t_indices([15, 21, 27], num_inference_steps=50, budget=8)
+        for lo, hi in [(0, 10), (10, 20), (20, 30)]:
+            assert any(lo <= t <= hi for t in result), f"band [{lo},{hi}] uncovered: {result}"
+
+    def test_generalises_to_five_step_schedule(self):
+        t_index_list = [5, 14, 23, 32, 41]
+        result = build_calibration_t_indices(t_index_list, num_inference_steps=50, budget=12)
+        assert set(t_index_list) <= set(result)
+        assert result == sorted(set(result))
+        assert len(result) <= 12
+
+    def test_generalises_to_three_step_schedule(self):
+        t_index_list = [15, 21, 27]
+        result = build_calibration_t_indices(t_index_list, num_inference_steps=50, budget=8)
+        assert set(t_index_list) <= set(result)
+        assert len(result) <= 8
+
+    def test_bands_clamp_at_max_index_no_out_of_range(self):
+        # num_inference_steps=25 -> max valid t_index is 24. Configured
+        # values sit near the top of the grid; bands must not run past it.
+        result = build_calibration_t_indices([20, 22, 24], num_inference_steps=25, budget=8)
+        assert all(0 <= t <= 24 for t in result)
+
+    def test_never_negative(self):
+        result = build_calibration_t_indices([0, 1, 2], num_inference_steps=10, budget=8)
+        assert all(t >= 0 for t in result)
+
+    def test_configured_values_win_when_budget_too_small(self):
+        """budget smaller than len(t_index_list): every deployment point must
+        still be present even though that means the result exceeds budget."""
+        t_index_list = [15, 21, 27, 33, 39]
+        result = build_calibration_t_indices(t_index_list, num_inference_steps=50, budget=3)
+        assert set(t_index_list) <= set(result)
+
+    def test_index_zero_absent_unless_configured(self):
+        """fp8-round-5-handoff round 6: band 0's floor was k*band_width == 0,
+        so t_index 0 (raw timestep ~999, pure noise) was silently included
+        even when nothing configured it. Band 0 must now floor at 1."""
+        result = build_calibration_t_indices([10, 20, 26], num_inference_steps=50, budget=8)
+        assert 0 not in result
+
+    def test_production_config_uses_full_budget(self):
+        """The exact config from the round-5 log (t_index_list=[10,20,26],
+        num_inference_steps=50, budget=8) must now consume all 8 slots as
+        distinct in-band indices, matching the fp8-round-7 hand trace under
+        neighbour-midpoint bands: [(1,15), (16,23), (24,49)]."""
+        result = build_calibration_t_indices([10, 20, 26], num_inference_steps=50, budget=8)
+        assert result == [4, 10, 12, 18, 20, 22, 26, 37]
+
+    def test_no_value_repeated_across_adjacent_bands(self):
+        """Regression for the old bug where _evenly_spaced_ints returned band
+        endpoints and adjacent bands shared a boundary, so most of the spare
+        budget re-picked an already-picked value instead of a new one."""
+        result = build_calibration_t_indices([10, 20, 26], num_inference_steps=50, budget=8)
+        assert len(result) == len(set(result)) == 8
+
+    def test_terminal_band_spill_is_not_dropped(self):
+        """fp8-round-6.1: the live t_index_list=[7,16,25] config left the last
+        band's own interior pick colliding with an already-picked value, and
+        forward-only spill has nowhere further to go from the last band --
+        budget silently dropped to 7/8. A round-robin top-up must recover it."""
+        result = build_calibration_t_indices([7, 16, 25], num_inference_steps=50, budget=8)
+        assert len(result) == 8
+
+    def test_full_budget_consumed_across_configs(self):
+        """Every config traced during the fp8-round-6.1 investigation must
+        consume its full budget now that the top-up sweep backstops spill."""
+        configs = [
+            [7, 16, 25],
+            [10, 20, 26],
+            [0, 16, 32, 45],
+            [5, 15],
+            [3, 13, 23, 33, 43],
+        ]
+        for t_index_list in configs:
+            result = build_calibration_t_indices(t_index_list, num_inference_steps=50, budget=8)
+            assert len(result) == 8, f"{t_index_list} -> {result}"
+
+    def test_single_t_index_spreads_across_full_range(self):
+        """fp8-round-7: under the old fixed-decade grid, a single configured
+        value only anchored band [1,9], collapsing 7 of 8 rows into the
+        noisiest indices (1..9) and leaving the deployment point isolated.
+        Neighbour-midpoint bands must give a lone value the *entire* range,
+        so the budget spreads across it instead of piling up near index 1."""
+        result = build_calibration_t_indices([25], num_inference_steps=50, budget=8)
+        assert len(result) == 8
+        assert max(result) > 9, f"budget collapsed near index 1: {result}"
+
+    def test_every_configured_value_lands_in_its_own_band(self):
+        """fp8-round-7: the old fixed-decade grid assigned band k to
+        t_index_list[k] positionally, with no guarantee the value actually
+        fell inside it -- e.g. [0,16,32,45] put 32 in band 3 (decade
+        [30,39], "belonging" to 45) and left 45 outside every band. Under
+        neighbour-midpoint bands each value must provably sit inside the
+        band derived for it -- except an explicit 0, whose own band 0 still
+        floors at 1 by design (see test_index_zero_absent_unless_configured);
+        0 stays in the result via direct picked-membership, just outside its
+        derived band's interior-sampling range."""
+        for t_index_list in ([7, 16, 25], [0, 16, 32, 45], [25], [5, 15]):
+            values = sorted(set(t_index_list))
+            n = len(values)
+            for k, t in enumerate(values):
+                if k == 0 and t == 0:
+                    continue
+                lo = 1 if k == 0 else (values[k - 1] + t) // 2 + 1
+                hi = 49 if k == n - 1 else (t + values[k + 1]) // 2
+                assert lo <= t <= hi, f"{t} not in its own band [{lo},{hi}] for {t_index_list}"
 
 
 class TestRescaleTIndexList:


### PR DESCRIPTION
## What

Fixes a real gap in FP8 calibration: a cached `calib_data.npz` recorded nothing about *how* it
was captured, and a crash after the npz write but before end-of-build stats left a complete
calibration artifact with zero provenance — indistinguishable from a good one until the next
build silently reused it.

## Changes

- **Provenance sidecar** (`calib_data.meta.json`) written alongside every `calib_data.npz`,
  recording capture mode, image source, token/pool settings, and a schema version. Schema v2
  pins the K/V/FI recorder's frame caps, which are env-overridable and therefore deliberately
  **not** part of the `calv*` engine-path tag — the calibration path itself is metadata-only, so
  `calv*` never forks on a value that doesn't change the cache contents.
- **Image-driven capture path**: calibration can now be driven by a directory of real images
  instead of only synthetic/random tensors, with mode-specific subdirectories.
  `images/calibration/README.md` documents the `general/` (CLIP-conditioned) vs. `faces/`
  (FaceID/ArcFace-conditioned) split. **No images are committed in this PR** — the directory
  ships empty except for the README.
- **`_patches/modelopt_arena_patch.py`** (bundled, not optional): ModelOpt's ORT-based FP8
  calibration pass was measured allocating 22+ GB of GPU memory calibrating an SDXL-Turbo UNet
  that needs a few GB — unreachable via any public ModelOpt parameter. The intended fix (ORT
  arena shrinkage) was measured dead: `INVALID_ARGUMENT` on ORT 1.24.4 + the CUDA EP, for both
  `cpu:0;gpu:0` and `gpu:0`-only arena configs, and the same failure is still present in ModelOpt
  0.45.0. The patch is version-gated hard to the pinned `0.43.0`
  (`install-tensorrt.py`'s sole `_VERIFIED_VERSIONS` entry) and warns-and-skips on any version
  mismatch rather than silently doing nothing. This PR bundles it because `fp8_quantize.py`
  imports it directly on the FP8 build path — without it, PR 1's own headline feature raises
  `ImportError` on first use.
- `config.py` / `param_schema.py` / `wrapper.py` wiring for the new capture-mode and
  provenance-relevant params, plus `configs/td_config.yaml.example` documentation.

## Cross-PR note

`param_schema.py` in this PR adds `compute_sub_timesteps`, `materialise_timestep_grid`,
`bleed_risk_message`, and their supporting constants. Two other PRs in this stack
(`pr/fi-warp-attenuation` and `pr/seed-blending-modes`) independently need a subset of these
same helpers and carry their own verbatim copies rather than depending on merge order — same
resolution as this stack's `faceid_embedding.py` dual ownership (`pr/faceid-loader-hardening` /
`pr/perf-orchestrator-threading`). No functional conflict; whichever of these lands first, the
others' copies are identical text and a normal merge/rebase resolves cleanly.

## Tests

`tests/unit/test_fp8_calib_provenance.py`, `test_fp8_calibration_capture_resolution.py`,
`test_fp8_calibration_mode_dirs.py`, `test_fp8_ipadapter_calibration_token_resolver.py`,
`test_fp8_rescale.py`, `test_modelopt_arena_patch.py`, plus updated
`test_config_extraction_golden.py` / `test_param_schema.py` and
`tests/quality/test_fp8_calib_tile.py`. Two dev probe scripts
(`scripts/fp8/probe_cache_saturation.py`, `probe_calib_pool_diversity.py`) are included for
reproducing the capture-quality measurements above.

## Branch

`pr/fp8-calibration-provenance` -> `SDTD_040_beta_release`
