### PR TITLE
fix: L2 persisting-cache window clamps, dynamic hitRatio, and reset

### DIFF
--- a/src/streamdiffusion/tools/cuda_l2_cache.py
+++ b/src/streamdiffusion/tools/cuda_l2_cache.py
@@ -23,14 +23,23 @@ Environment variables:
 
 Expected impact: 5-16% on memory-bandwidth-bound layers (normalization, small GEMMs).
 Hot layers on SDXL: mid_block, up_blocks.1 (most FF hooks + V2V cached attention).
+
+CUDA runtime access: this module goes through `cuda.bindings.runtime` (the same binding
+`acceleration/tensorrt/utilities.py` imports as `cudart`), not raw ctypes -- no DLL search,
+no manual struct/argtypes definitions, and every call's returned `cudaError_t` is checked
+individually (see `_cuda_check` below) instead of being swallowed with a blanket
+`cudaGetLastError()`.
 """
 
-import ctypes
 import os
-import sys
 from typing import Optional
 
 import torch
+
+try:
+    from cuda.bindings import runtime as cudart
+except ImportError:
+    from cuda import cudart
 
 # =============================================================================
 # Environment Controls (read at call time -- see module docstring precedence)
@@ -57,94 +66,35 @@ _DEFAULT_HOT_LAYER_PREFIXES = ["mid_block", "up_blocks.1"]
 
 
 # =============================================================================
-# CUDA Runtime Access Policy Structs (for Tier 2 per-tensor persistence)
+# Module state
 # =============================================================================
 
-
-class _CudaAccessPolicyWindow(ctypes.Structure):
-    """cudaAccessPolicyWindow struct for cudaStreamSetAttribute."""
-
-    _fields_ = [
-        ("base_ptr", ctypes.c_void_p),  # void* — start of memory region
-        ("num_bytes", ctypes.c_size_t),  # size_t — size of region in bytes
-        ("hitRatio", ctypes.c_float),  # float — fraction in [0, 1] to keep persistent
-        (
-            "hitProp",
-            ctypes.c_int,
-        ),  # cudaAccessProperty: 2 = cudaAccessPropertyPersisting
-        (
-            "missProp",
-            ctypes.c_int,
-        ),  # cudaAccessProperty: 1 = cudaAccessPropertyStreaming
-    ]
+# Bytes actually granted by the most recent successful reserve_l2_persisting_cache()
+# call (post-clamp) -- used by set_tensor_persisting() to scale hitRatio down instead
+# of hardcoding 1.0 (see its docstring). 0 means "nothing reserved yet".
+_granted_persist_bytes: int = 0
 
 
-# cudaAccessProperty enum values
-_CUDA_ACCESS_PROPERTY_NORMAL = 0
-_CUDA_ACCESS_PROPERTY_STREAMING = 1
-_CUDA_ACCESS_PROPERTY_PERSISTING = 2
+def _cuda_check(result, action: str):
+    """Unpack a `cudart` call's `(cudaError_t, *values)` return tuple.
 
