### PR TITLE
fix: faceid insightface loader, BGR conditioning, and IP-Adapter LoRA fusion

### DIFF
--- a/scripts/test_faceid_sanity.py
+++ b/scripts/test_faceid_sanity.py
@@ -1,0 +1,242 @@
+"""
+FaceID Sanity Test — headless PyTorch baseline vs FaceID IP-Adapter comparison.
+
+Modelled directly on scripts/test_lora_sanity.py (same acceleration='none' two-pass +
+side-by-side-PNG structure). Runs two StreamDiffusionWrapper passes from the same seed:
+  A) baseline — no IP-Adapter
+  B) faceid   — FaceID IP-Adapter conditioned on a face style image
+
+Saves baseline.png, faceid.png, and a side-by-side comparison PNG.
+
+Purpose: confirm FaceID IP-Adapter is visibly effective (identity transfer toward the style
+face) BEFORE paying for a TensorRT engine build. Run once after the B1 (BGR feed) fix alone,
+and again after B3+B2 (LoRA fusion + engine cache-key bump) land, per FaceID_PLAN.md Step 2 /
+Step 6 — B1 alone should already move the needle since a corrupted ArcFace vector can't be
+rescued downstream; B2 recovers the ~57% of the adapter's trained parameters (the LoRA) that
+are otherwise silently discarded on top of that.
+
+Usage:
+    venv/Scripts/python scripts/test_faceid_sanity.py
+    venv/Scripts/python scripts/test_faceid_sanity.py --style-image path/to/face.jpg
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Repo root on sys.path so `from streamdiffusion` works without install
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from PIL import Image
+
+from streamdiffusion import StreamDiffusionWrapper
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger("faceid_sanity")
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+DEFAULT_MODEL = "stabilityai/sdxl-turbo"
+DEFAULT_PROMPT = "a portrait photo, detailed face, studio lighting"
+DEFAULT_INPUT = str(_REPO_ROOT / "images" / "inputs" / "input.png")
+# insightface's own bundled multi-face test photo — real, detectable faces, no extra
+# download required (buffalo_l is already cached locally by the time this runs).
+DEFAULT_STYLE_IMAGE = str(Path(sys.prefix) / "Lib" / "site-packages" / "insightface" / "data" / "images" / "t1.jpg")
+DEFAULT_T_INDEX = [10, 35]
+DEFAULT_SEED = 42
+DEFAULT_OUTPUT_DIR = str(_REPO_ROOT / "outputs" / "faceid_sanity")
+DEFAULT_INSIGHTFACE_MODEL = "buffalo_l"
+
+
+# ---------------------------------------------------------------------------
+# Helper: run one inference pass with StreamDiffusionWrapper
+# ---------------------------------------------------------------------------
+def run_pass(
+    model_id: str,
+    prompt: str,
+    input_image: Image.Image,
+    t_index_list: list,
+    seed: int,
+    use_ipadapter: bool,
+    ipadapter_config: dict | None,
+    style_image: Image.Image | None,
+    label: str,
+) -> Image.Image:
+    logger.info(f"--- [{label}] Building wrapper (acceleration=none) ---")
+    if ipadapter_config:
+        logger.info(f"    ipadapter_config = {ipadapter_config}")
+
+    stream = StreamDiffusionWrapper(
+        model_id_or_path=model_id,
+        t_index_list=t_index_list,
+        frame_buffer_size=1,
+        width=512,
+        height=512,
+        warmup=1,
+        acceleration="none",
+        mode="img2img",
+        use_denoising_batch=True,
+        cfg_type="self",
+        seed=seed,
+        use_tiny_vae=True,
+        use_ipadapter=use_ipadapter,
+        ipadapter_config=ipadapter_config,
+    )
+
+    stream.prepare(
+        prompt=prompt,
+        negative_prompt="",
+        num_inference_steps=50,
+        guidance_scale=1.0,
+        delta=1.0,
+    )
+
+    if use_ipadapter and style_image is not None:
+        logger.info(f"    [{label}] Setting FaceID style image")
+        stream.update_style_image(style_image)
+
+    image_tensor = stream.preprocess_image(input_image)
+
+    # Warmup: batch_size - 1 dummy passes (required by StreamDiffusion)
+    for _ in range(stream.batch_size - 1):
+        stream(image=image_tensor)
+
+    output = stream(image=image_tensor)
+    logger.info(f"    [{label}] Done — output type: {type(output)}")
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main() -> int:
+    parser = argparse.ArgumentParser(description="FaceID sanity: baseline vs FaceID comparison")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="HF model id or local path")
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT, help="Text prompt")
+    parser.add_argument("--input", default=DEFAULT_INPUT, help="Input image path (img2img base frame)")
+    parser.add_argument("--style-image", default=DEFAULT_STYLE_IMAGE, help="Face photo for FaceID conditioning")
+    parser.add_argument(
+        "--insightface-model", default=DEFAULT_INSIGHTFACE_MODEL, help="InsightFace model name (e.g. buffalo_l)"
+    )
+    parser.add_argument(
+        "--t-index",
+        nargs="+",
+        type=int,
+        default=DEFAULT_T_INDEX,
+        metavar="T",
+        help="t_index_list (e.g. --t-index 10 35)",
+    )
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR, help="Directory for output PNGs")
+    args = parser.parse_args()
+
+    # ------------------------------------------------------------------
+    # Prepare output directory and input images
+    # ------------------------------------------------------------------
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    input_path = Path(args.input)
+    if not input_path.exists():
+        logger.error(f"Input image not found: {input_path}")
+        return 1
+
+    style_path = Path(args.style_image)
+    if not style_path.exists():
+        logger.error(f"Style (face) image not found: {style_path}")
+        return 1
+
+    input_image = Image.open(input_path).convert("RGB").resize((512, 512))
+    style_image = Image.open(style_path).convert("RGB")
+    logger.info(f"Input image: {input_path} -> resized to 512x512")
+    logger.info(f"Style (face) image: {style_path}")
+
+    t_index_list = args.t_index
+
+    ipadapter_config = {
+        "ipadapter_model_path": "h94/IP-Adapter-FaceID/ip-adapter-faceid_sdxl.bin",
+        "image_encoder_path": "h94/IP-Adapter/sdxl_models/image_encoder",
+        "type": "faceid",
+        "insightface_model_name": args.insightface_model,
+        "scale": 1.0,
+    }
+
+    # ------------------------------------------------------------------
+    # Run A: Baseline (no IP-Adapter)
+    # ------------------------------------------------------------------
+    logger.info("=" * 60)
+    logger.info("RUN A: baseline (no IP-Adapter)")
+    logger.info("=" * 60)
+    baseline_img = run_pass(
+        model_id=args.model,
+        prompt=args.prompt,
+        input_image=input_image,
+        t_index_list=t_index_list,
+        seed=args.seed,
+        use_ipadapter=False,
+        ipadapter_config=None,
+        style_image=None,
+        label="baseline",
+    )
+    baseline_path = output_dir / "baseline.png"
+    baseline_img.save(baseline_path)
+    logger.info(f"Saved baseline: {baseline_path}")
+
+    # ------------------------------------------------------------------
+    # Run B: FaceID
+    # ------------------------------------------------------------------
+    logger.info("=" * 60)
+    logger.info(f"RUN B: FaceID (insightface_model={args.insightface_model})")
+    logger.info("=" * 60)
+    try:
+        faceid_img = run_pass(
+            model_id=args.model,
+            prompt=args.prompt,
+            input_image=input_image,
+            t_index_list=t_index_list,
+            seed=args.seed,
+            use_ipadapter=True,
+            ipadapter_config=ipadapter_config,
+            style_image=style_image,
+            label="faceid",
+        )
+    except RuntimeError as e:
+        logger.error(f"FaceID run failed: {e}")
+        logger.info("Baseline image saved. FaceID run aborted.")
+        return 2
+
+    faceid_path = output_dir / "faceid.png"
+    faceid_img.save(faceid_path)
+    logger.info(f"Saved faceid: {faceid_path}")
+
+    # ------------------------------------------------------------------
+    # Side-by-side comparison
+    # ------------------------------------------------------------------
+    comparison = Image.new("RGB", (1024, 512))
+    comparison.paste(baseline_img.resize((512, 512)), (0, 0))
+    comparison.paste(faceid_img.resize((512, 512)), (512, 0))
+    comparison_path = output_dir / "comparison.png"
+    comparison.save(comparison_path)
+    logger.info(f"Saved side-by-side: {comparison_path}")
+
+    logger.info("=" * 60)
+    logger.info("DONE. Inspect outputs:")
+    logger.info(f"  baseline:   {baseline_path}")
+    logger.info(f"  faceid:     {faceid_path}")
+    logger.info(f"  comparison: {comparison_path}")
+    logger.info("=" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/streamdiffusion/modules/faceid_compat.py
+++ b/src/streamdiffusion/modules/faceid_compat.py
@@ -4,16 +4,17 @@
 ``livepeer/Diffusers_IPAdapter``), so it cannot be edited directly — edits are lost on
 reinstall. This module holds the fixes as monkeypatches / free functions, applied from
 ``IPAdapterModule.install()`` at runtime, and documents the silent-failure defects and
-wasted-work findings from ``docs/plans/FaceID_PLAN.md`` (B1, S1).
+wasted-work findings from ``docs/plans/FaceID_PLAN.md`` (B1, B2, S1).
 
-B1 produces **no errors or warnings** — FaceID runs end-to-end and looks healthy in the
-log while barely transferring any identity. S1 is not a correctness defect, just a
-redundant InsightFace pass on every SDXL update.
+B1 and B2 produce **no errors or warnings** — FaceID runs end-to-end and looks healthy
+in the log while barely transferring any identity. S1 is not a correctness defect, just
+a redundant InsightFace pass on every SDXL update.
 """
 
 from __future__ import annotations
 
 import logging
+from typing import Any, Dict
 
 import numpy as np
 import torch
@@ -157,3 +158,110 @@ def _apply_single_pass_face_conditioning_patch() -> None:
         "apply_faceid_patches: patched prepare_face_conditioning to detect faces once per "
         "update instead of twice (S1)."
     )
+
+
+# ---------------------------------------------------------------------------
+# B2 — the FaceID checkpoint's rank-128 LoRA (to_{q,k,v,out}_lora on all 140 attention
+# modules) is silently discarded. ip_adapter.py's strict load filters "lora"/"LoRA" keys
+# for FaceID models because no LoRA-aware processor exists in attention_processor.py,
+# and the TensorRT export path (unet_ipadapter_export.py) rebuilds every processor
+# before ONNX export regardless, so a processor-resident LoRA would be lost there too.
+# Fusing the LoRA into the base attention linears survives both paths.
+# ---------------------------------------------------------------------------
+_LORA_TARGET_ATTR: Dict[str, str] = {
+    "to_q_lora": "to_q",
+    "to_k_lora": "to_k",
+    "to_v_lora": "to_v",
+    "to_out_lora": "to_out.0",
+}
+
+
+def _load_faceid_state_dict(ckpt_path: str) -> Dict[str, Any]:
+    try:
+        return torch.load(ckpt_path, map_location="cpu", weights_only=True, mmap=True)
+    except TypeError:
+        # Older torch without the mmap kwarg.
+        return torch.load(ckpt_path, map_location="cpu", weights_only=True)
+
+
+def fuse_faceid_lora(unet: torch.nn.Module, ckpt_path: str, lora_scale: float = 1.0) -> int:
+    """Fuse the FaceID checkpoint's per-layer LoRA weights into the UNet's attention linears.
+
+    For each of the UNet's ``attn_processors`` (index ``i``, in ``unet.attn_processors``
+    iteration order — the same order ``diffusers_ipadapter`` uses to load
+    ``to_k_ip``/``to_v_ip``), adds ``(up @ down) * lora_scale`` into ``to_q``, ``to_k``,
+    ``to_v`` and ``to_out[0]`` of the corresponding attention module.
+
+    This is mathematically exact at ``lora_scale=1.0``: in h94's LoRA(IP)AttnProcessor,
+    each LoRA branch consumes the same input tensor as the base linear it parallels
+    (``to_q_lora`` <- ``hidden_states``; ``to_k_lora``/``to_v_lora`` <- the text slice of
+    ``encoder_hidden_states``, exactly what ``attn.to_k``/``attn.to_v`` receive;
+    ``to_out_lora`` <- the blended hidden states), and h94's ``LoRALinearLayer`` leaves
+    ``network_alpha=None`` — plain ``up @ down``, no rank/alpha division.
+
+    Once fused, the LoRA is permanent and is *not* modulated by ``ipadapter_scale`` at
+    runtime — this matches h94's reference behaviour (fixed ``lora_scale=1.0``). Callers
+    must bump the TensorRT engine cache-key marker (B3) so stale pre-fusion engines are
+    never reused.
+
+    Idempotent: a second call on an already-fused UNet is a no-op. Raises ``RuntimeError``
+    on any LoRA delta / target weight shape mismatch rather than silently skipping it —
+    this defect class (B1/B2) is exactly the silent-no-op failure this fix exists to end.
+
+    Returns the number of attention modules that received a fused update (0 if the
+    checkpoint carries no LoRA — e.g. a non-FaceID IP-Adapter — or the UNet was already
+    fused).
+    """
+    if getattr(unet, "_sdtd_faceid_lora_fused", False):
+        logger.info("fuse_faceid_lora: UNet already has fused FaceID LoRA — skipping.")
+        return 0
+
+    ckpt = _load_faceid_state_dict(ckpt_path)
+    ip_adapter_state_dict: Dict[str, torch.Tensor] = ckpt.get("ip_adapter", {})
+
+    if not any("_lora." in key for key in ip_adapter_state_dict):
+        logger.info("fuse_faceid_lora: checkpoint has no LoRA keys — nothing to fuse.")
+        del ckpt, ip_adapter_state_dict
+        return 0
+
+    processor_keys = list(unet.attn_processors.keys())
+    fused_layers = 0
+
+    with torch.no_grad():
+        for i, proc_key in enumerate(processor_keys):
+            if not proc_key.endswith(".processor"):
+                continue
+            module_path = proc_key[: -len(".processor")]
+
+            layer_fused = False
+            for lora_name, target_attr in _LORA_TARGET_ATTR.items():
+                down_key = f"{i}.{lora_name}.down.weight"
+                up_key = f"{i}.{lora_name}.up.weight"
+                if down_key not in ip_adapter_state_dict or up_key not in ip_adapter_state_dict:
+                    continue
+
+                down = ip_adapter_state_dict[down_key].float()
+                up = ip_adapter_state_dict[up_key].float()
+                delta = (up @ down) * lora_scale
+
+                target_linear = unet.get_submodule(f"{module_path}.{target_attr}")
+                if delta.shape != target_linear.weight.shape:
+                    raise RuntimeError(
+                        f"fuse_faceid_lora: shape mismatch at layer {i} "
+                        f"({module_path}.{target_attr}): delta {tuple(delta.shape)} "
+                        f"vs weight {tuple(target_linear.weight.shape)}"
+                    )
+                target_linear.weight.add_(
+                    delta.to(dtype=target_linear.weight.dtype, device=target_linear.weight.device)
+                )
+                layer_fused = True
+
+            if layer_fused:
+                fused_layers += 1
+
+    del ckpt, ip_adapter_state_dict
+    unet._sdtd_faceid_lora_fused = True
+    logger.info(
+        f"fuse_faceid_lora: fused FaceID LoRA into {fused_layers} attention modules (lora_scale={lora_scale})."
+    )
+    return fused_layers

