### PR TITLE
feat: trt engine cache-key tags for calibration, recipe, and controlnet

### DIFF
--- a/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
+++ b/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
@@ -253,21 +253,26 @@ class EngineManager:
             # Create prefix (from wrapper.py lines 1005-1013)
             prefix = f"{base_name}--tiny_vae-{use_tiny_vae}--min_batch-{min_batch_size}--max_batch-{max_batch_size}"
 
-            # IP-Adapter differentiation: add type and (optionally) tokens
-            # Keep scale out of identity for runtime control, but include a type flag to separate caches
-            if is_faceid:
-                prefix += "--fid"
-            if ipadapter_tokens is not None:
-                prefix += f"--tokens{ipadapter_tokens}"
-
-            # Fused Loras - use concise hashed signature to avoid long/invalid paths.
-            # Only UNet engines bake LoRA weights; VAE and other standard engines are
-            # LoRA-agnostic, so scoping the suffix to UNET prevents redundant VAE rebuilds
-            # every time the LoRA dict changes.
-            if engine_type == EngineType.UNET and lora_dict is not None and len(lora_dict) > 0:
-                prefix += f"--lora-{self._lora_signature(lora_dict)}"
-
             if engine_type == EngineType.UNET:
+                # IP-Adapter differentiation: add type and (optionally) tokens. Only UNet
+                # engines carry IP-Adapter cross-attention weights; VAE and other standard
+                # engines are IP-Adapter-agnostic, so scoping this suffix to UNET (same
+                # reasoning as the LoRA suffix just below) prevents a redundant VAE rebuild
+                # every time FaceID is toggled or the token count changes.
+                # Keep scale out of identity for runtime control, but include a type flag to
+                # separate caches.
+                if is_faceid:
+                    prefix += "--fid2"
+                if ipadapter_tokens is not None:
+                    prefix += f"--tokens{ipadapter_tokens}"
+
+                # Fused Loras - use concise hashed signature to avoid long/invalid paths.
+                # Only UNet engines bake LoRA weights; VAE and other standard engines are
+                # LoRA-agnostic, so scoping the suffix to UNET prevents redundant VAE rebuilds
+                # every time the LoRA dict changes.
+                if lora_dict is not None and len(lora_dict) > 0:
+                    prefix += f"--lora-{self._lora_signature(lora_dict)}"
+
                 prefix += f"--use_cached_attn-{use_cached_attn}"
                 # FI suffix MUST come right after cached_attn so stale engines
                 # (built without FI bindings) are never loaded when FI is enabled.

--- a/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
+++ b/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
@@ -95,6 +95,82 @@ class EngineManager:
         h = hashlib.sha1(canon.encode("utf-8")).hexdigest()[:10]
         return f"{len(lora_dict)}-{h}"
 