-# cudaStreamAttrID
-_CUDA_STREAM_ATTRIBUTE_ACCESS_POLICY_WINDOW = 1
-
-# cudaLimit enum (CUDA 11.2+)
-# 0x06 = cudaLimitPersistingL2CacheSize (size in bytes — correct for L2 persistence)
-_CUDA_LIMIT_PERSISTING_L2_CACHE_SIZE = 0x06
-
-
-# =============================================================================
-# CUDA Runtime Handle
-# =============================================================================
-
-_cudart: Optional[ctypes.CDLL] = None
-_cudart_loaded: bool = False
-
-
-def _get_cudart() -> Optional[ctypes.CDLL]:
-    """Load the CUDA runtime DLL. Cached after first call."""
-    global _cudart, _cudart_loaded
-    if _cudart_loaded:
-        return _cudart
-
-    _cudart_loaded = True
-
-    if sys.platform != "win32":
-        # Non-Windows: use libcudart.so — typically already loaded by PyTorch
-        try:
-            _cudart = ctypes.CDLL("libcudart.so", mode=ctypes.RTLD_GLOBAL)
-            return _cudart
-        except OSError:
-            pass
-        try:
-            from ctypes.util import find_library
-
-            lib = find_library("cudart")
-            if lib:
-                _cudart = ctypes.CDLL(lib)
-                return _cudart
-        except OSError:
-            pass
+    Every cudart binding call returns its status as element 0 -- there is no
+    thread-local "last error" to separately clear or swallow (that was a ctypes-only
+    concern; see the module docstring). On `cudaSuccess` this returns the trailing
+    payload (`None` for a bare status, the single value, or a tuple of values for
+    multi-value returns). On any other status this logs `[L2] <action> failed: <err>`
+    and returns `None` -- callers must check `is None`, not truthiness, since a
+    legitimate query result (e.g. an attribute value of 0) is also falsy.
+    """
+    err = result[0]
+    if err != cudart.cudaError_t.cudaSuccess:
+        print(f"[L2] {action} failed: {err}")
         return None
-
-    # Windows: find cudart64_*.dll shipped with PyTorch or CUDA toolkit
-    import glob
-
-    # Option 1: PyTorch ships cudart in torch/lib/
-    torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib")
-    candidates = sorted(glob.glob(os.path.join(torch_lib, "cudart64_*.dll")), reverse=True)
-
-    # Option 2: CUDA toolkit installation
-    cuda_path = os.environ.get("CUDA_PATH", r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8")
-    candidates += sorted(glob.glob(os.path.join(cuda_path, "bin", "cudart64_*.dll")), reverse=True)
-
-    for dll_path in candidates:
-        try:
-            _cudart = ctypes.WinDLL(dll_path)
-            return _cudart
-        except OSError:
-            continue
-
-    return None
+    if len(result) == 2:
+        return result[1]
+    if len(result) > 2:
+        return result[1:]
+    return True
 
 
 # =============================================================================
@@ -160,6 +110,13 @@ def reserve_l2_persisting_cache(persist_mb: Optional[int] = None) -> bool:
     of L2 should not be evicted by regular (streaming) accesses. Hot data set
     via access policy windows will preferentially stay in this reserved region.
 
+    The requested size is clamped to both 75% of total L2 and the device's actual
+    `cudaDevAttrMaxPersistingL2CacheSize` -- NVIDIA's own guidance
+    (`min(0.75 * l2CacheSize, persistingL2CacheMaxSize)`), since the two limits are
+    independent and the smaller one governs. A device reporting `persistingL2CacheMaxSize
+    == 0` does not support L2 persistence at all and is skipped rather than silently
+    over-requesting.
+
     Args:
         persist_mb: Megabytes of L2 to reserve. Should be <= half of total L2.
                     RTX 5090 has 128MB L2 → 64MB is a safe default.
@@ -168,6 +125,8 @@ def reserve_l2_persisting_cache(persist_mb: Optional[int] = None) -> bool:
     Returns:
         True if successful, False if unsupported or failed.
     """
+    global _granted_persist_bytes
+
     if persist_mb is None:
         persist_mb = _env_persist_mb()
 
@@ -182,56 +141,75 @@ def reserve_l2_persisting_cache(persist_mb: Optional[int] = None) -> bool:
         print(f"[L2] L2 persistence skipped — compute {major}.{minor} < 8.0 (Ampere required)")
         return False
 