--- a/src/streamdiffusion/modules/faceid_compat.py
+++ b/src/streamdiffusion/modules/faceid_compat.py
@@ -1,0 +1,159 @@
+"""Compatibility fixes for the vendored ``diffusers_ipadapter`` FaceID path.
+
+``diffusers_ipadapter`` is pip-installed from a pinned SHA (see ``setup.py`` ->
+``livepeer/Diffusers_IPAdapter``), so it cannot be edited directly — edits are lost on
+reinstall. This module holds the fixes as monkeypatches / free functions, applied from
+``IPAdapterModule.install()`` at runtime, and documents the silent-failure defects and
+wasted-work findings from ``docs/plans/FaceID_PLAN.md`` (B1, S1).
+
+B1 produces **no errors or warnings** — FaceID runs end-to-end and looks healthy in the
+log while barely transferring any identity. S1 is not a correctness defect, just a
+redundant InsightFace pass on every SDXL update.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# B1 — InsightFace is fed RGB, but every InsightFace ONNX model (arcface_onnx.py,
+# retinaface.py, scrfd.py) preprocesses with cv2.dnn.blobFromImage(..., swapRB=True) —
+# i.e. it swaps R/B internally and therefore contractually expects BGR input.
+# face_utils.py hands it a plain RGB numpy array (np.array(PIL_image)), so the ArcFace
+# identity embedding is computed from a channel-swapped face. Detection boxes stay
+# mostly correct (robust to the swap); the 512-d embedding does not.
+# ---------------------------------------------------------------------------
+def apply_faceid_patches() -> None:
+    """Monkeypatch ``detect_faces_multires`` so InsightFace receives BGR, then apply S1.
+
+    In the vendored code, both call sites (``extract_face_embeddings`` and
+    ``prepare_face_conditioning``'s re-crop branch, ``face_utils.py:117`` / ``:196``)
+    route through this single choke point, so patching it here covers both. Landmark-based
+    crops (``face_align.norm_crop``) are left untouched — they stay RGB, which is correct
+    for the CLIP encoder path used by FaceID-Plus.
+
+    Also applies the S1 fix (``_apply_single_pass_face_conditioning_patch``, below), which
+    replaces ``prepare_face_conditioning`` itself so the second call site above no longer
+    exists — one detection pass per image instead of two. Both patches touch the same
+    vendored module and are applied together from the same install-time hook.
+
+    Idempotent: safe to call more than once (e.g. one process installing IP-Adapter for
+    more than one stream).
+    """
+    from diffusers_ipadapter.ip_adapter import face_utils as _face_utils
+
+    if getattr(_face_utils.detect_faces_multires, "_sdtd_bgr_patched", False):
+        return
+
+    _original_detect_faces_multires = _face_utils.detect_faces_multires
+
+    def _bgr_detect_faces_multires(insightface_model, image, *args, **kwargs):
+        if isinstance(image, np.ndarray) and image.ndim == 3 and image.shape[2] == 3:
+            image = np.ascontiguousarray(image[:, :, ::-1])
+        return _original_detect_faces_multires(insightface_model, image, *args, **kwargs)
+
+    _bgr_detect_faces_multires._sdtd_bgr_patched = True
+    _bgr_detect_faces_multires._sdtd_original = _original_detect_faces_multires
+    _face_utils.detect_faces_multires = _bgr_detect_faces_multires
+    logger.info("apply_faceid_patches: patched detect_faces_multires to feed InsightFace BGR (B1).")
+
+    _apply_single_pass_face_conditioning_patch()
+
+
+# ---------------------------------------------------------------------------
+# S1 — prepare_face_conditioning() detects faces twice per update on SDXL/Kolors:
+# once inside extract_face_embeddings() (face_utils.py:117, cropped at image_size=224),
+# then again itself (face_utils.py:196) purely to get the same face's landmarks a second
+# time so it can re-crop at the model's real crop_size (256 for SDXL, 336 for Kolors —
+# get_face_crop_size() only returns 224 for plain SD1.5, so the second pass always fires
+# for SDXL/Kolors). Not a correctness bug (S1 is latent-cost, not silent-wrong like
+# B1/B2) but it doubles InsightFace's cost on every FaceID update for no benefit.
+# ---------------------------------------------------------------------------
+def _apply_single_pass_face_conditioning_patch() -> None:
+    """Monkeypatch ``prepare_face_conditioning`` to detect each face once, not twice.
+
+    Replaces the vendored two-pass implementation (detect at 224 -> re-detect at the
+    model's real crop size) with a single detection pass per image, cropped directly at
+    the final size. ``prepare_face_conditioning`` has exactly one caller in the vendored
+    package (``ip_adapter.py``'s ``_get_faceid_embeds``) and is itself the only caller of
+    ``extract_face_embeddings``, so replacing it whole is safe — no other code path
+    depends on ``extract_face_embeddings``'s 224-fixed crop.
+
+    Patches **two** bindings, not one: ``ip_adapter.py`` does
+    ``from .face_utils import ... prepare_face_conditioning``, which copies the function
+    object into ``ip_adapter``'s own module namespace at import time. Reassigning
+    ``face_utils.prepare_face_conditioning`` alone would not reach the actual call site
+    (``ip_adapter.py:206``, ``_get_faceid_embeds``) — unlike ``detect_faces_multires``,
+    whose only callers are inside ``face_utils.py`` itself and resolve the name through
+    that module's own globals at call time (B1's patch doesn't need this extra step).
+
+    Reads ``detect_faces_multires`` off the module dynamically on every call (not a
+    captured reference), so this patch composes correctly with the B1 BGR patch
+    regardless of which of the two is applied first.
+
+    Idempotent: safe to call more than once.
+    """
+    from diffusers_ipadapter.ip_adapter import face_utils as _face_utils
+    from diffusers_ipadapter.ip_adapter import ip_adapter as _ip_adapter_module
+
+    if getattr(_face_utils.prepare_face_conditioning, "_sdtd_single_pass_patched", False):
+        return
+
+    _original_prepare_face_conditioning = _face_utils.prepare_face_conditioning
+
+    def _single_pass_prepare_face_conditioning(
+        insightface_model,
+        images,
+        is_sdxl: bool = False,
+        is_kolors: bool = False,
+        normalize_embeddings: bool = True,
+    ):
+        from PIL import Image as _PILImage
+
+        try:
+            from insightface.utils import face_align
+        except ImportError as err:
+            raise ImportError("InsightFace face_align utility is required") from err
+
+        if isinstance(images, _PILImage.Image):
+            images = [images]
+
+        crop_size = _face_utils.get_face_crop_size(is_sdxl, is_kolors)
+
+        face_embeddings = []
+        cropped_faces = []
+        for i, image in enumerate(images):
+            image_np = np.array(image) if isinstance(image, _PILImage.Image) else image
+
+            # Dynamic lookup so this composes with the B1 BGR patch either order.
+            faces = _face_utils.detect_faces_multires(insightface_model, image_np)
+            if not faces:
+                raise ValueError(f"extract_face_embeddings: No face detected in image {i}")
+            face = faces[0]
+
+            if normalize_embeddings:
+                embedding = torch.from_numpy(face.normed_embedding).unsqueeze(0)
+            else:
+                embedding = torch.from_numpy(face.embedding).unsqueeze(0)
+            face_embeddings.append(embedding)
+
+            cropped_face = face_align.norm_crop(image_np, landmark=face.kps, image_size=crop_size)
+            cropped_faces.append(_PILImage.fromarray(cropped_face))
+
+        return torch.cat(face_embeddings, dim=0), cropped_faces
+
+    _single_pass_prepare_face_conditioning._sdtd_single_pass_patched = True
+    _single_pass_prepare_face_conditioning._sdtd_original = _original_prepare_face_conditioning
+    _face_utils.prepare_face_conditioning = _single_pass_prepare_face_conditioning
+    # The actual call site (ip_adapter.py:206) uses its own copied-in name — see docstring.
+    _ip_adapter_module.prepare_face_conditioning = _single_pass_prepare_face_conditioning
+    logger.info(
+        "apply_faceid_patches: patched prepare_face_conditioning to detect faces once per "
+        "update instead of twice (S1)."
+    )

--- a/src/streamdiffusion/modules/faceid_compat.py
+++ b/src/streamdiffusion/modules/faceid_compat.py
@@ -9,17 +9,54 @@ wasted-work findings from ``docs/plans/FaceID_PLAN.md`` (B1, B2, S1).
 B1 and B2 produce **no errors or warnings** — FaceID runs end-to-end and looks healthy
 in the log while barely transferring any identity. S1 is not a correctness defect, just
 a redundant InsightFace pass on every SDXL update.
+
+Also applies a cost-reduction pair not tracked in ``FaceID_PLAN.md`` (that plan's own S2
+is an unrelated dead-code finding): the "update image" button freezes streaming output
+in FaceID mode because the whole InsightFace pass runs inline on TouchDesigner's render
+thread (``td_manager.py``'s ``_process_ipadapter_frame``), and does far more work than
+FaceID actually needs. See ``_apply_insightface_loader_patch`` and
+``_apply_detect_faces_multires_patch`` below.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 import numpy as np
 import torch
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Shared by every patch below. ``ip_adapter.py`` does
+# ``from .face_utils import get_insightface_model, prepare_face_conditioning`` at
+# module level, which copies each imported function *object* into ``ip_adapter``'s own
+# namespace — and ``diffusers_ipadapter/ip_adapter/__init__.py`` does
+# ``from .face_utils import *``, which copies every public face_utils name into the
+# *package's* namespace too. Patching only ``face_utils`` therefore silently misses any
+# call site that resolves the name through one of those copies instead of through
+# ``face_utils`` itself.
+#
+# This is not hypothetical: ``_apply_insightface_loader_patch`` originally patched only
+# ``face_utils.get_insightface_model``. It worked perfectly in isolation — but
+# ``ip_adapter.py:56`` (the function's only real caller) reads its own copied-in name,
+# never the patched one, so ``allowed_modules`` never reached ``FaceAnalysis`` in
+# production despite every test passing. Rebind through this helper everywhere a
+# face_utils name is patched, so the next addition can't repeat that mistake.
+# ---------------------------------------------------------------------------
+def _rebind_across_modules(attr_name: str, original: Any, replacement: Any, modules: Iterable[Any]) -> None:
+    """Reassign ``attr_name`` to ``replacement`` on every module in ``modules`` that
+    currently holds ``original``.
+
+    Guards on identity (``is``) so callers can pass every module that *might* hold a
+    stale copy of the name without risk of clobbering an unrelated binding (e.g. a
+    module that was never given this name, or already points at ``replacement``).
+    """
+    for module in modules:
+        if getattr(module, attr_name, None) is original:
+            setattr(module, attr_name, replacement)
 
 
 # ---------------------------------------------------------------------------
@@ -31,40 +68,175 @@ logger = logging.getLogger(__name__)
 # mostly correct (robust to the swap); the 512-d embedding does not.
 # ---------------------------------------------------------------------------
 def apply_faceid_patches() -> None:
-    """Monkeypatch ``detect_faces_multires`` so InsightFace receives BGR, then apply S1.
-
-    In the vendored code, both call sites (``extract_face_embeddings`` and
-    ``prepare_face_conditioning``'s re-crop branch, ``face_utils.py:117`` / ``:196``)
-    route through this single choke point, so patching it here covers both. Landmark-based
-    crops (``face_align.norm_crop``) are left untouched — they stay RGB, which is correct
-    for the CLIP encoder path used by FaceID-Plus.
-
-    Also applies the S1 fix (``_apply_single_pass_face_conditioning_patch``, below), which
-    replaces ``prepare_face_conditioning`` itself so the second call site above no longer
-    exists — one detection pass per image instead of two. Both patches touch the same
-    vendored module and are applied together from the same install-time hook.
+    """Apply all face_utils patches: InsightFace loader cost cut, B1 + detection cost
+    cuts (merged into one replacement of ``detect_faces_multires``), then S1.
 
     Idempotent: safe to call more than once (e.g. one process installing IP-Adapter for
-    more than one stream).
+    more than one stream) — each sub-patch checks its own marker independently, but the
+    top-level check below (mirroring the pre-existing convention) is enough since all
+    three are always applied together from this one entry point.
     """
+    import diffusers_ipadapter.ip_adapter as _ip_adapter_pkg
     from diffusers_ipadapter.ip_adapter import face_utils as _face_utils
+    from diffusers_ipadapter.ip_adapter import ip_adapter as _ip_adapter_module
 
+    if getattr(_face_utils.detect_faces_multires, "_sdtd_bgr_patched", False):
+        return
+
+    # Every name patched below is re-exported by both ip_adapter.py's own
+    # `from .face_utils import ...` and the package __init__'s `from .face_utils
+    # import *` — see _rebind_across_modules above. Pass the full set to every patch so
+    # a future addition to either import list is covered automatically.
+    _aliasing_modules = (_face_utils, _ip_adapter_module, _ip_adapter_pkg)
+
+    _apply_insightface_loader_patch(_face_utils, _aliasing_modules)
+    _apply_detect_faces_multires_patch(_face_utils, _aliasing_modules)
+    _apply_single_pass_face_conditioning_patch(_aliasing_modules)
+
+
+# ---------------------------------------------------------------------------
+# Cost reduction — get_insightface_model() builds a full FaceAnalysis with all five
+# buffalo_l models: detection, recognition, genderage, landmark_2d_106, landmark_3d_68.
+# FaceAnalysis.get() (face_analysis.py:72-75) runs every non-detection model on every
+# detected face. FaceID only ever reads face.normed_embedding (recognition) and face.kps
+# (a byproduct of detection, not a separate model) — see
+# _single_pass_prepare_face_conditioning below and faceid_embedding.py. genderage,
+# landmark_2d_106, and the 143MB landmark_3d_68 run for zero benefit. Restricting via
+# InsightFace's own ``allowed_modules`` kwarg (face_analysis.py:24, :34-37) also saves
+# ~150MB of model memory at load.
+# ---------------------------------------------------------------------------
+_INSIGHTFACE_ALLOWED_MODULES = ["detection", "recognition"]
+
+
+def _apply_insightface_loader_patch(_face_utils, _aliasing_modules: Iterable[Any]) -> None:
+    """Monkeypatch ``get_insightface_model`` so FaceAnalysis loads only detection + recognition.
+
+    Rather than reimplementing ``get_insightface_model``'s body (provider
+    auto-detection, model-dir setup, error wrapping — ``face_utils.py:13-53``), this
+    patches ``insightface.app.FaceAnalysis`` for the duration of one call and lets the
+    original vendored function run unchanged. ``get_insightface_model`` does
+    ``from insightface.app import FaceAnalysis`` *inside* its own body
+    (``face_utils.py:25``), so it re-resolves that name from ``insightface.app``'s module
+    namespace on every call — the same dynamic-lookup property the BGR and single-pass
+    patches below rely on — which is what makes a swap-then-restore safe here: the
+    vendored function only ever sees the patched name during its own single call, and the
+    original is restored immediately after (call sites are all at install time, not on
+    a hot path where concurrent calls could interleave).
+
+    Rebinds through every module in ``_aliasing_modules`` (see ``_rebind_across_modules``),
+    not just ``face_utils`` — the real caller is ``ip_adapter.py:56``, which reads its own
+    copied-in name from ``from .face_utils import get_insightface_model``. Patching
+    ``face_utils`` alone leaves that call site on the unpatched original.
+
+    Idempotent: safe to call more than once.
+    """
+    if getattr(_face_utils.get_insightface_model, "_sdtd_allowed_modules_patched", False):
+        return
+
+    _original_get_insightface_model = _face_utils.get_insightface_model
+
+    def _restricted_get_insightface_model(*args, **kwargs):
+        import insightface.app as _insightface_app
+
+        _original_face_analysis = _insightface_app.FaceAnalysis
+
+        def _face_analysis_detection_recognition_only(*fa_args, **fa_kwargs):
+            fa_kwargs.setdefault("allowed_modules", _INSIGHTFACE_ALLOWED_MODULES)
+            return _original_face_analysis(*fa_args, **fa_kwargs)
+
+        _insightface_app.FaceAnalysis = _face_analysis_detection_recognition_only
+        try:
+            return _original_get_insightface_model(*args, **kwargs)
+        finally:
+            _insightface_app.FaceAnalysis = _original_face_analysis
+
+    _restricted_get_insightface_model._sdtd_allowed_modules_patched = True
+    _restricted_get_insightface_model._sdtd_original = _original_get_insightface_model
+    _rebind_across_modules(
+        "get_insightface_model",
+        _original_get_insightface_model,
+        _restricted_get_insightface_model,
+        _aliasing_modules,
+    )
+    logger.info(
+        "apply_faceid_patches: patched get_insightface_model to load only "
+        f"{_INSIGHTFACE_ALLOWED_MODULES} (skipping genderage/landmark_2d_106/landmark_3d_68)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cost reduction — detect_faces_multires() sweeps det_size from a fixed 640 down to
+# min_size in steps of 64 (up to 7 passes on a frame with no detectable face) and calls
+# insightface_model.get(image) with the default max_num=0 — detect *and run every
+# allowed model on* every face found, even though prepare_face_conditioning only ever
+# keeps faces[0]. On TouchDesigner's 512x512 style image (td_config.yaml width/height)
+# the first pass also upscales to 640 before the network sees a real face.
+#
+# Folded into the same choke point as B1 (both of face_utils.py's call sites,
+# extract_face_embeddings and prepare_face_conditioning's re-crop branch, route through
+# this one function) rather than layered as a second wrapper: B1's original
+# wrap-and-capture-closure approach would make a *later* reassignment of
+# detect_faces_multires invisible to it — the closure keeps calling whatever the module
+# attribute pointed to when B1 was installed, not whatever it points to now.
+# ---------------------------------------------------------------------------
+def _apply_detect_faces_multires_patch(_face_utils, _aliasing_modules: Iterable[Any]) -> None:
+    """Replace ``detect_faces_multires`` with a BGR-correct, cost-bounded implementation.
+
+    Combines B1 (RGB->BGR swap — see module docstring above) with three cost cuts:
+    ``max_num=1`` (stop running every non-detection model on faces
+    ``prepare_face_conditioning`` will discard), a sweep that starts at the input
+    image's own size instead of a fixed 640 (avoids upscaling a 512px style image before
+    detection even runs), and a sweep bounded to at most 3 sizes (avoids the worst case
+    — 7 full passes — on a frame with no detectable face). Logs when a smaller size
+    succeeds, and when the sweep is exhausted with no face found, so a bounded sweep
+    doesn't silently look identical to "no face in the image" from B1's era.
+
+    Rebinds through every module in ``_aliasing_modules`` (see ``_rebind_across_modules``)
+    for consistency with the other two patches, even though today's only known callers
+    (``face_utils.py``'s own ``extract_face_embeddings`` and this module's single-pass
+    replacement, both via ``_face_utils.detect_faces_multires`` dynamic lookup) resolve
+    the name through ``face_utils`` directly and would work with a single binding.
+
+    Idempotent: safe to call more than once.
+    """
     if getattr(_face_utils.detect_faces_multires, "_sdtd_bgr_patched", False):
         return
 
     _original_detect_faces_multires = _face_utils.detect_faces_multires
 
-    def _bgr_detect_faces_multires(insightface_model, image, *args, **kwargs):
+    def _restricted_detect_faces_multires(insightface_model, image, min_size: int = 256):
         if isinstance(image, np.ndarray) and image.ndim == 3 and image.shape[2] == 3:
-            image = np.ascontiguousarray(image[:, :, ::-1])
-        return _original_detect_faces_multires(insightface_model, image, *args, **kwargs)
+            image = np.ascontiguousarray(image[:, :, ::-1])  # B1: RGB -> BGR
 
-    _bgr_detect_faces_multires._sdtd_bgr_patched = True
-    _bgr_detect_faces_multires._sdtd_original = _original_detect_faces_multires
-    _face_utils.detect_faces_multires = _bgr_detect_faces_multires
-    logger.info("apply_faceid_patches: patched detect_faces_multires to feed InsightFace BGR (B1).")
+        h, w = image.shape[:2]
+        start = min(640, max(h, w))
+        start = max(64, (start // 64) * 64)
+        sizes = [start] if start <= min_size else list(range(start, min_size - 1, -64))
+        sizes = sizes[:3]  # bound the sweep — see docstring
 
-    _apply_single_pass_face_conditioning_patch()
+        for size in sizes:
+            insightface_model.det_model.input_size = (size, size)
+            faces = insightface_model.get(image, max_num=1)
+            if faces:
+                if size != sizes[0]:
+                    logger.info(f"detect_faces_multires: InsightFace detection resolution lowered to {size}x{size}")
+                return faces
+
+        logger.info(f"detect_faces_multires: no face found after trying sizes {sizes} (image {w}x{h})")
+        return []
+
+    _restricted_detect_faces_multires._sdtd_bgr_patched = True
+    _restricted_detect_faces_multires._sdtd_original = _original_detect_faces_multires
+    _rebind_across_modules(
+        "detect_faces_multires",
+        _original_detect_faces_multires,
+        _restricted_detect_faces_multires,
+        _aliasing_modules,
+    )
+    logger.info(
+        "apply_faceid_patches: patched detect_faces_multires for BGR input (B1), max_num=1, "
+        "and a size-bounded sweep starting from the image's own resolution."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -76,7 +248,7 @@ def apply_faceid_patches() -> None:
 # for SDXL/Kolors). Not a correctness bug (S1 is latent-cost, not silent-wrong like
 # B1/B2) but it doubles InsightFace's cost on every FaceID update for no benefit.
 # ---------------------------------------------------------------------------
-def _apply_single_pass_face_conditioning_patch() -> None:
+def _apply_single_pass_face_conditioning_patch(_aliasing_modules: Iterable[Any]) -> None:
     """Monkeypatch ``prepare_face_conditioning`` to detect each face once, not twice.
 
     Replaces the vendored two-pass implementation (detect at 224 -> re-detect at the
@@ -86,13 +258,15 @@ def _apply_single_pass_face_conditioning_patch() -> None:
     ``extract_face_embeddings``, so replacing it whole is safe — no other code path
     depends on ``extract_face_embeddings``'s 224-fixed crop.
 
-    Patches **two** bindings, not one: ``ip_adapter.py`` does
+    Rebinds through every module in ``_aliasing_modules`` (see ``_rebind_across_modules``),
+    not just ``face_utils``: ``ip_adapter.py`` does
     ``from .face_utils import ... prepare_face_conditioning``, which copies the function
     object into ``ip_adapter``'s own module namespace at import time. Reassigning
     ``face_utils.prepare_face_conditioning`` alone would not reach the actual call site
     (``ip_adapter.py:206``, ``_get_faceid_embeds``) — unlike ``detect_faces_multires``,
     whose only callers are inside ``face_utils.py`` itself and resolve the name through
-    that module's own globals at call time (B1's patch doesn't need this extra step).
+    that module's own globals at call time (B1's patch doesn't strictly need this extra
+    step, but uses the same helper for consistency — see that patch's docstring).
 
     Reads ``detect_faces_multires`` off the module dynamically on every call (not a
     captured reference), so this patch composes correctly with the B1 BGR patch
@@ -101,7 +275,6 @@ def _apply_single_pass_face_conditioning_patch() -> None:
     Idempotent: safe to call more than once.
     """
     from diffusers_ipadapter.ip_adapter import face_utils as _face_utils
-    from diffusers_ipadapter.ip_adapter import ip_adapter as _ip_adapter_module
 
     if getattr(_face_utils.prepare_face_conditioning, "_sdtd_single_pass_patched", False):
         return
@@ -151,9 +324,12 @@ def _apply_single_pass_face_conditioning_patch() -> None:
 
     _single_pass_prepare_face_conditioning._sdtd_single_pass_patched = True
     _single_pass_prepare_face_conditioning._sdtd_original = _original_prepare_face_conditioning
-    _face_utils.prepare_face_conditioning = _single_pass_prepare_face_conditioning
-    # The actual call site (ip_adapter.py:206) uses its own copied-in name — see docstring.
-    _ip_adapter_module.prepare_face_conditioning = _single_pass_prepare_face_conditioning
+    _rebind_across_modules(
+        "prepare_face_conditioning",
+        _original_prepare_face_conditioning,
+        _single_pass_prepare_face_conditioning,
+        _aliasing_modules,
+    )
     logger.info(
         "apply_faceid_patches: patched prepare_face_conditioning to detect faces once per "
         "update instead of twice (S1)."
@@ -265,3 +441,93 @@ def fuse_faceid_lora(unet: torch.nn.Module, ckpt_path: str, lora_scale: float = 
         f"fuse_faceid_lora: fused FaceID LoRA into {fused_layers} attention modules (lora_scale={lora_scale})."
     )
     return fused_layers
+
+
+# ---------------------------------------------------------------------------
+# Cost reduction — even after S1 (single detection pass, restricted model set), the
+# *first* "update image" press in a fresh process still measures ~1.7s (vs ~25ms on the
+# second and later presses; see docs/plans/FaceID_PLAN.md's Stage 1 measurement table).
+# Two lazy one-time costs land on that first press instead of on install:
+#   1. ``insightface.utils.face_align`` is imported lazily inside
+#      ``_single_pass_prepare_face_conditioning`` (see below), and its own module-level
+#      import (``from skimage import transform as trans``) pulls in a cold skimage import
+#      — commonly 0.5-1.5s on Windows.
+#   2. ONNX Runtime compiles/selects kernels and allocates its CUDA arena lazily on each
+#      session's *first* ``session.run()`` call, per input shape — paid once for the
+#      detection model and once for the recognition model.
+# Both are one-time-per-process, so warming them during ``install()`` (while TD is
+# already blocked building TensorRT engines) moves the cost off the user-visible render
+# thread entirely instead of just amortizing it.
+# ---------------------------------------------------------------------------
+def warmup_faceid(ipadapter: Any) -> None:
+    """Pay the FaceID cold-start cost (skimage import + ONNX Runtime session warmup)
+    during install instead of on the first "update image" press.
+
+    Takes the ``IPAdapter`` instance itself (not its already-loaded pieces) so callers
+    don't need to know which attributes matter — mirrors how ``fuse_faceid_lora`` above
+    takes the source objects it needs rather than pre-extracted values.
+
+    Each of the four steps is independently timed and guarded: a failure in one (e.g. an
+    InsightFace/skimage version that doesn't expose ``arcface_dst``) logs a warning and
+    lets the remaining steps still run, rather than aborting the whole warmup. Every step
+    is best-effort perf work — a cold first press is a latency regression, not a
+    correctness failure, so nothing here may raise into ``install()``.
+    """
+    import time
+
+    insightface_model = getattr(ipadapter, "insightface_model", None)
+    if insightface_model is None:
+        return
+
+    _t_total = time.perf_counter()
+
+    face_align = None
+    try:
+        _t0 = time.perf_counter()
+        from insightface.utils import face_align as _face_align
+
+        face_align = _face_align
+        logger.info(
+            f"warmup_faceid: imported insightface.utils.face_align in {(time.perf_counter() - _t0) * 1000:.1f}ms"
+        )
+    except Exception as e:
+        logger.warning(f"warmup_faceid: face_align import failed: {e}")
+
+    if face_align is not None:
+        try:
+            _t0 = time.perf_counter()
+            from diffusers_ipadapter.ip_adapter import face_utils as _face_utils
+
+            crop_size = _face_utils.get_face_crop_size(getattr(ipadapter, "is_sdxl", False), False)
+            dummy_crop_src = np.zeros((256, 256, 3), dtype=np.uint8)
+            face_align.norm_crop(dummy_crop_src, landmark=face_align.arcface_dst, image_size=crop_size)
+            logger.info(
+                f"warmup_faceid: warmed norm_crop (size={crop_size}) in {(time.perf_counter() - _t0) * 1000:.1f}ms"
+            )
+        except Exception as e:
+            logger.warning(f"warmup_faceid: norm_crop warmup failed: {e}")
+
+    det_model = getattr(insightface_model, "det_model", None)
+    if det_model is not None:
+        try:
+            _t0 = time.perf_counter()
+            dummy_frame = np.zeros((512, 512, 3), dtype=np.uint8)
+            det_model.input_size = (512, 512)
+            insightface_model.get(dummy_frame, max_num=1)
+            logger.info(f"warmup_faceid: warmed detection session in {(time.perf_counter() - _t0) * 1000:.1f}ms")
+        except Exception as e:
+            logger.warning(f"warmup_faceid: detection session warmup failed: {e}")
+
+    recognition_model = (
+        getattr(insightface_model, "models", {}).get("recognition") if hasattr(insightface_model, "models") else None
+    )
+    if recognition_model is not None:
+        try:
+            _t0 = time.perf_counter()
+            dummy_face = np.zeros((112, 112, 3), dtype=np.uint8)
+            recognition_model.get_feat(dummy_face)
+            logger.info(f"warmup_faceid: warmed recognition session in {(time.perf_counter() - _t0) * 1000:.1f}ms")
+        except Exception as e:
+            logger.warning(f"warmup_faceid: recognition session warmup failed: {e}")
+
+    logger.info(f"warmup_faceid: total warmup {(time.perf_counter() - _t_total) * 1000:.1f}ms")

--- a/src/streamdiffusion/modules/ipadapter_module.py
+++ b/src/streamdiffusion/modules/ipadapter_module.py
@@ -425,6 +425,18 @@ class IPAdapterModule(OrchestratorUser):
             except Exception as e:
                 report_error(f"IPAdapterModule.install: Failed to initialize FaceIDEmbeddingPreprocessor: {e}")
                 raise
+
+            # Pay the InsightFace cold-start cost (skimage import + first ONNX Runtime
+            # session.run() for detection/recognition) here, while TD is already blocked
+            # building TensorRT engines, instead of on the user's first "update image"
+            # press — see faceid_compat.warmup_faceid's docstring for the two lazy costs
+            # this removes. Best-effort: a warmup failure only means a slower first press.
+            try:
+                from streamdiffusion.modules.faceid_compat import warmup_faceid
+
+                warmup_faceid(ipadapter)
+            except Exception as e:
+                logger.warning(f"IPAdapterModule.install: warmup_faceid failed (non-fatal): {e}")
         else:
             embedding_preprocessor = IPAdapterEmbeddingPreprocessor(
                 ipadapter=ipadapter,

--- a/src/streamdiffusion/modules/ipadapter_module.py
+++ b/src/streamdiffusion/modules/ipadapter_module.py
@@ -203,10 +203,16 @@ class IPAdapterModule(OrchestratorUser):
         self.ipadapter: Optional[Any] = None
 
     def build_embedding_hook(self, stream) -> EmbeddingHook:
-        style_key = self.config.style_image_key or "default"
+        # S4: must match install()'s default (below) — a mismatch here would silently
+        # miss the cache under the key install() actually populated, hitting the
+        # zero-fill path below on every frame. Latent today only because both wrapper
+        # call sites (wrapper.py:2263, :2864) pin style_image_key explicitly.
+        style_key = self.config.style_image_key or "ipadapter_main"
         num_tokens = int(self.config.num_image_tokens)
+        warned_zero_fill = False
 
         def _embedding_hook(ctx: EmbedsCtx) -> EmbedsCtx:
+            nonlocal warned_zero_fill
             # Fetch cached image token embeddings (prompt, negative)
             cached: Optional[Tuple[torch.Tensor, torch.Tensor]] = stream._param_updater.get_cached_embeddings(
                 style_key
@@ -220,6 +226,18 @@ class IPAdapterModule(OrchestratorUser):
             hidden_dim = ctx.prompt_embeds.shape[2]
             batch_size = ctx.prompt_embeds.shape[0]
             if image_prompt_tokens is None:
+                # S4: silent zero-fill is the same failure class as B1/B2 — it disables
+                # image conditioning without ever raising or failing a shape check.
+                # Warn once per hook instance so a real-time streaming loop doesn't
+                # spam this every frame.
+                if not warned_zero_fill:
+                    logger.warning(
+                        "IPAdapterModule: no cached image-token embeddings for "
+                        f"style_image_key='{style_key}' — falling back to zero-filled "
+                        "tokens (image conditioning is a no-op until a style image is "
+                        "processed for this key). Logged once per hook instance."
+                    )
+                    warned_zero_fill = True
                 image_prompt_tokens = torch.zeros(
                     (batch_size, num_tokens, hidden_dim),
                     dtype=ctx.prompt_embeds.dtype,

--- a/src/streamdiffusion/modules/ipadapter_module.py
+++ b/src/streamdiffusion/modules/ipadapter_module.py
@@ -41,6 +41,47 @@ class IPAdapterConfig:
     type: IPAdapterType = IPAdapterType.REGULAR
     insightface_model_name: Optional[str] = None
 
+    @classmethod
+    def from_dict(cls, cfg: Dict[str, Any]) -> IPAdapterConfig:
+        """Build an IPAdapterConfig from a raw config dict (the ``ipadapter_config``
+        shape passed through ``wrapper.py``).
+
+        A4: both wrapper.py install sites (pre-TRT and post-TRT) previously built this
+        by hand with identical inline field lists — centralized here. Not used by
+        ``StreamParameterUpdater._get_current_ipadapter_config``: that dict is
+        deliberately lossy/demo-only (``demo/realtime-img2img``) and must not gain new
+        required-field validation.
+
+        Raises:
+            KeyError: if ``ipadapter_model_path`` or ``image_encoder_path`` is missing.
+            ValueError: if ``type == "faceid"`` and ``insightface_model_name`` is not
+                set. Without it, ``IPAdapter.insightface_model`` silently stays ``None``
+                and the failure only surfaces later, mid-stream, when the first style
+                image update raises inside ``_get_faceid_embeds`` — the same silent/late
+                failure class as B1/B2. Rejecting it here, at construction time, makes
+                the misconfiguration loud immediately.
+        """
+        adapter_type = IPAdapterType(cfg.get("type", "regular"))
+        insightface_model_name = cfg.get("insightface_model_name")
+
+        if adapter_type == IPAdapterType.FACEID and not insightface_model_name:
+            raise ValueError(
+                "IPAdapterConfig.from_dict: type='faceid' requires 'insightface_model_name' "
+                "to be set (e.g. 'buffalo_l') — without it, FaceID processing fails only "
+                "once a style image is actually submitted, mid-stream."
+            )
+
+        return cls(
+            style_image_key=cfg.get("style_image_key") or "ipadapter_main",
+            num_image_tokens=cfg.get("num_image_tokens", 4),
+            ipadapter_model_path=cfg["ipadapter_model_path"],
+            image_encoder_path=cfg["image_encoder_path"],
+            style_image=cfg.get("style_image"),
+            scale=cfg.get("scale", 1.0),
+            type=adapter_type,
+            insightface_model_name=insightface_model_name,
+        )
+
 
 # ---------------------------------------------------------------------------
 # IP-Adapter model path mapping by base model architecture and adapter type
@@ -459,8 +500,16 @@ class IPAdapterModule(OrchestratorUser):
             local_path = hf_hub_download(repo_id=repo_id, filename=subpath)
             return local_path
         else:
-            # Directory download
-            repo_root = snapshot_download(repo_id=repo_id, allow_patterns=[f"{subpath}/*"])
+            # Directory download.
+            # A6: HF image_encoder repos ship both model.safetensors and
+            # pytorch_model.bin (~3.69 GB each) for the same weights — transformers
+            # loads safetensors automatically when present, so the .bin (and other
+            # legacy formats) are pure dead weight on every fresh download.
+            repo_root = snapshot_download(
+                repo_id=repo_id,
+                allow_patterns=[f"{subpath}/*"],
+                ignore_patterns=["*.bin", "*.msgpack", "*.h5"],
+            )
             full_path = os.path.join(repo_root, subpath)
             if not os.path.exists(full_path):
                 raise FileNotFoundError(f"IPAdapterModule._resolve_model_path: Downloaded path not found: {full_path}")

--- a/src/streamdiffusion/modules/ipadapter_module.py
+++ b/src/streamdiffusion/modules/ipadapter_module.py
@@ -302,11 +302,22 @@ class IPAdapterModule(OrchestratorUser):
             "device": stream.device,
             "dtype": stream.dtype,
         }
-        if self.config.type == IPAdapterType.FACEID and self.config.insightface_model_name:
-            ip_kwargs["insightface_model_name"] = self.config.insightface_model_name
-            print(
-                f"IPAdapterModule.install: Initializing FaceID IP-Adapter with InsightFace model: {self.config.insightface_model_name}"
-            )
+        if self.config.type == IPAdapterType.FACEID:
+            # B1: diffusers_ipadapter feeds InsightFace RGB, but every InsightFace ONNX
+            # model expects BGR (swapRB=True internally) — patch the single choke point
+            # (detect_faces_multires) before any detection can run.
+            try:
+                from streamdiffusion.modules.faceid_compat import apply_faceid_patches
+
+                apply_faceid_patches()
+            except Exception as e:
+                logger.warning(f"IPAdapterModule.install: apply_faceid_patches (B1) failed: {e}")
+
+            if self.config.insightface_model_name:
+                ip_kwargs["insightface_model_name"] = self.config.insightface_model_name
+                print(
+                    f"IPAdapterModule.install: Initializing FaceID IP-Adapter with InsightFace model: {self.config.insightface_model_name}"
+                )
         ipadapter = IPAdapter(**ip_kwargs)
         self.ipadapter = ipadapter
 

--- a/src/streamdiffusion/modules/ipadapter_module.py
+++ b/src/streamdiffusion/modules/ipadapter_module.py
@@ -321,6 +321,21 @@ class IPAdapterModule(OrchestratorUser):
         ipadapter = IPAdapter(**ip_kwargs)
         self.ipadapter = ipadapter
 
+        # B2: the FaceID checkpoint's rank-128 LoRA is silently discarded by the vendored
+        # strict load (it filters "lora"/"LoRA" keys — no LoRA-aware processor exists) and
+        # would be lost again by the TensorRT export path even if it did load. Fuse it
+        # directly into the UNet's attention linears instead, where no processor rebuild
+        # can touch it. B3 (engine cache-key marker) MUST accompany this — see
+        # engine_manager.py's EngineType.UNET branch.
+        if self.config.type == IPAdapterType.FACEID:
+            try:
+                from streamdiffusion.modules.faceid_compat import fuse_faceid_lora
+
+                fuse_faceid_lora(stream.pipe.unet, resolved_ip_path, lora_scale=1.0)
+            except Exception as e:
+                report_error(f"IPAdapterModule.install: fuse_faceid_lora (B2) failed: {e}")
+                raise
+
         # Fix kvo_cache incompatibility: diffusers_ipadapter sets old AttnProcessor on
         # self-attention blocks (attn1) that doesn't accept the kvo_cache kwarg passed by
         # newer diffusers Attention.forward(). Replace them with diffusers' native

--- a/src/streamdiffusion/preprocessing/processors/faceid_embedding.py
+++ b/src/streamdiffusion/preprocessing/processors/faceid_embedding.py
@@ -24,7 +24,12 @@ class FaceIDEmbeddingPreprocessor(IPAdapterEmbeddingPreprocessor):
                 "faceid_v2_weight": {
                     "type": "float",
                     "default": 1.0,
-                    "description": "Weight for FaceID v2 models (higher values = stronger identity preservation)",
+                    "description": (
+                        "Weight for FaceID-Plus/v2 models only (passed through to "
+                        "diffusers_ipadapter's is_plus LoRA-scale/shortcut branch). Has "
+                        "no effect on plain (non-Plus) FaceID — the value is accepted "
+                        "but never read outside that branch."
+                    ),
                 }
             },
             "use_cases": [
@@ -76,7 +81,3 @@ class FaceIDEmbeddingPreprocessor(IPAdapterEmbeddingPreprocessor):
             msg = f"FaceIDEmbeddingPreprocessor: Failed to extract face embeddings: {e}"
             report_error(msg)
             raise RuntimeError(msg) from e
-
-    def update_faceid_v2_weight(self, weight: float) -> None:
-        self.faceid_v2_weight = float(weight)
-        print(f"FaceIDEmbeddingPreprocessor.update_faceid_v2_weight: Updated weight to {self.faceid_v2_weight}")

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -2248,7 +2248,6 @@ class StreamDiffusionWrapper:
                             from streamdiffusion.modules.ipadapter_module import (
                                 IPAdapterConfig,
                                 IPAdapterModule,
-                                IPAdapterType,
                             )
 
                             logger.info("Installing IPAdapter module before TensorRT compilation...")
@@ -2259,16 +2258,7 @@ class StreamDiffusionWrapper:
 
                             # Use first config if list provided
                             cfg = ipadapter_config[0] if isinstance(ipadapter_config, list) else ipadapter_config
-                            ip_cfg = IPAdapterConfig(
-                                style_image_key=cfg.get("style_image_key") or "ipadapter_main",
-                                num_image_tokens=cfg.get("num_image_tokens", 4),
-                                ipadapter_model_path=cfg["ipadapter_model_path"],
-                                image_encoder_path=cfg["image_encoder_path"],
-                                style_image=cfg.get("style_image"),
-                                scale=cfg.get("scale", 1.0),
-                                type=IPAdapterType(cfg.get("type", "regular")),
-                                insightface_model_name=cfg.get("insightface_model_name"),
-                            )
+                            ip_cfg = IPAdapterConfig.from_dict(cfg)
                             ip_module = IPAdapterModule(ip_cfg)
                             ip_module.install(stream)
                             # Expose for later updates
@@ -2852,24 +2842,12 @@ class StreamDiffusionWrapper:
             and hasattr(stream.unet, "attn_processors")
         ):
             try:
-                from streamdiffusion.modules.ipadapter_module import IPAdapterConfig, IPAdapterModule, IPAdapterType
+                from streamdiffusion.modules.ipadapter_module import IPAdapterConfig, IPAdapterModule
 
                 # Use first config if list provided
                 cfg = ipadapter_config[0] if isinstance(ipadapter_config, list) else ipadapter_config
 
-                # Get adapter type from config
-                ipadapter_type = IPAdapterType(cfg["type"])
-
-                ip_cfg = IPAdapterConfig(
-                    style_image_key=cfg.get("style_image_key") or "ipadapter_main",
-                    num_image_tokens=cfg.get("num_image_tokens", 4),
-                    ipadapter_model_path=cfg["ipadapter_model_path"],
-                    image_encoder_path=cfg["image_encoder_path"],
-                    style_image=cfg.get("style_image"),
-                    scale=cfg.get("scale", 1.0),
-                    type=ipadapter_type,
-                    insightface_model_name=cfg.get("insightface_model_name"),
-                )
+                ip_cfg = IPAdapterConfig.from_dict(cfg)
                 ip_module = IPAdapterModule(ip_cfg)
                 _saved_unet_processors_post = dict(stream.unet.attn_processors)
                 ip_module.install(stream)

--- a/tests/unit/test_faceid_bgr_patch.py
+++ b/tests/unit/test_faceid_bgr_patch.py
@@ -1,0 +1,197 @@
+"""
+Regression test for B1 — feeding InsightFace BGR instead of RGB
+(``streamdiffusion.modules.faceid_compat.apply_faceid_patches``), plus S1 — collapsing the
+two-detection-pass ``prepare_face_conditioning`` into one.
+
+Every InsightFace ONNX model (arcface_onnx.py, retinaface.py, scrfd.py) preprocesses with
+``swapRB=True`` — i.e. it contractually expects BGR. The vendored ``face_utils.py`` hands it a
+plain RGB numpy array (``np.array(PIL_image)``), so ArcFace computes the 512-d identity
+embedding from a channel-swapped face — no error, just a corrupted vector. B1's patch wraps
+``detect_faces_multires`` to reverse the channel axis before the array reaches the real
+detector.
+
+This test fakes out ``diffusers_ipadapter`` entirely (it is a pip-installed, pinned-SHA vendor
+package — not something to import for real in a unit test) with a minimal stand-in module tree
+that has the same shape as the two functions ``apply_faceid_patches`` touches, so the patch
+logic itself is exercised without any InsightFace/torch/PIL dependency beyond what the patch
+code already imports at module scope.
+
+Run with: pytest tests/unit/test_faceid_bgr_patch.py -v
+"""
+
+import sys
+import types
+
+import numpy as np
+import pytest
+
+
+def _install_fake_diffusers_ipadapter():
+    """Build a minimal fake ``diffusers_ipadapter.ip_adapter.{face_utils,ip_adapter}`` module
+    pair and register it in sys.modules, so ``faceid_compat`` can ``import`` it normally.
+
+    Mirrors the real shape just enough for the patch under test:
+    - ``face_utils.detect_faces_multires(insightface_model, image)`` — records the array it
+      was called with and returns a canned "faces" list.
+    - ``face_utils.prepare_face_conditioning`` — a two-pass stub matching the vendored
+      original's signature (so the S1 replacement's call signature is exercised too).
+    - ``ip_adapter.py``'s ``from .face_utils import ... prepare_face_conditioning`` is modeled
+      by copying the *same function object* into the fake ``ip_adapter`` module's namespace —
+      this is the exact aliasing behaviour the S1 patch has to defeat.
+    """
+    calls = {"detect": [], "prepare_two_pass": 0}
+
+    pkg = types.ModuleType("diffusers_ipadapter")
+    subpkg = types.ModuleType("diffusers_ipadapter.ip_adapter")
+    face_utils = types.ModuleType("diffusers_ipadapter.ip_adapter.face_utils")
+    ip_adapter_mod = types.ModuleType("diffusers_ipadapter.ip_adapter.ip_adapter")
+
+    class _FakeFace:
+        def __init__(self):
+            self.normed_embedding = np.zeros(512, dtype=np.float32)
+            self.embedding = np.zeros(512, dtype=np.float32)
+            self.kps = np.zeros((5, 2), dtype=np.float32)
+
+    def detect_faces_multires(insightface_model, image, *args, **kwargs):
+        calls["detect"].append(np.array(image, copy=True))
+        return [_FakeFace()]
+
+    def get_face_crop_size(is_sdxl=False, is_kolors=False):
+        if is_kolors:
+            return 336
+        if is_sdxl:
+            return 256
+        return 224
+
+    def prepare_face_conditioning(
+        insightface_model, images, is_sdxl=False, is_kolors=False, normalize_embeddings=True
+    ):
+        """Stand-in for the vendored *original* two-pass implementation: detects once inside
+        an 'extract_face_embeddings'-style helper, then a second time to re-crop at the real
+        model size. Only used to prove the S1 replacement stops calling this shape twice —
+        the replacement doesn't call this function at all, it calls detect_faces_multires
+        directly, so this counter would stay at 0 once patched.
+        """
+        calls["prepare_two_pass"] += 1
+        detect_faces_multires(insightface_model, images)
+        detect_faces_multires(insightface_model, images)
+        return None, None
+
+    face_utils.detect_faces_multires = detect_faces_multires
+    face_utils.get_face_crop_size = get_face_crop_size
+    face_utils.prepare_face_conditioning = prepare_face_conditioning
+
+    # Mirrors `from .face_utils import get_insightface_model, prepare_face_conditioning` in
+    # the real ip_adapter.py: copies the function *object* into this module's own namespace.
+    ip_adapter_mod.prepare_face_conditioning = face_utils.prepare_face_conditioning
+
+    sys.modules["diffusers_ipadapter"] = pkg
+    sys.modules["diffusers_ipadapter.ip_adapter"] = subpkg
+    sys.modules["diffusers_ipadapter.ip_adapter.face_utils"] = face_utils
+    sys.modules["diffusers_ipadapter.ip_adapter.ip_adapter"] = ip_adapter_mod
+
+    return face_utils, ip_adapter_mod, calls
+
+
+@pytest.fixture
+def fake_vendor(monkeypatch):
+    """Install the fake vendor modules for the duration of one test and always clean up
+    sys.modules afterward, plus reload faceid_compat so each test gets fresh patch state
+    (apply_faceid_patches is idempotent-guarded on the *patched function*, which is a fresh
+    object every time the fake module is rebuilt).
+    """
+    for name in (
+        "diffusers_ipadapter",
+        "diffusers_ipadapter.ip_adapter",
+        "diffusers_ipadapter.ip_adapter.face_utils",
+        "diffusers_ipadapter.ip_adapter.ip_adapter",
+    ):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    face_utils, ip_adapter_mod, calls = _install_fake_diffusers_ipadapter()
+    yield face_utils, ip_adapter_mod, calls
+
+
+class TestBgrPatch:
+    def test_reverses_channel_axis_before_detection(self, fake_vendor):
+        face_utils, _ip_adapter_mod, calls = fake_vendor
+        from streamdiffusion.modules import faceid_compat
+
+        faceid_compat.apply_faceid_patches()
+
+        rgb_image = np.zeros((8, 8, 3), dtype=np.uint8)
+        rgb_image[..., 0] = 10  # R
+        rgb_image[..., 1] = 20  # G
+        rgb_image[..., 2] = 30  # B
+
+        face_utils.detect_faces_multires(None, rgb_image)
+
+        assert len(calls["detect"]) == 1
+        received = calls["detect"][0]
+        assert received[0, 0, 0] == 30  # was B, now first channel
+        assert received[0, 0, 1] == 20  # G unchanged (middle channel)
+        assert received[0, 0, 2] == 10  # was R, now last channel
+
+    def test_leaves_non_hwc3_arrays_untouched(self, fake_vendor):
+        """Only ndim==3 and shape[-1]==3 arrays are channel-swapped — anything else (e.g. a
+        grayscale or already-preprocessed array) must pass through unmodified rather than
+        raising or silently mis-slicing.
+        """
+        face_utils, _ip_adapter_mod, calls = fake_vendor
+        from streamdiffusion.modules import faceid_compat
+
+        faceid_compat.apply_faceid_patches()
+
+        grayscale = np.full((8, 8), 42, dtype=np.uint8)
+        face_utils.detect_faces_multires(None, grayscale)
+
+        assert np.array_equal(calls["detect"][0], grayscale)
+
+    def test_patch_is_idempotent(self, fake_vendor):
+        face_utils, _ip_adapter_mod, calls = fake_vendor
+        from streamdiffusion.modules import faceid_compat
+
+        faceid_compat.apply_faceid_patches()
+        once_patched = face_utils.detect_faces_multires
+        faceid_compat.apply_faceid_patches()
+        twice_patched = face_utils.detect_faces_multires
+
+        assert once_patched is twice_patched
+
+        image = np.zeros((4, 4, 3), dtype=np.uint8)
+        face_utils.detect_faces_multires(None, image)
+        assert len(calls["detect"]) == 1  # not wrapped twice -> not swapped twice either
+
+    def test_single_pass_patch_detects_once_per_image_on_both_bindings(self, fake_vendor):
+        """S1: after apply_faceid_patches, both face_utils.prepare_face_conditioning and
+        ip_adapter.prepare_face_conditioning (the separately-imported binding real
+        ip_adapter.py's _get_faceid_embeds actually calls) must resolve to the same
+        single-detection-pass replacement.
+        """
+        face_utils, ip_adapter_mod, calls = fake_vendor
+        from PIL import Image
+
+        from streamdiffusion.modules import faceid_compat
+
+        faceid_compat.apply_faceid_patches()
+
+        assert face_utils.prepare_face_conditioning is ip_adapter_mod.prepare_face_conditioning
+
+        image = Image.new("RGB", (8, 8))
+        face_utils.prepare_face_conditioning(None, image, is_sdxl=True)
+
+        assert calls["prepare_two_pass"] == 0  # replacement never calls the two-pass original
+        assert len(calls["detect"]) == 1  # exactly one detection for one image
+
+    def test_single_pass_patch_uses_correct_crop_size(self, fake_vendor):
+        face_utils, ip_adapter_mod, _calls = fake_vendor
+        from PIL import Image
+
+        from streamdiffusion.modules import faceid_compat
+
+        faceid_compat.apply_faceid_patches()
+
+        image = Image.new("RGB", (16, 16))
+        _embeds, cropped = ip_adapter_mod.prepare_face_conditioning(None, image, is_sdxl=True)
+
+        assert cropped[0].size == (256, 256)

--- a/tests/unit/test_faceid_bgr_patch.py
+++ b/tests/unit/test_faceid_bgr_patch.py
@@ -1,20 +1,30 @@
 """
 Regression test for B1 — feeding InsightFace BGR instead of RGB
-(``streamdiffusion.modules.faceid_compat.apply_faceid_patches``), plus S1 — collapsing the
-two-detection-pass ``prepare_face_conditioning`` into one.
+(``streamdiffusion.modules.faceid_compat.apply_faceid_patches``), S1 — collapsing the
+two-detection-pass ``prepare_face_conditioning`` into one, and the cost-reduction patches
+(``_apply_insightface_loader_patch`` / ``_apply_detect_faces_multires_patch``) that cut the
+InsightFace work done per "update image" press.
 
 Every InsightFace ONNX model (arcface_onnx.py, retinaface.py, scrfd.py) preprocesses with
 ``swapRB=True`` — i.e. it contractually expects BGR. The vendored ``face_utils.py`` hands it a
 plain RGB numpy array (``np.array(PIL_image)``), so ArcFace computes the 512-d identity
-embedding from a channel-swapped face — no error, just a corrupted vector. B1's patch wraps
-``detect_faces_multires`` to reverse the channel axis before the array reaches the real
-detector.
+embedding from a channel-swapped face — no error, just a corrupted vector.
+
+``detect_faces_multires`` is *replaced*, not wrapped: the patch reimplements the
+resolution-sweep loop itself (BGR swap, ``max_num=1``, a sweep sized to the image and bounded
+to 3 attempts) rather than delegating to the vendored implementation, because the vendored
+loop offers no way to inject ``max_num`` or change its fixed 640-start / 7-attempt sweep from
+outside. That means the fake harness below models ``insightface_model`` as an object with
+``det_model.input_size`` and ``get(img, max_num)`` — the surface the replacement actually
+calls — rather than modeling ``detect_faces_multires`` itself as the thing under patch.
 
 This test fakes out ``diffusers_ipadapter`` entirely (it is a pip-installed, pinned-SHA vendor
 package — not something to import for real in a unit test) with a minimal stand-in module tree
-that has the same shape as the two functions ``apply_faceid_patches`` touches, so the patch
-logic itself is exercised without any InsightFace/torch/PIL dependency beyond what the patch
-code already imports at module scope.
+that has the same shape as the functions ``apply_faceid_patches`` touches, so the patch logic
+itself is exercised without any InsightFace/torch/PIL dependency beyond what the patch code
+already imports at module scope. The one exception is ``insightface.app.FaceAnalysis``, which
+the loader patch monkeypatches for real (see ``TestInsightfaceLoaderPatch``) — that is the
+actual real package, exercised the same way production code exercises it.
 
 Run with: pytest tests/unit/test_faceid_bgr_patch.py -v
 """
@@ -26,35 +36,76 @@ import numpy as np
 import pytest
 
 
+class _FakeFace:
+    def __init__(self):
+        self.normed_embedding = np.zeros(512, dtype=np.float32)
+        self.embedding = np.zeros(512, dtype=np.float32)
+        self.kps = np.zeros((5, 2), dtype=np.float32)
+
+
+class _FakeDetModel:
+    def __init__(self):
+        self.input_size = None
+
+
+class _FakeInsightFaceModel:
+    """Stands in for a real InsightFace ``FaceAnalysis`` instance — only the surface the
+    ``detect_faces_multires`` replacement actually touches: ``det_model.input_size``
+    (settable, mirrors the sweep's resolution) and ``get(img, max_num)``.
+
+    ``succeed_at_size`` lets a test control which sweep attempt first returns a face, to
+    exercise the fallback-to-smaller-size path. ``always_faces=False`` simulates a frame with
+    no detectable face at any size, to exercise the bounded-sweep-exhausted path.
+    """
+
+    def __init__(self, calls, always_faces=True, succeed_at_size=None):
+        self.det_model = _FakeDetModel()
+        self._calls = calls
+        self._always_faces = always_faces
+        self._succeed_at_size = succeed_at_size
+
+    def get(self, img, max_num=0):
+        size = self.det_model.input_size
+        self._calls["get"].append({"image": np.array(img, copy=True), "max_num": max_num, "size": size})
+        if self._succeed_at_size is not None:
+            return [_FakeFace()] if size == self._succeed_at_size else []
+        return [_FakeFace()] if self._always_faces else []
+
+
 def _install_fake_diffusers_ipadapter():
     """Build a minimal fake ``diffusers_ipadapter.ip_adapter.{face_utils,ip_adapter}`` module
     pair and register it in sys.modules, so ``faceid_compat`` can ``import`` it normally.
 
-    Mirrors the real shape just enough for the patch under test:
-    - ``face_utils.detect_faces_multires(insightface_model, image)`` — records the array it
-      was called with and returns a canned "faces" list.
+    Mirrors the real shape just enough for the patches under test:
+    - ``face_utils.detect_faces_multires(insightface_model, image)`` — a stand-in for the
+      *un-patched vendored* implementation. Only ``prepare_face_conditioning``'s internal
+      closure-captured call to it (below) still exercises this; the real patch under test
+      never calls it, since it replaces the vendored sweep outright rather than wrapping it.
     - ``face_utils.prepare_face_conditioning`` — a two-pass stub matching the vendored
       original's signature (so the S1 replacement's call signature is exercised too).
-    - ``ip_adapter.py``'s ``from .face_utils import ... prepare_face_conditioning`` is modeled
-      by copying the *same function object* into the fake ``ip_adapter`` module's namespace —
-      this is the exact aliasing behaviour the S1 patch has to defeat.
+    - ``face_utils.get_insightface_model`` — returns a fresh ``_FakeInsightFaceModel``.
+
+    Both aliasing sites the real vendor package has for these names are modeled too, so a
+    patch that only reaches ``face_utils`` fails a test here exactly as it fails in
+    production:
+    - ``ip_adapter.py``'s ``from .face_utils import get_insightface_model,
+      prepare_face_conditioning`` — copies both function *objects* into the fake
+      ``ip_adapter`` module's own namespace. (A prior version of this harness copied only
+      ``prepare_face_conditioning``, which is why the loader patch's missing second
+      binding shipped without a failing test — see ``TestInsightfaceLoaderPatch``.)
+    - ``diffusers_ipadapter/ip_adapter/__init__.py``'s ``from .face_utils import *`` —
+      copies every fake public name into the package module (``sys.modules
+      ["diffusers_ipadapter.ip_adapter"]``, i.e. ``subpkg`` below) as well.
     """
-    calls = {"detect": [], "prepare_two_pass": 0}
+    calls = {"get": [], "prepare_two_pass": 0, "get_insightface_model": []}
 
     pkg = types.ModuleType("diffusers_ipadapter")
     subpkg = types.ModuleType("diffusers_ipadapter.ip_adapter")
     face_utils = types.ModuleType("diffusers_ipadapter.ip_adapter.face_utils")
     ip_adapter_mod = types.ModuleType("diffusers_ipadapter.ip_adapter.ip_adapter")
 
-    class _FakeFace:
-        def __init__(self):
-            self.normed_embedding = np.zeros(512, dtype=np.float32)
-            self.embedding = np.zeros(512, dtype=np.float32)
-            self.kps = np.zeros((5, 2), dtype=np.float32)
-
     def detect_faces_multires(insightface_model, image, *args, **kwargs):
-        calls["detect"].append(np.array(image, copy=True))
-        return [_FakeFace()]
+        return insightface_model.get(image)
 
     def get_face_crop_size(is_sdxl=False, is_kolors=False):
         if is_kolors:
@@ -77,13 +128,26 @@ def _install_fake_diffusers_ipadapter():
         detect_faces_multires(insightface_model, images)
         return None, None
 
+    def get_insightface_model(model_name="buffalo_l", providers=None):
+        calls["get_insightface_model"].append({"model_name": model_name, "providers": providers})
+        return _FakeInsightFaceModel(calls)
+
     face_utils.detect_faces_multires = detect_faces_multires
     face_utils.get_face_crop_size = get_face_crop_size
     face_utils.prepare_face_conditioning = prepare_face_conditioning
+    face_utils.get_insightface_model = get_insightface_model
 
     # Mirrors `from .face_utils import get_insightface_model, prepare_face_conditioning` in
-    # the real ip_adapter.py: copies the function *object* into this module's own namespace.
+    # the real ip_adapter.py: copies both function *objects* into this module's own namespace.
+    ip_adapter_mod.get_insightface_model = face_utils.get_insightface_model
     ip_adapter_mod.prepare_face_conditioning = face_utils.prepare_face_conditioning
+
+    # Mirrors the real package __init__'s `from .face_utils import *`: every fake public
+    # face_utils name gets its own copy in the package module too.
+    subpkg.detect_faces_multires = face_utils.detect_faces_multires
+    subpkg.get_face_crop_size = face_utils.get_face_crop_size
+    subpkg.prepare_face_conditioning = face_utils.prepare_face_conditioning
+    subpkg.get_insightface_model = face_utils.get_insightface_model
 
     sys.modules["diffusers_ipadapter"] = pkg
     sys.modules["diffusers_ipadapter.ip_adapter"] = subpkg
@@ -112,6 +176,10 @@ def fake_vendor(monkeypatch):
     yield face_utils, ip_adapter_mod, calls
 
 
+def _make_model(calls, **kwargs):
+    return _FakeInsightFaceModel(calls, **kwargs)
+
+
 class TestBgrPatch:
     def test_reverses_channel_axis_before_detection(self, fake_vendor):
         face_utils, _ip_adapter_mod, calls = fake_vendor
@@ -124,10 +192,11 @@ class TestBgrPatch:
         rgb_image[..., 1] = 20  # G
         rgb_image[..., 2] = 30  # B
 
-        face_utils.detect_faces_multires(None, rgb_image)
+        model = _make_model(calls)
+        face_utils.detect_faces_multires(model, rgb_image)
 
-        assert len(calls["detect"]) == 1
-        received = calls["detect"][0]
+        assert len(calls["get"]) == 1
+        received = calls["get"][0]["image"]
         assert received[0, 0, 0] == 30  # was B, now first channel
         assert received[0, 0, 1] == 20  # G unchanged (middle channel)
         assert received[0, 0, 2] == 10  # was R, now last channel
@@ -143,9 +212,10 @@ class TestBgrPatch:
         faceid_compat.apply_faceid_patches()
 
         grayscale = np.full((8, 8), 42, dtype=np.uint8)
-        face_utils.detect_faces_multires(None, grayscale)
+        model = _make_model(calls)
+        face_utils.detect_faces_multires(model, grayscale)
 
-        assert np.array_equal(calls["detect"][0], grayscale)
+        assert np.array_equal(calls["get"][0]["image"], grayscale)
 
     def test_patch_is_idempotent(self, fake_vendor):
         face_utils, _ip_adapter_mod, calls = fake_vendor
@@ -158,9 +228,10 @@ class TestBgrPatch:
 
         assert once_patched is twice_patched
 
+        model = _make_model(calls)
         image = np.zeros((4, 4, 3), dtype=np.uint8)
-        face_utils.detect_faces_multires(None, image)
-        assert len(calls["detect"]) == 1  # not wrapped twice -> not swapped twice either
+        face_utils.detect_faces_multires(model, image)
+        assert len(calls["get"]) == 1  # not wrapped twice -> not swapped twice either
 
     def test_single_pass_patch_detects_once_per_image_on_both_bindings(self, fake_vendor):
         """S1: after apply_faceid_patches, both face_utils.prepare_face_conditioning and
@@ -177,21 +248,287 @@ class TestBgrPatch:
 
         assert face_utils.prepare_face_conditioning is ip_adapter_mod.prepare_face_conditioning
 
+        model = _make_model(calls)
         image = Image.new("RGB", (8, 8))
-        face_utils.prepare_face_conditioning(None, image, is_sdxl=True)
+        face_utils.prepare_face_conditioning(model, image, is_sdxl=True)
 
         assert calls["prepare_two_pass"] == 0  # replacement never calls the two-pass original
-        assert len(calls["detect"]) == 1  # exactly one detection for one image
+        assert len(calls["get"]) == 1  # exactly one detection for one image
 
     def test_single_pass_patch_uses_correct_crop_size(self, fake_vendor):
-        face_utils, ip_adapter_mod, _calls = fake_vendor
+        face_utils, ip_adapter_mod, calls = fake_vendor
         from PIL import Image
 
         from streamdiffusion.modules import faceid_compat
 
         faceid_compat.apply_faceid_patches()
 
+        model = _make_model(calls)
         image = Image.new("RGB", (16, 16))
-        _embeds, cropped = ip_adapter_mod.prepare_face_conditioning(None, image, is_sdxl=True)
+        _embeds, cropped = ip_adapter_mod.prepare_face_conditioning(model, image, is_sdxl=True)
 
         assert cropped[0].size == (256, 256)
+
+
+class TestDetectFacesCostReduction:
+    """Coverage for the sweep-size / max_num cost cuts folded into the same replacement as B1."""
+
+    def test_uses_max_num_one_and_starts_from_image_native_size(self, fake_vendor):
+        face_utils, _ip_adapter_mod, calls = fake_vendor
+        from streamdiffusion.modules import faceid_compat
+
+        faceid_compat.apply_faceid_patches()
+
+        model = _make_model(calls)  # always finds a face
+        image = np.zeros((512, 512, 3), dtype=np.uint8)
+        faces = face_utils.detect_faces_multires(model, image)
+
+        assert len(faces) == 1
+        assert len(calls["get"]) == 1  # first attempt succeeds -> no wasted sweep
+        assert calls["get"][0]["max_num"] == 1
+        assert calls["get"][0]["size"] == (512, 512)  # native size, never upscaled to 640
+
+    def test_sweep_falls_back_to_smaller_size(self, fake_vendor):
+        face_utils, _ip_adapter_mod, calls = fake_vendor
+        from streamdiffusion.modules import faceid_compat
+
+        faceid_compat.apply_faceid_patches()
+
+        model = _make_model(calls, succeed_at_size=(384, 384))
+        image = np.zeros((512, 512, 3), dtype=np.uint8)
+        faces = face_utils.detect_faces_multires(model, image)
+
+        assert len(faces) == 1
+        sizes_tried = [c["size"] for c in calls["get"]]
+        assert sizes_tried == [(512, 512), (448, 448), (384, 384)]
+
+    def test_sweep_is_bounded_to_three_attempts(self, fake_vendor):
+        """The vendored original sweeps up to 7 sizes (640 down to 256) before giving up.
+        The replacement must not reproduce that worst case."""
+        face_utils, _ip_adapter_mod, calls = fake_vendor
+        from streamdiffusion.modules import faceid_compat
+
+        faceid_compat.apply_faceid_patches()
+
+        model = _make_model(calls, always_faces=False)  # no face at any size
+        image = np.zeros((512, 512, 3), dtype=np.uint8)
+        faces = face_utils.detect_faces_multires(model, image)
+
+        assert faces == []
+        assert len(calls["get"]) == 3
+
+
+class TestInsightfaceLoaderPatch:
+    """Coverage for _apply_insightface_loader_patch: get_insightface_model must construct
+    FaceAnalysis with allowed_modules=['detection', 'recognition'], and must restore the
+    real insightface.app.FaceAnalysis binding afterward regardless of what called it.
+    """
+
+    def test_forwards_allowed_modules_to_face_analysis_and_restores_binding(self, fake_vendor, monkeypatch):
+        face_utils, ip_adapter_mod, _calls = fake_vendor
+        import insightface.app as insightface_app_module
+
+        fa_calls = []
+
+        class _RecordingFaceAnalysis:
+            def __init__(self, *args, **kwargs):
+                fa_calls.append(kwargs)
+
+        monkeypatch.setattr(insightface_app_module, "FaceAnalysis", _RecordingFaceAnalysis)
+
+        def fake_get_insightface_model(model_name="buffalo_l", providers=None):
+            # Mirrors the real vendored function's actual construction call
+            # (face_utils.py:49): FaceAnalysis(name=..., root=..., providers=...).
+            return insightface_app_module.FaceAnalysis(name=model_name, providers=providers)
+
+        # Install the SAME function object on both bindings, mirroring how the real
+        # `from .face_utils import get_insightface_model` in ip_adapter.py copies one
+        # function object into two module namespaces. Setting only `face_utils`'s binding
+        # (as this test used to) leaves `ip_adapter_mod`'s pointing at the fixture's
+        # original get_insightface_model, so apply_faceid_patches's identity-guarded
+        # rebind — see _rebind_across_modules — would skip it, and the test would call
+        # through a binding the patch never touches: exactly the wrong-seam gap that let
+        # the shipped bug (loader patch never reaching ip_adapter.py:56) through review.
+        face_utils.get_insightface_model = fake_get_insightface_model
+        ip_adapter_mod.get_insightface_model = fake_get_insightface_model
+
+        from streamdiffusion.modules import faceid_compat
+
+        faceid_compat.apply_faceid_patches()
+
+        assert face_utils.get_insightface_model is ip_adapter_mod.get_insightface_model
+
+        # The real call site is ip_adapter.py:56, which reads *its own* copied-in name —
+        # invoke through that binding, not face_utils's, so this test can only pass if the
+        # patch actually reached the real caller.
+        ip_adapter_mod.get_insightface_model("buffalo_l", None)
+
+        assert len(fa_calls) == 1
+        assert fa_calls[0]["allowed_modules"] == ["detection", "recognition"]
+
+        # The patch must not leave insightface.app.FaceAnalysis pointing at its own
+        # injector after the call returns — it should be restored to whatever was bound
+        # (here, the test's own monkeypatched recorder) before the call started.
+        assert insightface_app_module.FaceAnalysis is _RecordingFaceAnalysis
+
+    def test_does_not_override_an_explicit_allowed_modules(self, fake_vendor, monkeypatch):
+        """setdefault semantics: if a future vendored version starts passing its own
+        allowed_modules, this patch must not silently clobber it."""
+        face_utils, ip_adapter_mod, _calls = fake_vendor
+        import insightface.app as insightface_app_module
+
+        fa_calls = []
+
+        class _RecordingFaceAnalysis:
+            def __init__(self, *args, **kwargs):
+                fa_calls.append(kwargs)
+
+        monkeypatch.setattr(insightface_app_module, "FaceAnalysis", _RecordingFaceAnalysis)
+
+        def fake_get_insightface_model(model_name="buffalo_l", providers=None):
+            return insightface_app_module.FaceAnalysis(
+                name=model_name, providers=providers, allowed_modules=["detection"]
+            )
+
+        # Same-object install on both bindings — see the comment in the sibling test above.
+        face_utils.get_insightface_model = fake_get_insightface_model
+        ip_adapter_mod.get_insightface_model = fake_get_insightface_model
+
+        from streamdiffusion.modules import faceid_compat
+
+        faceid_compat.apply_faceid_patches()
+        ip_adapter_mod.get_insightface_model("buffalo_l", None)
+
+        assert fa_calls[0]["allowed_modules"] == ["detection"]
+
+    def test_patch_is_idempotent(self, fake_vendor):
+        face_utils, _ip_adapter_mod, _calls = fake_vendor
+        from streamdiffusion.modules import faceid_compat
+
+        faceid_compat.apply_faceid_patches()
+        once_patched = face_utils.get_insightface_model
+        faceid_compat.apply_faceid_patches()
+        twice_patched = face_utils.get_insightface_model
+
+        assert once_patched is twice_patched
+
+
+class _FakeRecognitionModel:
+    """Stands in for the InsightFace 'recognition' entry of FaceAnalysis.models — only
+    the surface warmup_faceid actually touches: get_feat(img)."""
+
+    def __init__(self, calls):
+        self._calls = calls
+
+    def get_feat(self, img):
+        self._calls.append(np.array(img, copy=True))
+        return np.zeros((1, 512), dtype=np.float32)
+
+
+class _FakeInsightFaceModelForWarmup:
+    """Like _FakeInsightFaceModel, but also exposes a `models` dict (keyed by taskname,
+    mirroring face_analysis.py:39) so warmup_faceid can reach 'recognition' directly."""
+
+    def __init__(self, det_calls, recognition_calls):
+        self.det_model = _FakeDetModel()
+        self._det_calls = det_calls
+        self.models = {"recognition": _FakeRecognitionModel(recognition_calls)}
+
+    def get(self, img, max_num=0):
+        self._det_calls.append(
+            {"image": np.array(img, copy=True), "max_num": max_num, "size": self.det_model.input_size}
+        )
+        return []  # a blank warmup frame never contains a face
+
+
+class _FakeIPAdapterForWarmup:
+    def __init__(self, insightface_model, is_sdxl=True):
+        self.insightface_model = insightface_model
+        self.is_sdxl = is_sdxl
+
+
+class TestWarmupFaceid:
+    """Coverage for warmup_faceid: it must not be reachable from apply_faceid_patches
+    (the fake harness above calls that on every test and must stay unaffected), must warm
+    the detection session at 512x512/max_num=1, must warm the recognition session
+    directly via models['recognition'].get_feat, and must never raise — a warmup failure
+    is a perf regression (slow first press), not a correctness failure.
+    """
+
+    def test_warms_detection_and_recognition_sessions(self, fake_vendor):
+        from streamdiffusion.modules import faceid_compat
+
+        det_calls = []
+        rec_calls = []
+        model = _FakeInsightFaceModelForWarmup(det_calls, rec_calls)
+        ipadapter = _FakeIPAdapterForWarmup(model, is_sdxl=True)
+
+        faceid_compat.warmup_faceid(ipadapter)
+
+        assert len(det_calls) == 1
+        assert det_calls[0]["max_num"] == 1
+        assert det_calls[0]["size"] == (512, 512)
+        assert model.det_model.input_size == (512, 512)
+
+        assert len(rec_calls) == 1
+        assert rec_calls[0].shape == (112, 112, 3)
+
+    def test_no_insightface_model_is_a_noop(self):
+        from streamdiffusion.modules import faceid_compat
+
+        class _NoInsightfaceModel:
+            pass
+
+        faceid_compat.warmup_faceid(_NoInsightfaceModel())  # must not raise
+
+    def test_detection_failure_does_not_block_recognition_warmup(self, fake_vendor):
+        from streamdiffusion.modules import faceid_compat
+
+        rec_calls = []
+
+        class _RaisingModel:
+            def __init__(self):
+                self.det_model = _FakeDetModel()
+                self.models = {"recognition": _FakeRecognitionModel(rec_calls)}
+
+            def get(self, img, max_num=0):
+                raise RuntimeError("simulated detection session failure")
+
+        ipadapter = _FakeIPAdapterForWarmup(_RaisingModel(), is_sdxl=False)
+
+        faceid_compat.warmup_faceid(ipadapter)  # must not raise
+
+        assert len(rec_calls) == 1  # later step still ran despite the earlier failure
+
+    def test_missing_recognition_model_is_a_noop_for_that_step(self, fake_vendor):
+        from streamdiffusion.modules import faceid_compat
+
+        det_calls = []
+
+        class _NoRecognitionModel:
+            def __init__(self):
+                self.det_model = _FakeDetModel()
+                self.models = {}  # allowed_modules=['detection'] only, e.g.
+
+            def get(self, img, max_num=0):
+                det_calls.append(max_num)
+                return []
+
+        ipadapter = _FakeIPAdapterForWarmup(_NoRecognitionModel(), is_sdxl=True)
+
+        faceid_compat.warmup_faceid(ipadapter)  # must not raise
+
+        assert det_calls == [1]
+
+    def test_apply_faceid_patches_does_not_invoke_warmup(self, fake_vendor, monkeypatch):
+        """apply_faceid_patches must stay warmup-free: every other test in this file calls
+        it against a fake vendor tree with no insightface_model at all, so if warmup ever
+        got folded in there, those tests would start failing."""
+        from streamdiffusion.modules import faceid_compat
+
+        calls = []
+        monkeypatch.setattr(faceid_compat, "warmup_faceid", lambda ipadapter: calls.append(ipadapter))
+
+        faceid_compat.apply_faceid_patches()
+
+        assert calls == []

--- a/tests/unit/test_faceid_lora_fusion.py
+++ b/tests/unit/test_faceid_lora_fusion.py
@@ -1,0 +1,179 @@
+"""
+Regression test for B2 — fusing the FaceID checkpoint's discarded rank-128 LoRA into the
+UNet's attention linears (``streamdiffusion.modules.faceid_compat.fuse_faceid_lora``).
+
+``ip_adapter.py``'s strict ``load_state_dict`` silently drops every ``to_{q,k,v,out}_lora``
+key because no LoRA-aware attention-processor class exists in the vendored
+``attention_processor.py``, and the TensorRT export path rebuilds every processor before ONNX
+export regardless (``IPAdapterUNetExportWrapper.__init__``), so a processor-resident LoRA would
+be lost there too. ``fuse_faceid_lora`` instead adds ``(up @ down) * lora_scale`` directly into
+the base ``to_q``/``to_k``/``to_v``/``to_out[0]`` linears, which no processor rebuild can touch.
+
+This test uses a tiny synthetic attention module (real ``torch.nn.Module`` instances, so
+``unet.get_submodule("layers.<i>.to_out.0")`` resolves exactly like it does on the real UNet's
+``attn1``/``attn2`` — a ``ModuleList`` index is just a string-keyed submodule) and a synthetic
+LoRA state dict — no GPU, no checkpoint download, no diffusers UNet construction.
+
+Run with: pytest tests/unit/test_faceid_lora_fusion.py -v
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from streamdiffusion.modules.faceid_compat import _LORA_TARGET_ATTR, fuse_faceid_lora
+
+_DIM = 4
+_RANK = 2
+_N_LAYERS = 3
+
+
+class _FakeAttnModule(nn.Module):
+    """Mirrors the shape of a real diffusers Attention module: to_q/to_k/to_v linears plus
+    a to_out ModuleList (index 0 is the projection linear, matching ``to_out.0``), and a
+    ``.processor`` submodule standing in for the real ``AttnProcessor``/``IPAttnProcessor``.
+    """
+
+    def __init__(self, dim: int = _DIM):
+        super().__init__()
+        self.to_q = nn.Linear(dim, dim, bias=False)
+        self.to_k = nn.Linear(dim, dim, bias=False)
+        self.to_v = nn.Linear(dim, dim, bias=False)
+        self.to_out = nn.ModuleList([nn.Linear(dim, dim, bias=False)])
+        self.processor = nn.Module()
+
+
+class _FakeUNet(nn.Module):
+    """Minimal stand-in for UNet2DConditionModel: only ``attn_processors`` and
+    ``get_submodule`` (inherited from nn.Module, unmodified) are used by ``fuse_faceid_lora``.
+    """
+
+    def __init__(self, n_layers: int = _N_LAYERS, dim: int = _DIM):
+        super().__init__()
+        self.layers = nn.ModuleList([_FakeAttnModule(dim) for _ in range(n_layers)])
+
+    @property
+    def attn_processors(self):
+        # Real diffusers_ipadapter iterates unet.attn_processors.keys() in this same
+        # ".processor"-suffixed form to resolve module_path via proc_key[:-len(".processor")].
+        return {f"layers.{i}.processor": self.layers[i].processor for i in range(len(self.layers))}
+
+
+def _make_lora_checkpoint(tmp_path, n_layers=_N_LAYERS, dim=_DIM, rank=_RANK, only_indices=None):
+    """Build a synthetic FaceID-shaped checkpoint and save it to a real file (fuse_faceid_lora
+    loads via torch.load(ckpt_path, ...), not from an in-memory dict).
+    """
+    indices = range(n_layers) if only_indices is None else only_indices
+    sd = {}
+    for i in indices:
+        for lora_name in _LORA_TARGET_ATTR:
+            sd[f"{i}.{lora_name}.down.weight"] = torch.randn(rank, dim)
+            sd[f"{i}.{lora_name}.up.weight"] = torch.randn(dim, rank)
+    ckpt_path = tmp_path / "fake_faceid.bin"
+    torch.save({"ip_adapter": sd}, ckpt_path)
+    return ckpt_path, sd
+
+
+class TestFuseFaceIdLora:
+    def test_fuses_up_at_down_into_target_linears(self, tmp_path):
+        unet = _FakeUNet()
+        ckpt_path, sd = _make_lora_checkpoint(tmp_path)
+
+        original_to_q = [layer.to_q.weight.detach().clone() for layer in unet.layers]
+        original_to_out = [layer.to_out[0].weight.detach().clone() for layer in unet.layers]
+
+        fused_count = fuse_faceid_lora(unet, str(ckpt_path))
+
+        assert fused_count == _N_LAYERS
+        for i, layer in enumerate(unet.layers):
+            down = sd[f"{i}.to_q_lora.down.weight"]
+            up = sd[f"{i}.to_q_lora.up.weight"]
+            expected = original_to_q[i] + (up @ down)
+            assert torch.allclose(layer.to_q.weight, expected, atol=1e-6)
+
+            down_out = sd[f"{i}.to_out_lora.down.weight"]
+            up_out = sd[f"{i}.to_out_lora.up.weight"]
+            expected_out = original_to_out[i] + (up_out @ down_out)
+            assert torch.allclose(layer.to_out[0].weight, expected_out, atol=1e-6)
+
+    def test_lora_scale_scales_the_delta(self, tmp_path):
+        unet = _FakeUNet()
+        ckpt_path, sd = _make_lora_checkpoint(tmp_path)
+        original_to_k = [layer.to_k.weight.detach().clone() for layer in unet.layers]
+
+        fuse_faceid_lora(unet, str(ckpt_path), lora_scale=0.5)
+
+        for i, layer in enumerate(unet.layers):
+            down = sd[f"{i}.to_k_lora.down.weight"]
+            up = sd[f"{i}.to_k_lora.up.weight"]
+            expected = original_to_k[i] + (up @ down) * 0.5
+            assert torch.allclose(layer.to_k.weight, expected, atol=1e-6)
+
+    def test_second_fusion_is_a_noop(self, tmp_path):
+        unet = _FakeUNet()
+        ckpt_path, _ = _make_lora_checkpoint(tmp_path)
+
+        first_count = fuse_faceid_lora(unet, str(ckpt_path))
+        after_first = [layer.to_v.weight.detach().clone() for layer in unet.layers]
+
+        second_count = fuse_faceid_lora(unet, str(ckpt_path))
+        after_second = [layer.to_v.weight.detach().clone() for layer in unet.layers]
+
+        assert first_count == _N_LAYERS
+        assert second_count == 0
+        for a, b in zip(after_first, after_second):
+            assert torch.equal(a, b)
+
+    def test_shape_mismatch_raises(self, tmp_path):
+        unet = _FakeUNet(n_layers=1, dim=_DIM)
+        # up/down shaped for a *different* dim than the target linear -> matmul shape
+        # (wrong_dim, wrong_dim) can never equal the real to_q weight's (dim, dim).
+        wrong_dim = _DIM + 1
+        sd = {
+            "0.to_q_lora.down.weight": torch.randn(_RANK, wrong_dim),
+            "0.to_q_lora.up.weight": torch.randn(wrong_dim, _RANK),
+        }
+        ckpt_path = tmp_path / "bad_shape.bin"
+        torch.save({"ip_adapter": sd}, ckpt_path)
+
+        with pytest.raises(RuntimeError, match="shape mismatch"):
+            fuse_faceid_lora(unet, str(ckpt_path))
+
+    def test_no_lora_keys_is_a_noop(self, tmp_path):
+        """A non-FaceID (or already to_k_ip/to_v_ip-only) checkpoint has no '_lora.' keys —
+        fuse_faceid_lora must recognise this and skip cleanly rather than fusing nothing
+        per-layer via 140 no-op inner loops.
+        """
+        unet = _FakeUNet()
+        original_to_q = [layer.to_q.weight.detach().clone() for layer in unet.layers]
+
+        sd = {"0.to_k_ip.weight": torch.randn(_DIM, _DIM)}
+        ckpt_path = tmp_path / "no_lora.bin"
+        torch.save({"ip_adapter": sd}, ckpt_path)
+
+        fused_count = fuse_faceid_lora(unet, str(ckpt_path))
+
+        assert fused_count == 0
+        for i, layer in enumerate(unet.layers):
+            assert torch.equal(layer.to_q.weight, original_to_q[i])
+
+    def test_partial_lora_only_fuses_layers_present_in_checkpoint(self, tmp_path):
+        """Real FaceID checkpoints only carry LoRA on layers that also have IP cross-attn
+        (odd indices / attn2) — even-index attn1 processors are paramless. fuse_faceid_lora
+        must fuse exactly the layers present and leave the rest untouched.
+        """
+        unet = _FakeUNet(n_layers=4)
+        ckpt_path, sd = _make_lora_checkpoint(tmp_path, n_layers=4, only_indices=[1, 3])
+        original = [layer.to_q.weight.detach().clone() for layer in unet.layers]
+
+        fused_count = fuse_faceid_lora(unet, str(ckpt_path))
+
+        assert fused_count == 2
+        for i, layer in enumerate(unet.layers):
+            if i in (1, 3):
+                down = sd[f"{i}.to_q_lora.down.weight"]
+                up = sd[f"{i}.to_q_lora.up.weight"]
+                expected = original[i] + (up @ down)
+                assert torch.allclose(layer.to_q.weight, expected, atol=1e-6)
+            else:
+                assert torch.equal(layer.to_q.weight, original[i])

--- a/tests/unit/test_faceid_preprocessor_contract.py
+++ b/tests/unit/test_faceid_preprocessor_contract.py
@@ -1,0 +1,101 @@
+"""
+Regression test for A5 — ``FaceIDEmbeddingPreprocessor``
+(``streamdiffusion.preprocessing.processors.faceid_embedding``).
+
+Two things changed: the dead ``update_faceid_v2_weight`` method (zero callers anywhere in the
+tree, confirmed by repo-wide search) was deleted, and the ``faceid_v2_weight`` metadata
+description was corrected — it previously implied ``faceid_v2_weight`` affects all FaceID
+models, but tracing its only read site (vendored ``ip_adapter.py``'s ``_get_faceid_embeds``,
+inside ``if self.is_plus:`` branches) shows it only affects FaceID-Plus/v2, never plain FaceID.
+This test locks in the deletion and the corrected metadata wording, plus the preprocessor's
+existing construction/processing contract so a future edit can't silently regress either.
+
+Run with: pytest tests/unit/test_faceid_preprocessor_contract.py -v
+"""
+
+import pytest
+import torch
+from PIL import Image
+
+from streamdiffusion.preprocessing.processors.faceid_embedding import FaceIDEmbeddingPreprocessor
+
+
+class _FakeIPAdapter:
+    def __init__(self, insightface_model="buffalo_l", raise_on_embed=False):
+        self.insightface_model = insightface_model
+        self.raise_on_embed = raise_on_embed
+        self.calls = []
+
+    def get_image_embeds(self, images, faceid_v2_weight=None):
+        self.calls.append({"images": images, "faceid_v2_weight": faceid_v2_weight})
+        if self.raise_on_embed:
+            raise RuntimeError("boom")
+        return torch.zeros(1, 4, 8), torch.ones(1, 4, 8)
+
+
+class TestMetadataCorrection:
+    def test_faceid_v2_weight_description_scopes_to_plus_v2_only(self):
+        meta = FaceIDEmbeddingPreprocessor.get_preprocessor_metadata()
+        description = meta["parameters"]["faceid_v2_weight"]["description"]
+
+        assert "Plus" in description or "v2" in description
+        assert "no effect" in description.lower() or "only" in description.lower()
+
+    def test_dead_update_method_was_removed(self):
+        """A5: update_faceid_v2_weight had zero callers anywhere in the tree — deleted
+        outright rather than left as unreachable code.
+        """
+        assert not hasattr(FaceIDEmbeddingPreprocessor, "update_faceid_v2_weight")
+
+
+class TestConstructionContract:
+    def test_requires_insightface_model_attribute(self):
+        class _NoInsightface:
+            def get_image_embeds(self, **kwargs):
+                return None
+
+        with pytest.raises(ValueError, match="InsightFace"):
+            FaceIDEmbeddingPreprocessor(ipadapter=_NoInsightface())
+
+    def test_requires_insightface_model_not_none(self):
+        with pytest.raises(ValueError, match="InsightFace"):
+            FaceIDEmbeddingPreprocessor(ipadapter=_FakeIPAdapter(insightface_model=None))
+
+    def test_requires_get_image_embeds_method(self):
+        class _NoEmbedMethod:
+            insightface_model = "buffalo_l"
+
+        with pytest.raises(ValueError, match="get_image_embeds"):
+            FaceIDEmbeddingPreprocessor(ipadapter=_NoEmbedMethod())
+
+    def test_default_faceid_v2_weight_is_one(self):
+        pre = FaceIDEmbeddingPreprocessor(ipadapter=_FakeIPAdapter())
+        assert pre.faceid_v2_weight == 1.0
+
+    def test_custom_faceid_v2_weight_is_coerced_to_float(self):
+        pre = FaceIDEmbeddingPreprocessor(ipadapter=_FakeIPAdapter(), faceid_v2_weight=2)
+        assert pre.faceid_v2_weight == 2.0
+        assert isinstance(pre.faceid_v2_weight, float)
+
+
+class TestProcessCore:
+    def test_passes_image_and_weight_through_to_get_image_embeds(self):
+        fake = _FakeIPAdapter()
+        pre = FaceIDEmbeddingPreprocessor(ipadapter=fake, faceid_v2_weight=0.5)
+        image = Image.new("RGB", (8, 8))
+
+        positive, negative = pre._process_core(image)
+
+        assert len(fake.calls) == 1
+        assert fake.calls[0]["images"] == [image]
+        assert fake.calls[0]["faceid_v2_weight"] == 0.5
+        assert positive.shape == (1, 4, 8)
+        assert negative.shape == (1, 4, 8)
+
+    def test_wraps_embed_failure_in_runtime_error(self):
+        fake = _FakeIPAdapter(raise_on_embed=True)
+        pre = FaceIDEmbeddingPreprocessor(ipadapter=fake)
+        image = Image.new("RGB", (8, 8))
+
+        with pytest.raises(RuntimeError, match="Failed to extract face embeddings"):
+            pre._process_core(image)

--- a/tests/unit/test_ipadapter_config_from_dict.py
+++ b/tests/unit/test_ipadapter_config_from_dict.py
@@ -1,0 +1,98 @@
+"""
+Regression test for A4 — ``IPAdapterConfig.from_dict``
+(``streamdiffusion.modules.ipadapter_module.IPAdapterConfig``).
+
+Both ``wrapper.py`` install sites (pre-TRT and post-TRT) used to build this dataclass by hand
+with duplicated inline field lists and no validation. ``from_dict`` centralizes that and adds
+one fail-fast check: a ``type="faceid"`` config with no ``insightface_model_name`` used to
+construct successfully and only fail later, mid-stream, inside ``_get_faceid_embeds`` on the
+first style-image update — the same silent/late-failure class as B1/B2. This test locks in
+both the happy paths and that fail-fast behaviour.
+
+Run with: pytest tests/unit/test_ipadapter_config_from_dict.py -v
+"""
+
+import pytest
+
+from streamdiffusion.modules.ipadapter_module import IPAdapterConfig, IPAdapterType
+
+_BASE_CFG = {
+    "ipadapter_model_path": "h94/IP-Adapter/models/ip-adapter_sd15.bin",
+    "image_encoder_path": "h94/IP-Adapter/models/image_encoder",
+}
+
+
+class TestFromDictHappyPaths:
+    def test_regular_config_defaults(self):
+        cfg = IPAdapterConfig.from_dict(dict(_BASE_CFG))
+
+        assert cfg.type == IPAdapterType.REGULAR
+        assert cfg.ipadapter_model_path == _BASE_CFG["ipadapter_model_path"]
+        assert cfg.image_encoder_path == _BASE_CFG["image_encoder_path"]
+        assert cfg.style_image_key == "ipadapter_main"
+        assert cfg.num_image_tokens == 4
+        assert cfg.scale == 1.0
+        assert cfg.style_image is None
+        assert cfg.insightface_model_name is None
+
+    def test_faceid_config_with_insightface_model_name_succeeds(self):
+        cfg = IPAdapterConfig.from_dict(
+            dict(
+                _BASE_CFG,
+                type="faceid",
+                insightface_model_name="buffalo_l",
+            )
+        )
+
+        assert cfg.type == IPAdapterType.FACEID
+        assert cfg.insightface_model_name == "buffalo_l"
+
+    def test_explicit_style_image_key_is_preserved(self):
+        cfg = IPAdapterConfig.from_dict(dict(_BASE_CFG, style_image_key="secondary"))
+
+        assert cfg.style_image_key == "secondary"
+
+    def test_empty_string_style_image_key_falls_back_to_default(self):
+        """S4 alignment: an empty string (falsy) must still resolve to the same default
+        'ipadapter_main' that build_embedding_hook and install() both use — not '' itself,
+        which would silently desync the hook's cache lookup from the installed style key.
+        """
+        cfg = IPAdapterConfig.from_dict(dict(_BASE_CFG, style_image_key=""))
+
+        assert cfg.style_image_key == "ipadapter_main"
+
+    def test_custom_num_image_tokens_and_scale_pass_through(self):
+        cfg = IPAdapterConfig.from_dict(dict(_BASE_CFG, num_image_tokens=16, scale=0.7))
+
+        assert cfg.num_image_tokens == 16
+        assert cfg.scale == 0.7
+
+    def test_style_image_passes_through(self):
+        sentinel = object()
+        cfg = IPAdapterConfig.from_dict(dict(_BASE_CFG, style_image=sentinel))
+
+        assert cfg.style_image is sentinel
+
+
+class TestFromDictValidation:
+    def test_faceid_without_insightface_model_name_raises_value_error(self):
+        with pytest.raises(ValueError, match="insightface_model_name"):
+            IPAdapterConfig.from_dict(dict(_BASE_CFG, type="faceid"))
+
+    def test_faceid_with_empty_insightface_model_name_raises_value_error(self):
+        with pytest.raises(ValueError, match="insightface_model_name"):
+            IPAdapterConfig.from_dict(dict(_BASE_CFG, type="faceid", insightface_model_name=""))
+
+    def test_missing_ipadapter_model_path_raises_key_error(self):
+        cfg = {"image_encoder_path": _BASE_CFG["image_encoder_path"]}
+        with pytest.raises(KeyError):
+            IPAdapterConfig.from_dict(cfg)
+
+    def test_missing_image_encoder_path_raises_key_error(self):
+        cfg = {"ipadapter_model_path": _BASE_CFG["ipadapter_model_path"]}
+        with pytest.raises(KeyError):
+            IPAdapterConfig.from_dict(cfg)
+
+    def test_invalid_type_string_raises_value_error(self):
+        with pytest.raises(ValueError):
+            IPAdapterConfig.from_dict(dict(_BASE_CFG, type="not-a-real-type"))


### PR DESCRIPTION
## What

Hardens the FaceID/IP-Adapter loading and conditioning path. This is the largest PR in the
stack and the most opinionated — it adds `faceid_compat.py`, a module upstream does not have —
so it leads with measured numbers rather than asking for trust:

- **InsightFace load time**: the first "update image" press after a cold start measured
  **1238.3 ms**, dropping to **~25 ms** once `FaceAnalysis`'s `allowed_modules` is restricted to
  only the models FaceID actually needs (detection + recognition), instead of loading
  InsightFace's full default model zoo (landmark, gender/age, etc.) on every session.
- **A real aliasing bug that made an existing loader patch a no-op**: the vendored
  `diffusers_ipadapter`'s `ip_adapter.py:56` does `from .face_utils import *` at import time,
  which binds a *module-level copy* of the loader function into `ip_adapter`'s own namespace.
  A monkeypatch applied to `face_utils`'s attribute after that point never reaches
  `ip_adapter.py`'s call site, because it's calling its own private alias, not the patched
  module. The package root re-exports a *third* copy via its own `from .face_utils import *`.
  `faceid_compat.py` patches all three binding sites, not just the "obvious" one.

## Changes

- **`faceid_compat.py`** (new): centralizes the InsightFace `allowed_modules` restriction, the
  three-site loader patch above, and version-compat shims for the vendored
  `diffusers_ipadapter` package. No public seam exists in that vendored code for any of this —
  it is monkeypatched because there is no supported extension point to hook instead.
- **BGR conditioning fix**: InsightFace's `FaceAnalysis` returns embeddings computed from BGR
  input; a wrong-order RGB frame reaching it silently produces a plausible-looking but degraded
  embedding rather than an error. Corrects the channel order at the actual conditioning
  call site.
- **IP-Adapter LoRA fusion**: an existing fusion step was being computed and then discarded
  before it reached the UNet's applied weights — fixed so IP-Adapter LoRA weights actually fuse.
- `ipadapter_module.py` / `engine_manager.py` (FaceID half only — the ControlNet-token half of
  this fork commit ships in PR 2, not here) wiring for the above.
- `scripts/test_faceid_sanity.py` — dev script for manually verifying the load-time and
  embedding-correctness fixes end-to-end.

## Cross-PR notes

- `wrapper.py`: this PR's hunk is disjoint from PR 1's FP8-provenance hunk in the same file —
  different regions, no functional overlap.
- `preprocessing/processors/faceid_embedding.py`: this PR and PR 8
  (`pr/perf-orchestrator-threading`) both touch this file for genuinely different reasons
  (FaceID correctness here; threading/orchestration there). Both changes are needed
  independently; whichever lands first, the other rebases cleanly against it.
- `tests/unit/test_engine_path_ipadapter_suffixes.py` is intentionally **not** included here —
  it's already byte-identical to PR 2's copy and belongs there.

## Tests

`tests/unit/test_faceid_bgr_patch.py`, `test_faceid_lora_fusion.py`,
`test_faceid_preprocessor_contract.py`, `test_ipadapter_config_from_dict.py`.

## Branch

`pr/faceid-loader-hardening` -> `SDTD_040_beta_release`