+    def _calibration_image_signature(self, path: Optional[str]) -> Optional[str]:
+        """Short content hash of `fp8_calibration_style_image` (fp8-round-9.1)
+        — a single file, or every recognized-extension file in a directory,
+        sorted by filename to match wrapper.py's
+        `_load_fp8_calibration_style_images` loading order.
+
+        Hashes file *contents*, not the path string, so editing an image in
+        place (same filename, new bytes) or adding/removing a file correctly
+        forks the cache — a path-only signature would miss both. Returns None
+        when nothing is configured or nothing hashable was found, so the
+        `--ci<hash>` suffix is skipped entirely rather than forked on an
+        empty signature.
+        """
+        if not path:
+            return None
+        from .fp8_quantize import _list_calibration_images
+
+        files = _list_calibration_images(path)
+        if not files:
+            return None
+        h = hashlib.sha1()
+        for f in files:
+            try:
+                h.update(f.read_bytes())
+            except OSError:
+                continue
+        return h.hexdigest()[:6]
+
+    def _fp8_recipe_tag(
+        self,
+        fp8_mha_qdq: bool,
+        fp8_scale_headroom: float,
+        fp8_exclude_attention: bool,
+        fp8_exclude_ipadapter: bool = False,
+    ) -> str:
+        """Build the FP8 recipe cache-key tag. Called from both the "canonical" prefix
+        (feeds the UNet directory-name hash) and the final human-readable UNet prefix —
+        the two call sites must stay byte-identical, which is why this is factored out
+        rather than duplicated (fp8-round-8 lesson: engine_manager.py:194 and :284 drifted
+        out of sync once already when the tag was inlined at both sites).
+
+        v3 -> v4 (fp8-round-8): the underlying scale-conversion math changed (see
+        fp8_quantize.py::_rescale_fp8_qdq_scales), so every existing v3 engine is stale
+        under v4's semantics even with every recipe flag at its default — the base tag
+        itself must fork, not just gain a suffix.
+        """
+        tag = "--fp8v4"
+        if fp8_mha_qdq:
+            tag += "-mhaq"
+        if fp8_exclude_attention:
+            tag += "-noattn"
+        if fp8_exclude_ipadapter:
+            tag += "-noip"
+        if fp8_scale_headroom != 1.0:
+            tag += f"-hr{fp8_scale_headroom:g}"
+        return tag
+
+    def _trt_cc_tag(self) -> str:
+        """TRT version + compute-capability cache-key token, shared by every engine
+        type so a TRT upgrade or GPU change auto-invalidates every branch's cache, not
+        just the standard UNet/VAE branch (fp8-round-12: previously only that branch
+        called this, so ControlNet engines silently never invalidated on a TRT/GPU
+        change). Fails silently to "" if tensorrt/torch aren't importable yet (e.g.
+        during a partial install) -- same semantics as the inline block this replaces.
+        Factored out for the same anti-drift reason as _fp8_recipe_tag above: two
+        hand-written copies of a cache-key token is how the fp8-round-8 prefix-vs-hash
+        drift bug happened."""
+        try:
+            import tensorrt as _trt
+            import torch as _torch
+
+            _cc = _torch.cuda.get_device_capability(0)
+            return f"--trt{_trt.__version__}--cc{_cc[0]}{_cc[1]}"
+        except Exception:
+            return ""
+
     def get_engine_path(
         self,
         engine_type: EngineType,
@@ -113,6 +189,13 @@ class EngineManager:
         use_controlnet: bool = False,
         fp8: bool = False,
         fp8_mha_qdq: bool = False,
+        fp8_scale_headroom: float = 1.0,
+        fp8_exclude_attention: bool = False,
+        fp8_exclude_ipadapter: bool = False,
+        fp8_calib_t_index_len: Optional[int] = None,
+        fp8_calib_num_steps: Optional[int] = None,
+        fp8_calib_scheduler_type: Optional[str] = None,
+        fp8_calibration_style_image: Optional[str] = None,
         resolution: Optional[tuple] = None,
         builder_optimization_level: Optional[int] = None,
         build_static_batch: Optional[bool] = None,
@@ -146,8 +229,21 @@ class EngineManager:
                 prefix = f"controlnet_{model_dir_name}--min_batch-{min_batch_size}--max_batch-{max_batch_size}--res-{resolution[0]}x{resolution[1]}"
             else:
                 prefix = f"controlnet_{model_dir_name}--min_batch-{min_batch_size}--max_batch-{max_batch_size}--dyn-256-1024"
+            # fp8-round-12: ControlNet is always built with build_static_batch=True
+            # (_get_default_controlnet_build_options), at opt_batch_size baked to the
+            # caller's trt_unet_batch_size -- but that value previously never reached
+            # this path, only the capacity range (min/max_batch above, fixed wrapper
+            # constructor defaults) did. Two different t-index counts collided on the
+            # same directory and the second failed set_input_shape on the first frame.
+            # Mirrors the standard branch's --sbatch/--batch-/_trt_cc_tag guards below
+            # (see :368-376 and _trt_cc_tag) so both branches read the same way.
+            if build_static_batch is not None:
+                prefix += f"--sbatch{int(build_static_batch)}"
+            if build_static_batch and static_batch_size is not None:
+                prefix += f"--batch-{static_batch_size}"
+            prefix += self._trt_cc_tag()
             fp8_suffix = "--fp8" if fp8 else ""
-            return self.engine_dir / (prefix + optlvl_suffix + fp8_suffix) / filename
+            engine_path = self.engine_dir / (prefix + optlvl_suffix + fp8_suffix) / filename
         else:
             # Standard engines use the unified prefix format
             # Extract base name (from wrapper.py lines 1002-1003)
@@ -181,9 +277,137 @@ class EngineManager:
                 if fp8:
                     # Quantization-recipe changes are NOT otherwise part of the cache
                     # key, so experimental recipe flags must fork the tag here. The
-                    # base "--fp8v3" must stay byte-identical when every recipe flag
-                    # is off — bumping it would orphan the deployed production engines.
-                    prefix += "--fp8v3-mhaq" if fp8_mha_qdq else "--fp8v3"
+                    # base tag must stay byte-identical when every recipe flag is off
+                    # — bumping it would orphan the deployed production engines.
+                    prefix += self._fp8_recipe_tag(
+                        fp8_mha_qdq, fp8_scale_headroom, fp8_exclude_attention, fp8_exclude_ipadapter
+                    )
+                    # Band-based calibration schedule (fp8-round-5-handoff Step 2f):
+                    # calib_data.npz is cached inside the engine dir and short-circuited
+                    # on existence AND explicitly preserved by artifact cleanup, so a
+                    # config-agnostic tag would silently keep serving pre-fix calibration
+                    # data forever. "calv1" forks away from every engine built before this
+                    # schedule existed; len(t_index_list)/num_inference_steps/scheduler_type
+                    # fork again only when the *derived band layout* would actually change.
+                    # Deliberately excludes t_index_list's literal values — a live /t_list
+                    # change must not force a rebuild.
+                    # "calv2" (fp8-round-5-handoff Step 4): forks again away from calv1
+                    # engines, whose calib_data.npz was captured against the raw diffusers
+                    # UNet -- 91.2% of quantized activations (kvo_cache_in_*, fio_cache_in_*,
+                    # fi_strength/threshold, ipadapter_scale) calibrated on zeros/ones
+                    # (Defect B) plus the band-0 t=999 spurious index (Defect A). Deliberately
+                    # still excludes the scalar deployment values themselves (fi_strength,
+                    # ipadapter_scale, ...) for the same "keep runtime scale out of identity"
+                    # reason as above -- a live scale tweak must not force a rebuild.
+                    # "calv3" (fp8-round-6.1, then fp8-round-7): forks again away from calv2
+                    # engines. Round 6.1 fixed forward-only spill dropping budget in the
+                    # terminal band (observed: 7/8 distinct timesteps for t_index_list=
+                    # [7,16,25]) with a round-robin top-up. Round 7 replaced the fixed-decade
+                    # band grid itself with neighbour-midpoint bands derived from the
+                    # configured values, fixing two more defects the decade grid had: a short
+                    # t_index_list collapsed most of the budget into the noisiest indices
+                    # (single-entry configs put 7/8 rows in index 1..9), and band k was
+                    # assigned to t_index_list[k] positionally with no guarantee the value
+                    # actually landed in it. No engine ever shipped under the intermediate
+                    # top-up-only form of calv3, so the label is reused rather than bumped
+                    # again — band_width is no longer a parameter (bands derive from the
+                    # values, not a fixed width), so it is dropped from the tag.
+                    # "calv4" (fp8-round-9): forks again away from calv3 engines, whose
+                    # calib_data.npz calibrated the IP-Adapter cross-attention branch on
+                    # identically-zero input on BOTH axes independently — encoder_hidden_states
+                    # was zero-padded (bias-free to_k_ip/to_v_ip -> zero activations) AND
+                    # ipadapter_scale was baked in at its then-current deployment value (0.0 at
+                    # capture time), zeroing the merge term a second, independent way. Round 9
+                    # feeds real IP-Adapter projection tokens (or their measured zeros-surrogate)
+                    # instead of zero-padding, and calibrates the scale at its runtime bound
+                    # (max(config, 1.0)) instead of the deployment snapshot. calv3 engines are
+                    # not invalidated by anything else changing here — fp8v4 stays, the rescale
+                    # math (_rescale_fp8_qdq_scales) is unchanged.
+                    # "calv5" (fp8-round-9.1): forks again away from calv4 engines. Round 9's
+                    # real-token path only fired for `is_faceid and not is_plus`; every other
+                    # adapter flavour, including the shipped `type: regular` config, still fell
+                    # through to the zero-pad reconciliation calv4 was meant to fix (confirmed
+                    # byte-identical fp8_uncalibrated_scales=420 across a calv4 rebuild). Round
+                    # 9.1 (_resolve_fp8_ipadapter_calibration_tokens, wrapper.py) dispatches on
+                    # image_proj_model.proj's actual shape (nn.Sequential vs. bare nn.Linear)
+                    # instead of adapter flavour, so regular adapters now get a real zeros-
+                    # surrogate too. calv4 engines are not invalidated by anything else changing
+                    # here — fp8v4 stays, the rescale math is unchanged.
+                    # "calv6" (fp8-round-10): forks again away from calv5 engines, whose
+                    # calib_data.npz was captured with no height/width passed to pipe(), so
+                    # diffusers silently fell back to pipe.unet.config.sample_size (512 for
+                    # SDXL-Turbo) regardless of the engine's actual build resolution. Confirmed
+                    # via two completed builds (h92807e04ef45 @ 512, hb290e7269028 @ 1024):
+                    # both captured identical (8, 4, 64, 64) `sample`/512-valued `time_ids`,
+                    # which is the actual evidence (`fp8_scale_realized_peak` also matched
+                    # bit-for-bit between them, but that is NOT corroborating: it samples
+                    # only static-weight QuantizeLinear nodes (_rescale_fp8_qdq_scales,
+                    # fp8_quantize.py) and is invariant to calibration content by
+                    # construction). Real-vs-zero-padded seq fraction on kvo_cache_in_*/
+                    # fio_cache_in_* scales as (512/R)² — 100% at 512, 25% at 1024, 11% at 1536
+                    # — so every build above 512 was calibrating on a mostly zero-padded cache.
+                    # capture_calibration_data now takes image_height/image_width and
+                    # builder.py passes opt_image_height/opt_image_width (mirroring the
+                    # ControlNet branch, which already did this). 512 builds are unaffected in
+                    # substance — the fix makes explicit what the fallback already chose — but
+                    # the tag still forks so every resolution re-captures at its real shape
+                    # rather than reusing a stale, wrongly-shaped calv5 calib_data.npz.
+                    # "calv7" (fp8-round-11): forks again away from calv6 engines.
+                    # _select_calibration_calls took bucket[round_idx] with round_idx
+                    # starting at 0, so every distinct timestep's selected row came from
+                    # the SAME early pipe() call -- all 8 calibration rows were drawn from
+                    # prompt batch 0, and the other ~31 of 32 captured batches contributed
+                    # zero signal to any amax, despite calib_data.npz showing correct
+                    # per-timestep stratification (confirmed on-disk: the calv6
+                    # h92807e04ef45/haebb243bc74e/hb290e7269028 captures all show 8 rows,
+                    # 8 distinct timesteps -- distinctness of timestep was checked, but
+                    # never the source call index behind it). Selection is now staggered
+                    # per ordered-timestep position so the 8 selected rows span 8 distinct
+                    # prompt batches instead of 1 (see _select_calibration_calls,
+                    # fp8_quantize.py); same row count, same memory footprint. The
+                    # recorder cap feeding that selection was also widened (byte-budgeted,
+                    # SDTD_FP8_CALIB_RECORD_BYTES, on top of the existing call-count cap).
+                    # CORRECTION (fp8-round-14, see below): that widening did not actually
+                    # work -- SDTD_FP8_CALIB_RECORD_BYTES (4 GiB) trips before the widened
+                    # call-count cap (64) at ~124 MiB/call on a real SDXL-Turbo UNet, so
+                    # only ~33 of the 64 calls needed for the full 8-batch stagger were ever
+                    # recorded. calv6 engines are not invalidated by anything else changing
+                    # here -- fp8v4 stays, the rescale math is unchanged.
+                    # "calv8" (fp8-round-14): forks again away from calv7 engines, fixing
+                    # the byte-cap-defeats-call-cap defect the calv7 paragraph above
+                    # describes. Measured on disk (hashing per-n_itr K chunks of
+                    # kvo_cache_in_0): calv6 (pre-stagger-fix) has 8 distinct K sources;
+                    # both calv7 engines (h081fefde15ae @ 512x512, hfb5ce64fea8d @ 640x384)
+                    # have only 4 -- the second half of every stagger (calls 36/45/54/63)
+                    # was silently dropped, and _pool_for_layer's cyclic reuse of the
+                    # surviving 4 sources (not a zero-fill -- see fp8_quantize.py's
+                    # _pool_missed_calls warning) halved kvo/fio calibration diversity in
+                    # every calv7 build at both resolutions. capture_calibration_data now
+                    # predicts, before the capture loop runs, exactly which ~8 calls
+                    # _select_calibration_calls will select (_predict_selected_calls,
+                    # fp8_quantize.py) and gates the K/V/FI recorder hooks on membership in
+                    # that set instead of a call-count prefix -- so the recorder admits
+                    # exactly the calls that matter and peak recorder memory drops from
+                    # ~4 GiB to ~1 GiB, comfortably under the byte cap. calv7 engines are
+                    # not invalidated by anything else changing here -- fp8v4 stays, the
+                    # rescale math is unchanged.
+                    if fp8_calib_t_index_len is not None and fp8_calib_num_steps is not None:
+                        prefix += (
+                            f"--calv8-n{fp8_calib_t_index_len}"
+                            f"-s{fp8_calib_num_steps}"
+                            f"-{fp8_calib_scheduler_type or 'na'}"
+                        )
+                    # fp8-round-9.1: the calibration image set is part of the recipe —
+                    # swapping which image(s) feed the real-token path must fork the
+                    # cache the same way every other fp8_* flag does. Content-hashed
+                    # (see _calibration_image_signature) rather than path-hashed so an
+                    # edited file at the same path also forks. Not folded into
+                    # _fp8_recipe_tag: like calv5, this only needs to live in the
+                    # hashed `canonical` string below, not in the short human-readable
+                    # directory name.
+                    _ci_sig = self._calibration_image_signature(fp8_calibration_style_image)
+                    if _ci_sig is not None:
+                        prefix += f"--ci{_ci_sig}"
                 # Encode the actual batch-profile policy so that a static-batch engine
                 # and a dynamic-batch engine never share the same directory.
                 # The capacity range (min_batch / max_batch above) is the same for both,
@@ -212,16 +436,8 @@ class EngineManager:
 
             # Embed TRT version + compute capability so upgrading TRT invalidates
             # stale engines automatically. Old engine dirs are orphaned (not deleted),
-            # keeping them available for rollback. Fails silently if tensorrt isn't
-            # installed yet (e.g. during a partial install).
-            try:
-                import tensorrt as _trt
-                import torch as _torch
-
-                _cc = _torch.cuda.get_device_capability(0)
-                prefix += f"--trt{_trt.__version__}--cc{_cc[0]}{_cc[1]}"
-            except Exception:
-                pass
+            # keeping them available for rollback.
+            prefix += self._trt_cc_tag()
 
             if resolution is not None:
                 prefix += f"--res-{resolution[0]}x{resolution[1]}"
@@ -237,26 +453,33 @@ class EngineManager:
                 # stable directory, just without spelling out every flag on disk.
                 canonical = prefix
                 short_hash = hashlib.sha1(canonical.encode("utf-8")).hexdigest()[:12]
-                fp8_tag = ("--fp8v3-mhaq" if fp8_mha_qdq else "--fp8v3") if fp8 else ""
+                fp8_tag = (
+                    self._fp8_recipe_tag(fp8_mha_qdq, fp8_scale_headroom, fp8_exclude_attention, fp8_exclude_ipadapter)
+                    if fp8
+                    else ""
+                )
                 res_tag = f"--res-{resolution[0]}x{resolution[1]}" if resolution is not None else ""
                 prefix = f"{base_name}{fp8_tag}--h{short_hash}{res_tag}"
                 logger.debug(f"EngineManager: UNet cache key h{short_hash} = {canonical}")
 
             engine_path = self.engine_dir / prefix / filename
 
-            # Belt-and-suspenders: warn (rather than silently mkdir-then-fail-on-write)
-            # if the longest artifact derived from this path would still exceed Windows'
-            # 260-char MAX_PATH — e.g. an unusually deep user-configured engine_dir.
-            # ".opt.onnx" is the longest suffix appended to engine_path (see builder.py).
-            longest_derived = len(str(engine_path)) + len(".opt.onnx")
-            if longest_derived >= 250:
-                logger.warning(
-                    f"EngineManager: engine path is {longest_derived} chars once .opt.onnx is "
-                    f"appended (Windows MAX_PATH=260). Move engine_dir closer to the drive root "
-                    f"if TensorRT export fails with FileNotFoundError: {engine_path}"
-                )
+        # Belt-and-suspenders: warn (rather than silently mkdir-then-fail-on-write) if
+        # the longest artifact derived from this path would still exceed Windows'
+        # 260-char MAX_PATH — e.g. an unusually deep user-configured engine_dir.
+        # ".opt.onnx" is the longest suffix appended to engine_path (see builder.py).
+        # Covers BOTH branches (fp8-round-12): ControlNet has no hash compaction to
+        # fall back on, and its prefix just grew three tokens longer, so it needs this
+        # warning at least as much as the standard branch does.
+        longest_derived = len(str(engine_path)) + len(".opt.onnx")
+        if longest_derived >= 250:
+            logger.warning(
+                f"EngineManager: engine path is {longest_derived} chars once .opt.onnx is "
+                f"appended (Windows MAX_PATH=260). Move engine_dir closer to the drive root "
+                f"if TensorRT export fails with FileNotFoundError: {engine_path}"
+            )
 
-            return engine_path
+        return engine_path
 
     def _get_embedding_dim_for_model_type(self, model_type: str) -> int:
         """Get embedding dimension based on model type."""
@@ -443,6 +666,21 @@ class EngineManager:
 
         Replaces ControlNetEnginePool.get_or_load_engine functionality.
         """
+        # fp8-round-12: build the options dict ONCE and feed both the path and the
+        # compile step from it. Previously get_engine_path() never saw
+        # build_static_batch/static_batch_size at all -- they weren't cache-key
+        # inputs for ControlNet -- and _get_default_controlnet_build_options() was
+        # called a second, independent time down in compile_and_load_engine's
+        # engine_build_options kwarg. Two independently-constructed option dicts is
+        # exactly how the prefix-vs-hash cache key drifted apart in fp8-round-8; a
+        # single source here prevents a repeat.
+        build_options = self._get_default_controlnet_build_options(
+            opt_image_height=opt_image_height,
+            opt_image_width=opt_image_width,
+            builder_optimization_level=builder_optimization_level,
+            fp8=fp8,
+        )
+
         # Generate engine path using ControlNet-specific logic
         engine_path = self.get_engine_path(
             EngineType.CONTROLNET,
@@ -454,6 +692,8 @@ class EngineManager:
             controlnet_model_id=model_id,
             resolution=(opt_image_height, opt_image_width),
             builder_optimization_level=builder_optimization_level,
+            build_static_batch=build_options["build_static_batch"],
+            static_batch_size=batch_size,
             fp8=fp8,
         )
 
@@ -472,10 +712,5 @@ class EngineManager:
             unet=unet,
             model_path=model_path,
             conditioning_channels=conditioning_channels,
-            engine_build_options=self._get_default_controlnet_build_options(
-                opt_image_height=opt_image_height,
-                opt_image_width=opt_image_width,
-                builder_optimization_level=builder_optimization_level,
-                fp8=fp8,
-            ),
+            engine_build_options=build_options,
         )

--- a/src/streamdiffusion/acceleration/tensorrt/models/models.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/models.py
@@ -733,10 +733,16 @@ class UNet(BaseModel):
             # hardcoded resolution for now due to VRAM limitations
             # NOTE: dim[0]=2 (K/V pair) must stay static — attention Gather nodes
             # index into it at idx=0 and idx=1, so dim[0]<2 causes OOB errors.
-            # The "C" (cache-frames) axis is itself dropped when pin_cache_frames has
+            # The "C" (cache-frames) axis is dropped here when pin_cache_frames has
             # pinned min_cache_maxframes == max_cache_maxframes (has_symbolic_cache_dims
-            # False) so the exported graph has no symbolic dims left and TRT's l2tc
-            # (L2 tiling) pass can validate.
+            # False) -- but that drop is local to kvo/fio bindings. "sample" /
+            # "timestep" / "encoder_hidden_states" above still declare "2B" (and "H"/"W")
+            # unconditionally, so a fully-pinned build's exported ONNX still has plenty
+            # of symbolic dims (verified: 120 of 122 inputs on a current build). What
+            # actually lets TRT's l2tc (L2 tiling) pass validate is that the engine's
+            # single optimization profile has min=opt=max for every dim -- TRT
+            # specializes the network to concrete shapes at build time from that,
+            # independent of what the ONNX itself declares as dynamic.
             for i in range(self.kvo_cache_count):
                 base_axes[f"kvo_cache_in_{i}"] = {1: "C", 2: "2B"} if self.has_symbolic_cache_dims else {2: "2B"}
                 base_axes[f"kvo_cache_out_{i}"] = {2: "2B"}

--- a/tests/unit/test_engine_path_controlnet_tokens.py
+++ b/tests/unit/test_engine_path_controlnet_tokens.py
@@ -1,0 +1,195 @@
+"""
+Regression tests for fp8-round-12's ControlNet cache-key fix.
+
+``EngineManager.get_engine_path``'s ControlNet branch (acceleration/tensorrt/
+engine_manager.py, ``EngineType.CONTROLNET``) builds
+``controlnet_{model_id}--min_batch-N--max_batch-N--res-HxW`` and returns immediately --
+unlike the UNet branch there is no hash compaction, so this literal prefix IS the cache
+key. Before this fix it omitted two tokens the UNet branch already has:
+
+- ``--batch-{static_batch_size}``: ControlNet is always built with
+  ``build_static_batch=True`` (``_get_default_controlnet_build_options``) at
+  ``opt_batch_size`` baked to the caller's ``stream.trt_unet_batch_size`` (=
+  ``len(t_index_list) * frame_buffer_size`` for the default cfg_type). That value never
+  reached ``get_engine_path`` -- only the *capacity* range (min/max_batch_size, fixed
+  wrapper constructor defaults, not config-driven) did. Two different t_index_list
+  lengths therefore baked two different static batches into the SAME ``cnet.engine``
+  file, and the second config to load failed ``set_input_shape`` on the first frame.
+- ``--trt{version}--cc{sm}``: TRT engines are not portable across TRT versions or GPU
+  compute capabilities. Every other engine type auto-invalidates on a TRT upgrade or GPU
+  change; ControlNet silently did not.
+
+This test constructs ``EngineManager`` via ``__new__`` (bypassing ``__init__``'s
+compile-fn imports, which need TensorRT/onnx/polygraphy installed) so it only exercises
+the pure-path logic in ``get_engine_path`` -- same pattern as test_engine_path_length.py
+and test_engine_path_ipadapter_suffixes.py.
+
+Run with: pytest tests/unit/test_engine_path_controlnet_tokens.py -v
+"""
+
+from pathlib import Path
+
+import pytest
+
+try:
+    from streamdiffusion.acceleration.tensorrt.engine_manager import EngineManager, EngineType
+
+    IMPORT_OK = True
+except ImportError:
+    IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(
+    not IMPORT_OK,
+    reason="acceleration.tensorrt.engine_manager not importable",
+)
+
+_ENGINE_DIR = r"C:\Users\deswh\Documents\sdtd040\StreamDiffusion\engines\td"
+
+_FILENAMES = {
+    EngineType.UNET: "unet.engine",
+    EngineType.CONTROLNET: "cnet.engine",
+}
+
+_BASE_KWARGS = {
+    "engine_type": EngineType.CONTROLNET,
+    "model_id_or_path": "",  # not used for ControlNet
+    "max_batch_size": 4,
+    "min_batch_size": 1,
+    "mode": "",  # not used for ControlNet
+    "use_tiny_vae": False,  # not used for ControlNet
+    "controlnet_model_id": "lllyasviel/sd-controlnet-canny",
+    "resolution": (512, 512),
+    "build_static_batch": True,
+    "static_batch_size": 2,
+    "fp8": False,
+}
+
+# Minimal viable UNET-branch call, reused only by TestTrtCcTagSharedAcrossBranches to
+# prove both branches are driven by the same EngineManager._trt_cc_tag() method.
+_UNET_BASE_KWARGS = {
+    "engine_type": EngineType.UNET,
+    "model_id_or_path": "stabilityai/sdxl-turbo",
+    "max_batch_size": 4,
+    "min_batch_size": 1,
+    "mode": "img2img",
+    "use_tiny_vae": True,
+}
+
+
+def _make_engine_manager(engine_dir: str = _ENGINE_DIR) -> EngineManager:
+    """Build an EngineManager without running __init__'s heavy compile-fn imports."""
+    em = EngineManager.__new__(EngineManager)
+    em.engine_dir = Path(engine_dir)
+    em._configs = {etype: {"filename": fname} for etype, fname in _FILENAMES.items()}
+    return em
+
+
+class TestControlNetBatchSizeCacheKey:
+    """The core fp8-round-12 fix. Direct analog of
+    test_engine_path_length.py::TestUnetEnginePathLength.test_distinct_configs_do_not_collide
+    (same static_batch_size variable, same assertion shape) applied to the ControlNet
+    branch. RED before fp8-round-12 (both paths collided into the same directory),
+    GREEN after."""
+
+    def test_distinct_static_batch_sizes_do_not_collide(self):
+        em = _make_engine_manager()
+        path_a = em.get_engine_path(**dict(_BASE_KWARGS, static_batch_size=1))
+        path_b = em.get_engine_path(**dict(_BASE_KWARGS, static_batch_size=2))
+
+        assert path_a != path_b
+        assert path_a.parent != path_b.parent
+
+    def test_sbatch_flag_present_when_static(self):
+        em = _make_engine_manager()
+        path = em.get_engine_path(**_BASE_KWARGS)
+        assert "--sbatch1" in path.parent.name
+        assert "--batch-2" in path.parent.name
+
+    def test_batch_size_omitted_when_not_static_batch(self):
+        """build_static_batch=False (a hypothetical future dynamic-batch ControlNet)
+        must not bake a batch size into the path -- mirrors the UNet branch's guard at
+        engine_manager.py:407-408 (``if build_static_batch and static_batch_size is
+        not None``)."""
+        em = _make_engine_manager()
+        path = em.get_engine_path(**dict(_BASE_KWARGS, build_static_batch=False, static_batch_size=2))
+        assert "--batch-2" not in path.parent.name
+        assert "--sbatch0" in path.parent.name
+
+    def test_engine_path_is_deterministic(self):
+        """Same config -> same path, so a previously-built engine is still found on
+        rebuild (ControlNet has no hash compaction, so this also guards against any
+        accidental non-determinism creeping into the new token ordering)."""
+        em = _make_engine_manager()
+        path_a = em.get_engine_path(**_BASE_KWARGS)
+        path_b = em.get_engine_path(**_BASE_KWARGS)
+        assert path_a == path_b
+
+
+class TestTrtCcTagSharedAcrossBranches:
+    """Both the ControlNet and standard branches call the single
+    EngineManager._trt_cc_tag() helper (extracted this round for the same anti-drift
+    reason as the existing _fp8_recipe_tag extraction -- two hand-written copies of a
+    cache-key token is how the fp8-round-8 prefix-vs-hash drift bug happened).
+    Monkeypatched so this test needs no CUDA device."""
+
+    def test_trt_cc_tag_present_in_controlnet_path(self, monkeypatch):
+        em = _make_engine_manager()
+        monkeypatch.setattr(EngineManager, "_trt_cc_tag", lambda self: "--trtTEST--cc89")
+        path = em.get_engine_path(**_BASE_KWARGS)
+        assert "--trtTEST--cc89" in path.parent.name
+
+    def test_trt_cc_tag_forks_both_branches(self, monkeypatch):
+        """Changing the tag must fork BOTH branches' output: literally, for
+        ControlNet (unhashed prefix); via the hash, for UNet (whose directory name
+        compacts the full prefix to a sha1 short hash, so the raw tag text is not
+        expected to appear verbatim there -- only the fact that the path forks is)."""
+        em = _make_engine_manager()
+
+        monkeypatch.setattr(EngineManager, "_trt_cc_tag", lambda self: "--trtAAA--cc86")
+        cn_a = em.get_engine_path(**_BASE_KWARGS)
+        unet_a = em.get_engine_path(**_UNET_BASE_KWARGS)
+
+        monkeypatch.setattr(EngineManager, "_trt_cc_tag", lambda self: "--trtBBB--cc90")
+        cn_b = em.get_engine_path(**_BASE_KWARGS)
+        unet_b = em.get_engine_path(**_UNET_BASE_KWARGS)
+
+        assert cn_a != cn_b, "ControlNet path must fork when the TRT/CC tag changes"
+        assert unet_a != unet_b, "UNet path must fork when the TRT/CC tag changes (via the hash)"
+        assert "--trtAAA--cc86" in cn_a.parent.name
+        assert "--trtBBB--cc90" in cn_b.parent.name
+
+    def test_trt_cc_tag_absent_without_cuda_does_not_raise(self):
+        """The real _trt_cc_tag() silently fails to "" if tensorrt/torch aren't
+        importable or no CUDA device is present -- must not raise, matching the
+        inline block it replaced."""
+        em = _make_engine_manager()
+        path = em.get_engine_path(**_BASE_KWARGS)
+        assert path.parent.name  # constructed without raising
+
+
+class TestControlNetPathExistingDiscrimination:
+    """Coverage that did not exist before fp8-round-12 -- pins the behavior the fix
+    must not regress while touching this branch."""
+
+    def test_path_changes_with_model_id(self):
+        em = _make_engine_manager()
+        path_a = em.get_engine_path(**_BASE_KWARGS)
+        path_b = em.get_engine_path(**dict(_BASE_KWARGS, controlnet_model_id="lllyasviel/sd-controlnet-openpose"))
+        assert path_a != path_b
+
+    def test_path_changes_with_resolution(self):
+        em = _make_engine_manager()
+        path_a = em.get_engine_path(**_BASE_KWARGS)
+        path_b = em.get_engine_path(**dict(_BASE_KWARGS, resolution=(1024, 1024)))
+        assert path_a != path_b
+
+    def test_path_changes_with_fp8(self):
+        em = _make_engine_manager()
+        path_a = em.get_engine_path(**_BASE_KWARGS)
+        path_b = em.get_engine_path(**dict(_BASE_KWARGS, fp8=True))
+        assert path_a != path_b
+
+    def test_model_id_slash_is_sanitized_to_underscore(self):
+        em = _make_engine_manager()
+        path = em.get_engine_path(**_BASE_KWARGS)
+        assert "/" not in path.parent.name