-    l2_total_mb = props.L2_cache_size // (1024 * 1024)
-    persist_bytes = min(persist_mb * 1024 * 1024, props.L2_cache_size // 2)
-    persist_mb_actual = persist_bytes // (1024 * 1024)
-
-    cudart = _get_cudart()
-    if cudart is None:
-        print("[L2] CUDA runtime not found — L2 persistence unavailable")
+    l2_cache_size = _cuda_check(
+        cudart.cudaDeviceGetAttribute(cudart.cudaDeviceAttr.cudaDevAttrL2CacheSize, device),
+        "cudaDeviceGetAttribute(L2CacheSize)",
+    )
+    if l2_cache_size is None:
         return False
 
-    try:
-        result = cudart.cudaDeviceSetLimit(
-            ctypes.c_int(_CUDA_LIMIT_PERSISTING_L2_CACHE_SIZE),
-            ctypes.c_size_t(persist_bytes),
-        )
-        # CRITICAL: Always clear CUDA error state after ctypes calls.
-        # cudaDeviceSetLimit sets the thread-local CUDA error on failure, and
-        # PyTorch's C10_CUDA_KERNEL_LAUNCH_CHECK() reads it on the next kernel
-        # launch — causing a stale error to crash an unrelated operation.
-        cudart.cudaGetLastError()
-        if result != 0:
-            print(f"[L2] cudaDeviceSetLimit failed: error {result}")
-            return False
-
-        print(
-            f"[L2] Reserved {persist_mb_actual}MB of {l2_total_mb}MB L2 for persisting cache "
-            f"(compute {major}.{minor}, {props.name})"
-        )
-        return True
-
-    except (OSError, ctypes.ArgumentError, AttributeError) as e:
-        print(f"[L2] L2 reservation failed: {e}")
+    max_persisting = _cuda_check(
+        cudart.cudaDeviceGetAttribute(cudart.cudaDeviceAttr.cudaDevAttrMaxPersistingL2CacheSize, device),
+        "cudaDeviceGetAttribute(MaxPersistingL2CacheSize)",
+    )
+    if max_persisting is None:
         return False
+
+    if max_persisting == 0:
+        print("[L2] L2 persistence unsupported on this device (persistingL2CacheMaxSize == 0)")
+        return False
+
+    requested_bytes = persist_mb * 1024 * 1024
+    persist_bytes = min(requested_bytes, int(l2_cache_size * 0.75), max_persisting)
+
+    ok = _cuda_check(
+        cudart.cudaDeviceSetLimit(cudart.cudaLimit.cudaLimitPersistingL2CacheSize, persist_bytes),
+        "cudaDeviceSetLimit(PersistingL2CacheSize)",
+    )
+    if ok is None:
+        return False
+
+    _granted_persist_bytes = persist_bytes
+    print(
+        f"[L2] Reserved {persist_bytes / 1024 / 1024:.1f}MB of {l2_cache_size / 1024 / 1024:.1f}MB L2 "
+        f"for persisting cache (max persisting {max_persisting / 1024 / 1024:.1f}MB, "
+        f"compute {major}.{minor}, {props.name})"
+    )
+    return True
 
 
 # =============================================================================
 # Tier 2: Per-Tensor Access Policy (stream attribute window)
 # =============================================================================
 
+# NOTE on applicability: the access policy window set below is a *per-stream* attribute
+# (cudaStreamSetAttribute), applied to whatever `torch.cuda.current_stream()` is at call
+# time. It only affects kernels subsequently launched on that stream -- not the whole
+# device or process, and not retroactively. This is exactly right for the torch/compile
+# Tier 2 path (weights are pinned once, on the stream inference runs on). On the TRT path,
+# Tier 2 is never reached at all: pin_hot_unet_weights() requires an nn.Module and a
+# serialized TRT engine is not one, so only Tier 1 (which is inert without a Tier 2 window
+# to consume the reservation) applies there, and Tier 1 itself defaults off for
+# acceleration=="tensorrt" (see setup_l2_persistence). No behavior change from the
+# ctypes version -- this is the existing constraint, written down.
 
-def set_tensor_persisting(tensor: torch.Tensor, hit_ratio: float = 1.0) -> bool:
+
+def set_tensor_persisting(tensor: torch.Tensor, hit_ratio: Optional[float] = None) -> bool:
     """
     Mark a tensor's memory region as L2-persistent.
 
-    Uses cudaStreamSetAttribute with cudaAccessPolicyWindow to request that
-    `hit_ratio` fraction of the tensor's data stays in the L2 persisting region.
+    Uses cudaStreamSetAttribute with cudaAccessPolicyWindow to request that `hit_ratio`
+    fraction of the tensor's data stays in the L2 persisting region.
 
     Args:
         tensor: CUDA tensor whose weights should persist in L2.
         hit_ratio: Fraction [0, 1] of accesses to serve from persisting cache.
-                   1.0 = always try to keep in L2 (good for weights).
+                   None (default) -> min(1.0, granted_set_aside_bytes / num_bytes), so a
+                   window larger than what reserve_l2_persisting_cache() actually set
+                   aside scales down instead of thrashing cache lines at a hardcoded 1.0
+                   (NVIDIA's own guidance -- a window bigger than the set-aside at
+                   hitRatio=1.0 evicts and re-admits persisting lines every pass instead
+                   of settling).
 
     Returns:
         True if successful.
@@ -239,30 +217,48 @@ def set_tensor_persisting(tensor: torch.Tensor, hit_ratio: float = 1.0) -> bool:
     if not tensor.is_cuda or not tensor.is_contiguous():
         return False
 
-    cudart = _get_cudart()
-    if cudart is None:
+    device = tensor.get_device()
+    max_window = _cuda_check(
+        cudart.cudaDeviceGetAttribute(cudart.cudaDeviceAttr.cudaDevAttrMaxAccessPolicyWindowSize, device),
+        "cudaDeviceGetAttribute(MaxAccessPolicyWindowSize)",
+    )
+    if max_window is None:
         return False
 
+    # accessPolicyMaxWindowSize clamp — docs require num_bytes < this limit (measured
+    # 134,213,632 B on an RTX 4090). Unclamped, an oversized tensor would trip
+    # cudaErrorInvalidValue here instead of silently degrading.
+    num_bytes = min(tensor.nbytes, max_window)
+    if num_bytes <= 0:
+        return False
+
+    if hit_ratio is None:
+        hit_ratio = min(1.0, _granted_persist_bytes / num_bytes)
+    hit_ratio = max(0.0, min(1.0, hit_ratio))
+
     try:
+        window = cudart.cudaAccessPolicyWindow()
+        window.base_ptr = tensor.data_ptr()
+        window.num_bytes = num_bytes
+        window.hitRatio = hit_ratio
+        window.hitProp = cudart.cudaAccessProperty.cudaAccessPropertyPersisting
+        window.missProp = cudart.cudaAccessProperty.cudaAccessPropertyStreaming
+
+        attr_value = cudart.cudaStreamAttrValue()
+        attr_value.accessPolicyWindow = window
+
         stream_ptr = torch.cuda.current_stream().cuda_stream
-
-        window = _CudaAccessPolicyWindow(
-            base_ptr=ctypes.c_void_p(tensor.data_ptr()),
-            num_bytes=ctypes.c_size_t(tensor.nbytes),
-            hitRatio=ctypes.c_float(hit_ratio),
-            hitProp=ctypes.c_int(_CUDA_ACCESS_PROPERTY_PERSISTING),
-            missProp=ctypes.c_int(_CUDA_ACCESS_PROPERTY_STREAMING),
+        ok = _cuda_check(
+            cudart.cudaStreamSetAttribute(
+                stream_ptr,
+                cudart.cudaStreamAttrID.cudaLaunchAttributeAccessPolicyWindow,
+                attr_value,
+            ),
+            "cudaStreamSetAttribute(accessPolicyWindow)",
         )
-
-        result = cudart.cudaStreamSetAttribute(
-            ctypes.c_void_p(stream_ptr),
-            ctypes.c_int(_CUDA_STREAM_ATTRIBUTE_ACCESS_POLICY_WINDOW),
-            ctypes.byref(window),
-        )
-        cudart.cudaGetLastError()  # Clear any stale CUDA error from ctypes call
-        return result == 0
-
-    except (RuntimeError, OSError, ctypes.ArgumentError, AttributeError):
+        return ok is not None
+    except (RuntimeError, AttributeError, TypeError) as e:
+        print(f"[L2] set_tensor_persisting failed: {e}")
         return False
 
 
@@ -270,33 +266,42 @@ def clear_tensor_persisting(tensor: torch.Tensor) -> bool:
     """
     Remove L2 persistence policy for a tensor (reset to normal access).
 
-    Call when a tensor is no longer hot (e.g., model unload) to release
-    the L2 persisting budget for other tensors.
+    Call when a tensor is no longer hot (e.g., model unload) to release the L2
+    persisting budget for other tensors. Also explicitly resets the persisting L2
+    cache lines via cudaCtxResetPersistingL2Cache() -- the docs call out that relying
+    on the driver's automatic reset instead "is strongly discouraged because of the
+    undetermined length of time required", so this never leaves it to chance.
     """
     if not tensor.is_cuda:
         return False
 
-    cudart = _get_cudart()
-    if cudart is None:
-        return False
-
     try:
+        window = cudart.cudaAccessPolicyWindow()
+        window.base_ptr = tensor.data_ptr()
+        window.num_bytes = 0
+        window.hitRatio = 0.0
+        window.hitProp = cudart.cudaAccessProperty.cudaAccessPropertyNormal
+        window.missProp = cudart.cudaAccessProperty.cudaAccessPropertyStreaming
+
+        attr_value = cudart.cudaStreamAttrValue()
+        attr_value.accessPolicyWindow = window
+
         stream_ptr = torch.cuda.current_stream().cuda_stream
-        window = _CudaAccessPolicyWindow(
-            base_ptr=ctypes.c_void_p(tensor.data_ptr()),
-            num_bytes=ctypes.c_size_t(0),
-            hitRatio=ctypes.c_float(0.0),
-            hitProp=ctypes.c_int(_CUDA_ACCESS_PROPERTY_NORMAL),
-            missProp=ctypes.c_int(_CUDA_ACCESS_PROPERTY_STREAMING),
+        ok = _cuda_check(
+            cudart.cudaStreamSetAttribute(
+                stream_ptr,
+                cudart.cudaStreamAttrID.cudaLaunchAttributeAccessPolicyWindow,
+                attr_value,
+            ),
+            "cudaStreamSetAttribute(clear accessPolicyWindow)",
         )
-        result = cudart.cudaStreamSetAttribute(
-            ctypes.c_void_p(stream_ptr),
-            ctypes.c_int(_CUDA_STREAM_ATTRIBUTE_ACCESS_POLICY_WINDOW),
-            ctypes.byref(window),
-        )
-        cudart.cudaGetLastError()  # Clear any stale CUDA error from ctypes call
-        return result == 0
-    except (RuntimeError, OSError, ctypes.ArgumentError, AttributeError):
+        if ok is None:
+            return False
+
+        reset_ok = _cuda_check(cudart.cudaCtxResetPersistingL2Cache(), "cudaCtxResetPersistingL2Cache")
+        return reset_ok is not None
+    except (RuntimeError, AttributeError, TypeError) as e:
+        print(f"[L2] clear_tensor_persisting failed: {e}")
         return False
 
 


### PR DESCRIPTION
## What

Rewrites `tools/cuda_l2_cache.py` onto `cuda.bindings.runtime`'s named enums, with real clamps
on the two values that control the persisting-L2-cache window and a reset call that was
previously missing entirely.

## Changes

- `accessPolicyMaxWindowSize` and `persistingL2CacheMaxSize` are now clamped to the values the
  device actually reports, instead of being passed through unclamped (previously capable of
  requesting a window larger than the device supports, which either silently truncates or
  behaves inconsistently across GPU generations depending on driver version).
- `hitRatio` is computed dynamically from the requested working-set size relative to the
  clamped window, rather than using a fixed ratio that stops matching reality once the window
  itself is clamped.
- Adds the missing `cudaCtxResetPersistingL2Cache()` call — without it, a persisting-L2
  configuration from an earlier context/window setup could continue to influence eviction
  behavior after the working set that justified it is gone.
- Migrates from raw `cudart` integer constants to `cuda.bindings.runtime`'s named enums for
  readability and to avoid magic numbers at each call site.

This is a self-contained, single-file rewrite — reviewable with no reference to the CUDA-stream
work in `pr/trt-capture-stream-events` or `pr/perf-orchestrator-threading`. It does not carry an
accompanying test file (no GPU-independent contract to pin without a real CUDA device driving
the runtime calls it wraps); the module has been validated by direct manual runs against actual
hardware as described in the commit.

## Branch

`pr/l2-persisting-cache` -> `SDTD_040_beta_release`