--- a/tests/unit/test_engine_path_ipadapter_suffixes.py
+++ b/tests/unit/test_engine_path_ipadapter_suffixes.py
@@ -1,0 +1,193 @@
+"""
+Regression test for IP-Adapter/FaceID scoping of the TensorRT engine cache key.
+
+``EngineManager.get_engine_path`` (acceleration/tensorrt/engine_manager.py) only folds
+``is_faceid`` / ``ipadapter_tokens`` into the cache key inside the
+``if engine_type == EngineType.UNET:`` block (:160-178). VAE-encoder and VAE-decoder engines
+are IP-Adapter-agnostic (they never see cross-attention weights), so those two params must be
+accepted but ignored for ``EngineType.VAE_ENCODER`` / ``EngineType.VAE_DECODER`` — otherwise
+toggling FaceID or changing the token count would force a redundant VAE rebuild.
+
+This is also the B3 regression test: bumping the marker from ``--fid`` to ``--fid2`` (a plain
+generation bump, done because B2's LoRA fusion changes the exported UNet graph and would
+otherwise let a stale ``--fid`` engine be silently reused) must still fork the UNet cache key
+whenever ``is_faceid`` flips, independent of the literal marker string. The UNet prefix is
+hashed (``engine_manager.py:240-247``) before becoming a directory name, so this test compares
+*paths*, not literal substrings — pinning ``--fid2`` itself would break the moment the marker
+is bumped again.
+
+Reuses the ``_make_engine_manager`` / GPU-less-import pattern from test_engine_path_length.py.
+
+Run with: pytest tests/unit/test_engine_path_ipadapter_suffixes.py -v
+"""
+
+from pathlib import Path
+
+import pytest
+
+try:
+    from streamdiffusion.acceleration.tensorrt.engine_manager import EngineManager, EngineType
+
+    IMPORT_OK = True
+except ImportError:
+    IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(
+    not IMPORT_OK,
+    reason="acceleration.tensorrt.engine_manager not importable",
+)
+
+_ENGINE_DIR = r"C:\Users\deswh\Documents\sdtd040\StreamDiffusion\engines\td"
+
+_BASE_KWARGS = {
+    "model_id_or_path": "stabilityai/sdxl-turbo",
+    "max_batch_size": 4,
+    "min_batch_size": 1,
+    "mode": "img2img",
+    "use_tiny_vae": True,
+}
+
+# Extra filenames beyond UNET (test_engine_path_length.py's _make_engine_manager only wires
+# UNET), so VAE_ENCODER/VAE_DECODER paths can be built too.
+_FILENAMES = {
+    EngineType.UNET: "unet.engine",
+    EngineType.VAE_ENCODER: "vae_encoder.engine",
+    EngineType.VAE_DECODER: "vae_decoder.engine",
+}
+
+
+def _make_engine_manager(engine_dir: str = _ENGINE_DIR) -> EngineManager:
+    """Build an EngineManager without running __init__'s heavy compile-fn imports."""
+    em = EngineManager.__new__(EngineManager)
+    em.engine_dir = Path(engine_dir)
+    em._configs = {etype: {"filename": fname} for etype, fname in _FILENAMES.items()}
+    return em
+
+
+class TestUnetPathForksOnFaceIdAndTokens:
+    def test_unet_path_changes_when_faceid_toggled(self):
+        em = _make_engine_manager()
+        path_regular = em.get_engine_path(engine_type=EngineType.UNET, is_faceid=False, **_BASE_KWARGS)
+        path_faceid = em.get_engine_path(engine_type=EngineType.UNET, is_faceid=True, **_BASE_KWARGS)
+
+        assert path_regular != path_faceid
+        assert path_regular.parent != path_faceid.parent
+
+    def test_unet_path_changes_with_ipadapter_tokens(self):
+        em = _make_engine_manager()
+        path_4 = em.get_engine_path(engine_type=EngineType.UNET, is_faceid=True, ipadapter_tokens=4, **_BASE_KWARGS)
+        path_77 = em.get_engine_path(engine_type=EngineType.UNET, is_faceid=True, ipadapter_tokens=77, **_BASE_KWARGS)
+
+        assert path_4 != path_77
+
+    def test_unet_path_is_deterministic(self):
+        """Same FaceID/token config -> same path, so a previously-built engine is reused."""
+        em = _make_engine_manager()
+        kwargs = dict(_BASE_KWARGS, engine_type=EngineType.UNET, is_faceid=True, ipadapter_tokens=4)
+
+        path_a = em.get_engine_path(**kwargs)
+        path_b = em.get_engine_path(**kwargs)
+
+        assert path_a == path_b
+
+
+class TestVaePathsIgnoreIpAdapterFlags:
+    def test_vae_encoder_path_unaffected_by_faceid(self):
+        em = _make_engine_manager()
+        path_regular = em.get_engine_path(engine_type=EngineType.VAE_ENCODER, is_faceid=False, **_BASE_KWARGS)
+        path_faceid = em.get_engine_path(engine_type=EngineType.VAE_ENCODER, is_faceid=True, **_BASE_KWARGS)
+
+        assert path_regular == path_faceid
+
+    def test_vae_decoder_path_unaffected_by_faceid(self):
+        em = _make_engine_manager()
+        path_regular = em.get_engine_path(engine_type=EngineType.VAE_DECODER, is_faceid=False, **_BASE_KWARGS)
+        path_faceid = em.get_engine_path(engine_type=EngineType.VAE_DECODER, is_faceid=True, **_BASE_KWARGS)
+
+        assert path_regular == path_faceid
+
+    def test_vae_paths_unaffected_by_ipadapter_tokens(self):
+        em = _make_engine_manager()
+        path_4 = em.get_engine_path(
+            engine_type=EngineType.VAE_DECODER, is_faceid=True, ipadapter_tokens=4, **_BASE_KWARGS
+        )
+        path_77 = em.get_engine_path(
+            engine_type=EngineType.VAE_DECODER, is_faceid=True, ipadapter_tokens=77, **_BASE_KWARGS
+        )
+
+        assert path_4 == path_77
+
+    def test_vae_encoder_and_decoder_paths_differ_from_each_other(self):
+        """Sanity check that the two VAE engine types don't collide via a shared filename bug."""
+        em = _make_engine_manager()
+        path_enc = em.get_engine_path(engine_type=EngineType.VAE_ENCODER, is_faceid=True, **_BASE_KWARGS)
+        path_dec = em.get_engine_path(engine_type=EngineType.VAE_DECODER, is_faceid=True, **_BASE_KWARGS)
+
+        assert path_enc != path_dec
+
+
+class TestFp8RecipeTagOrthogonalToIpAdapterSuffixes:
+    """fp8-round-8: the fp8 recipe tag (fp8_mha_qdq / fp8_scale_headroom /
+    fp8_exclude_attention) is appended to the same UNet ``prefix`` string as the
+    FaceID/token suffixes covered above, inside the same
+    ``if engine_type == EngineType.UNET:`` block in engine_manager.py. Guard that
+    toggling one axis doesn't silently cancel or alias the other's fork.
+    """
+
+    def test_fp8_recipe_forks_independently_of_faceid(self):
+        em = _make_engine_manager()
+        base = em.get_engine_path(engine_type=EngineType.UNET, is_faceid=True, fp8=True, **_BASE_KWARGS)
+        mhaq = em.get_engine_path(
+            engine_type=EngineType.UNET, is_faceid=True, fp8=True, fp8_mha_qdq=True, **_BASE_KWARGS
+        )
+        no_faceid = em.get_engine_path(engine_type=EngineType.UNET, is_faceid=False, fp8=True, **_BASE_KWARGS)
+        no_faceid_mhaq = em.get_engine_path(
+            engine_type=EngineType.UNET, is_faceid=False, fp8=True, fp8_mha_qdq=True, **_BASE_KWARGS
+        )
+
+        assert base != mhaq
+        assert no_faceid != no_faceid_mhaq
+        assert base != no_faceid
+        assert mhaq != no_faceid_mhaq
+
+    def test_fp8_exclude_ipadapter_forks_independently_of_faceid(self):
+        """fp8-round-9: the new -noip tag (fp8_exclude_ipadapter) must fork the UNet
+        cache key the same way -noattn does, independent of whether FaceID/IP-Adapter
+        is even enabled for this build."""
+        em = _make_engine_manager()
+        base = em.get_engine_path(engine_type=EngineType.UNET, is_faceid=True, fp8=True, **_BASE_KWARGS)
+        noip = em.get_engine_path(
+            engine_type=EngineType.UNET, is_faceid=True, fp8=True, fp8_exclude_ipadapter=True, **_BASE_KWARGS
+        )
+        no_faceid = em.get_engine_path(engine_type=EngineType.UNET, is_faceid=False, fp8=True, **_BASE_KWARGS)
+        no_faceid_noip = em.get_engine_path(
+            engine_type=EngineType.UNET, is_faceid=False, fp8=True, fp8_exclude_ipadapter=True, **_BASE_KWARGS
+        )
+
+        assert base != noip
+        assert no_faceid != no_faceid_noip
+        assert base != no_faceid
+        assert noip != no_faceid_noip
+
+    def test_fp8_exclude_ipadapter_forks_independently_of_exclude_attention(self):
+        """-noip and -noattn are independent levers (Fix 3's plan explicitly notes they
+        cover non-overlapping node sets) -- toggling one must not alias the other, and
+        both together must differ from either alone."""
+        em = _make_engine_manager()
+        neither = em.get_engine_path(engine_type=EngineType.UNET, is_faceid=True, fp8=True, **_BASE_KWARGS)
+        noattn = em.get_engine_path(
+            engine_type=EngineType.UNET, is_faceid=True, fp8=True, fp8_exclude_attention=True, **_BASE_KWARGS
+        )
+        noip = em.get_engine_path(
+            engine_type=EngineType.UNET, is_faceid=True, fp8=True, fp8_exclude_ipadapter=True, **_BASE_KWARGS
+        )
+        both = em.get_engine_path(
+            engine_type=EngineType.UNET,
+            is_faceid=True,
+            fp8=True,
+            fp8_exclude_attention=True,
+            fp8_exclude_ipadapter=True,
+            **_BASE_KWARGS,
+        )
+
+        assert len({neither, noattn, noip, both}) == 4

--- a/tests/unit/test_engine_path_length.py
+++ b/tests/unit/test_engine_path_length.py
@@ -96,3 +96,65 @@ class TestUnetEnginePathLength:
 
         assert path_a != path_b
         assert path_a.parent != path_b.parent
+
+
+class TestFp8RecipeTagV4:
+    """fp8-round-8: the fp8 tag bumped --fp8v3 -> --fp8v4 (the scale-conversion math
+    changed — see fp8_quantize.py::_rescale_fp8_qdq_scales — so every existing v3
+    engine is stale even with every recipe flag at its default) and gained new
+    components for fp8_scale_headroom / fp8_exclude_attention. This tag is built by
+    EngineManager._fp8_recipe_tag and used verbatim (not hashed) in the final UNet
+    directory name at both engine_manager.py:~197 (feeds the canonical/hash string)
+    and :~287 (the literal on-disk suffix) — the two call sites must stay in sync.
+    """
+
+    def test_default_recipe_uses_v4_base_tag(self):
+        em = _make_engine_manager(_CRASH_ENGINE_DIR)
+        path = em.get_engine_path(**dict(_CRASH_UNET_KWARGS, fp8_mha_qdq=False))
+        assert "fp8v3" not in path.parent.name
+        assert "fp8v4" in path.parent.name
+
+    def test_all_new_recipe_flags_stay_under_max_path(self):
+        """Worst case for the length regression this file guards: every fp8-round-8
+        recipe flag active at once, on top of the already-tight crash config."""
+        em = _make_engine_manager(_CRASH_ENGINE_DIR)
+        kwargs = dict(
+            _CRASH_UNET_KWARGS,
+            fp8_mha_qdq=True,
+            fp8_exclude_attention=True,
+            fp8_scale_headroom=2.0,
+        )
+        engine_path = em.get_engine_path(**kwargs)
+        onnx_path = str(engine_path) + ".onnx"
+        opt_onnx_path = str(engine_path) + ".opt.onnx"
+
+        assert len(onnx_path) < 260, f"onnx path is {len(onnx_path)} chars (MAX_PATH=260): {onnx_path}"
+        assert len(opt_onnx_path) < 260, f"opt.onnx path is {len(opt_onnx_path)} chars (MAX_PATH=260): {opt_onnx_path}"
+
+    def test_recipe_flags_fork_the_path_independently(self):
+        em = _make_engine_manager(_CRASH_ENGINE_DIR)
+        base = em.get_engine_path(**_CRASH_UNET_KWARGS)
+        mhaq = em.get_engine_path(**dict(_CRASH_UNET_KWARGS, fp8_mha_qdq=True))
+        noattn = em.get_engine_path(**dict(_CRASH_UNET_KWARGS, fp8_exclude_attention=True))
+        hr2 = em.get_engine_path(**dict(_CRASH_UNET_KWARGS, fp8_scale_headroom=2.0))
+
+        assert len({base, mhaq, noattn, hr2}) == 4, "each recipe flag must fork a distinct engine directory"
+
+    def test_recipe_flags_compose(self):
+        """All three flags together must differ from any single flag alone — guards
+        against one flag's suffix silently overwriting another's in string concat."""
+        em = _make_engine_manager(_CRASH_ENGINE_DIR)
+        mhaq_only = em.get_engine_path(**dict(_CRASH_UNET_KWARGS, fp8_mha_qdq=True))
+        all_three = em.get_engine_path(
+            **dict(_CRASH_UNET_KWARGS, fp8_mha_qdq=True, fp8_exclude_attention=True, fp8_scale_headroom=2.0)
+        )
+        assert mhaq_only != all_three
+
+    def test_recipe_tag_is_deterministic(self):
+        em = _make_engine_manager(_CRASH_ENGINE_DIR)
+        kwargs = dict(_CRASH_UNET_KWARGS, fp8_mha_qdq=True, fp8_exclude_attention=True, fp8_scale_headroom=2.0)
+
+        path_a = em.get_engine_path(**kwargs)
+        path_b = em.get_engine_path(**kwargs)
+
+        assert path_a == path_b


### PR DESCRIPTION
## What

A bug fix against upstream's current baseline, not a cherry-pick artifact: VAE encoder/decoder
engines carry no IP-Adapter cross-attention weights, so today every FaceID toggle or
IP-Adapter token-count change forces a redundant VAE rebuild — the engine cache key includes
those tokens even for engines that can never use them.

## Changes

- Scopes the IP-Adapter/FaceID suffix (`--fid`) to `EngineType.UNET` only; VAE and ControlNet
  engine paths no longer carry it.
- Bumps the tag to `--fid2` so old-scheme cache entries (which incorrectly forked VAE paths on
  FaceID token count) are treated as stale and rebuilt once, rather than silently reused with a
  now-meaningless suffix.
- Adds a ControlNet-token component to the engine path so distinct ControlNet configurations
  get distinct cache entries, matching the existing pattern for IP-Adapter tokens.

## Tests

`tests/unit/test_engine_path_controlnet_tokens.py`, `test_engine_path_ipadapter_suffixes.py`,
`test_engine_path_length.py` — cover suffix scoping by engine type, the `--fid`→`--fid2`
migration, and total path-length bounds under combined suffixes.

## Branch

`pr/trt-engine-cache-tags` -> `SDTD_040_beta_release`
