### PR TITLE
perf: threaded preprocessing orchestrators with event-gated stream handoff

### DIFF
--- a/src/streamdiffusion/preprocessing/base_orchestrator.py
+++ b/src/streamdiffusion/preprocessing/base_orchestrator.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import contextlib
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Generic, Optional, TypeVar
@@ -44,9 +45,13 @@ class BaseOrchestrator(Generic[T, R], ABC):
 
         # CUDA stream for background processing to avoid GPU contention
         self._background_stream = None
+        self._bg_pre_event: Optional[torch.cuda.Event] = None  # caller stream -> background stream barrier
+        self._bg_post_event: Optional[torch.cuda.Event] = None  # background stream -> consumer stream barrier
         device_str = str(device)
         if device_str.startswith("cuda") and torch.cuda.is_available():
             self._background_stream = torch.cuda.Stream()
+            self._bg_pre_event = torch.cuda.Event()
+            self._bg_post_event = torch.cuda.Event()
 
     def cleanup(self) -> None:
         """Cleanup thread pool and CUDA stream resources"""
@@ -136,6 +141,11 @@ class BaseOrchestrator(Generic[T, R], ABC):
 
     def _start_next_frame_processing(self, input_data: T, *args, **kwargs) -> None:
         """Start processing for next frame in background thread"""
+        # Pre-exec barrier: order the background stream's work after this (caller)
+        # thread's queued work before handing off to the executor. Must happen here,
+        # not inside _process_frame_background -- a worker thread has no notion of
+        # "the caller's current stream" (see _arm_background_handoff).
+        self._arm_background_handoff()
         # Submit background processing
         self._next_frame_future = self._executor.submit(self._process_frame_background, input_data, *args, **kwargs)
 
@@ -145,6 +155,9 @@ class BaseOrchestrator(Generic[T, R], ABC):
             try:
                 # Use configurable timeout based on orchestrator type
                 self._next_frame_result = self._next_frame_future.result(timeout=self.timeout_ms / 1000.0)
+                # Post-exec barrier: make this (consumer) thread's stream wait for the
+                # background stream's work to land, and record_stream() the results.
+                self._consume_background_handoff(self._next_frame_result)
             except concurrent.futures.TimeoutError:
                 # Non-blocking: skip applying results this frame
                 self._next_frame_result = None
@@ -195,25 +208,98 @@ class BaseOrchestrator(Generic[T, R], ABC):
 
         return result["result"]
 
-    def _set_background_stream_context(self):
-        """
-        Set CUDA stream context for background processing.
+    # ------------------------------------------------------------------
+    # Event-based cross-stream handoff for background processing.
+    #
+    # torch.cuda.Stream() is non-blocking by default, so there is no implicit
+    # legacy-stream synchronization between it and whatever stream the caller/
+    # consumer is on -- an explicit event barrier is required on both ends of the
+    # handoff. Mirrors the producer/consumer event protocol already proven in
+    # preprocessing/processors/trt_base.py's TensorRTEngine.infer():
+    #   producer: pre_event.record(); dedicated_stream.wait_event(pre_event); ... work ...
+    #             post_event.record(dedicated_stream)
+    #   consumer: current_stream().wait_event(post_event); tensor.record_stream(current_stream())
+    #
+    # Split across two call sites because _process_frame_background runs in a
+    # ThreadPoolExecutor worker thread: torch.cuda.current_stream() is thread-local,
+    # so "the caller's current stream" can only be read/recorded on the caller
+    # thread itself, before dispatch -- not from inside the worker. See each
+    # method's docstring for exactly which thread must call it.
+    # ------------------------------------------------------------------
 
-        Returns:
-            The original stream to restore later, or None if no background stream
+    def _arm_background_handoff(self) -> None:
+        """
+        Pre-exec barrier: record an event on the CALLING thread's current stream,
+        then make `_background_stream` wait on it before running anything new.
+
+        Must run on the thread whose queued work the background stream needs to
+        wait behind. For the async pipeline path that's `_start_next_frame_processing`,
+        called on the caller thread before dispatch to the executor. For a
+        same-thread caller (e.g. `process_sync`) there is no thread hop, so it may
+        call this immediately before doing the GPU work itself.
         """
         if self._background_stream is not None:
-            original_stream = torch.cuda.current_stream()
-            torch.cuda.set_stream(self._background_stream)
-            return original_stream
-        return None
+            self._bg_pre_event.record()
+            self._background_stream.wait_event(self._bg_pre_event)
 
-    def _restore_stream_context(self, original_stream):
+    def _background_stream_scope(self):
         """
-        Restore the original CUDA stream context.
+        Scope `torch.cuda.current_stream()` (thread-local) to `_background_stream`
+        for GPU work about to run on the calling thread. Records no barrier --
+        callers that need the pre-exec barrier call `_arm_background_handoff()`
+        themselves first (see that method for why it can't just happen here).
 
-        Args:
-            original_stream: The stream to restore, or None to do nothing
+        Returns a context manager (`torch.cuda.stream(...)`), or a no-op context
+        manager if there is no background stream (CPU device).
         """
-        if self._background_stream is not None and original_stream is not None:
-            torch.cuda.set_stream(original_stream)
+        if self._background_stream is None:
+            return contextlib.nullcontext()
+        return torch.cuda.stream(self._background_stream)
+
+    def _finish_background_handoff(self) -> None:
+        """
+        Post-exec barrier, producer side: record the completion event on
+        `_background_stream`. Must be the last GPU-related action taken for this
+        frame's background work, before the consumer touches results -- called
+        from `_process_frame_background`'s `finally` block (still on the worker
+        thread) or, for a same-thread caller, right after its GPU work.
+        """
+        if self._background_stream is not None:
+            self._bg_post_event.record(self._background_stream)
+
+    def _consume_background_handoff(self, result: Any) -> Any:
+        """
+        Post-exec barrier, consumer side: make the CONSUMING thread's current
+        stream wait on `_background_stream`'s completion event, then
+        `record_stream()` every CUDA tensor found in `result` (recursing through
+        list/tuple/dict containers) so PyTorch's caching allocator can't reclaim a
+        buffer the background stream might still be writing.
+
+        Safe to call even when `_finish_background_handoff()` was never reached
+        this frame (e.g. an exception path bailed out early): waiting on a
+        never-recorded `torch.cuda.Event` is a documented no-op -- "If
+        cudaEventRecord() has not been called on event, this call acts as if the
+        record has already completed."
+
+        Returns `result` unchanged, for call-site chaining.
+        """
+        if self._background_stream is None:
+            return result
+        current = torch.cuda.current_stream()
+        current.wait_event(self._bg_post_event)
+        self._record_stream_on_tensors(result, current)
+        return result
+
+    @staticmethod
+    def _record_stream_on_tensors(obj: Any, stream: "torch.cuda.Stream") -> None:
+        """Recurse through list/tuple/dict containers, calling `tensor.record_stream(stream)`
+        on every CUDA tensor found."""
+        if isinstance(obj, torch.Tensor):
+            if obj.is_cuda:
+                obj.record_stream(stream)
+        elif isinstance(obj, dict):
+            for v in obj.values():
+                BaseOrchestrator._record_stream_on_tensors(v, stream)
+        elif isinstance(obj, (list, tuple)):
+            for v in obj:
+                BaseOrchestrator._record_stream_on_tensors(v, stream)

--- a/src/streamdiffusion/preprocessing/pipeline_preprocessing_orchestrator.py
+++ b/src/streamdiffusion/preprocessing/pipeline_preprocessing_orchestrator.py
@@ -110,27 +110,30 @@ class PipelinePreprocessingOrchestrator(BaseOrchestrator[torch.Tensor, torch.Ten
             Dictionary containing processing results and status
         """
         try:
-            # Set CUDA stream for background processing
-            original_stream = self._set_background_stream_context()
+            # Scope this frame's GPU work to the background stream. The pre-exec
+            # barrier (background stream waiting on the caller's queued work) was
+            # already armed by _start_next_frame_processing on the caller thread --
+            # see BaseOrchestrator._arm_background_handoff.
+            with self._background_stream_scope():
+                if not processors:
+                    return {"result": input_tensor, "status": "success"}
 
-            if not processors:
-                return {"result": input_tensor, "status": "success"}
+                # Process processors sequentially (most pipeline preprocessing is dependent)
+                current_tensor = input_tensor
+                for processor in processors:
+                    if processor is not None:
+                        current_tensor = self._apply_single_processor(current_tensor, processor)
 
-            # Process processors sequentially (most pipeline preprocessing is dependent)
-            current_tensor = input_tensor
-            for processor in processors:
-                if processor is not None:
-                    current_tensor = self._apply_single_processor(current_tensor, processor)
-
-            return {"result": current_tensor, "status": "success"}
+                return {"result": current_tensor, "status": "success"}
 
         except Exception as e:
             logger.error(f"PipelinePreprocessingOrchestrator: Background processing failed: {e}")
             # Return original input tensor on error
             return {"result": input_tensor, "error": str(e), "status": "error"}
         finally:
-            # Restore original CUDA stream
-            self._restore_stream_context(original_stream)
+            # Post-exec barrier, producer side: record the background stream's
+            # completion event for the consumer (_consume_background_handoff) to wait on.
+            self._finish_background_handoff()
 
     def _apply_single_processor(self, input_tensor: torch.Tensor, processor: Any) -> torch.Tensor:
         """

--- a/src/streamdiffusion/preprocessing/postprocessing_orchestrator.py
+++ b/src/streamdiffusion/preprocessing/postprocessing_orchestrator.py
@@ -91,18 +91,24 @@ class PostprocessingOrchestrator(BaseOrchestrator[torch.Tensor, torch.Tensor]):
         if not postprocessors:
             return input_tensor
 
-        # Use same stream context as background processing for consistency
-        original_stream = self._set_background_stream_context()
+        # Event-based handoff, all on this thread: arm the pre-exec barrier, run the
+        # postprocessors on the background stream, record the post-exec barrier, then
+        # make this thread's (the consumer's) stream wait on it and record_stream()
+        # the result before returning. Same producer+consumer protocol as
+        # _process_frame_background / _wait_for_previous_processing, collapsed onto a
+        # single thread since process_sync has no executor hop.
+        self._arm_background_handoff()
         try:
-            # Sequential application of postprocessors
-            current_tensor = input_tensor
-            for postprocessor in postprocessors:
-                if postprocessor is not None:
-                    current_tensor = self._apply_single_postprocessor(current_tensor, postprocessor)
-
-            return current_tensor
+            with self._background_stream_scope():
+                # Sequential application of postprocessors
+                current_tensor = input_tensor
+                for postprocessor in postprocessors:
+                    if postprocessor is not None:
+                        current_tensor = self._apply_single_postprocessor(current_tensor, postprocessor)
         finally:
-            self._restore_stream_context(original_stream)
+            self._finish_background_handoff()
+
+        return self._consume_background_handoff(current_tensor)
 
     def _process_frame_background(
         self, input_tensor: torch.Tensor, postprocessors: List[Any], *args, **kwargs
@@ -116,43 +122,45 @@ class PostprocessingOrchestrator(BaseOrchestrator[torch.Tensor, torch.Tensor]):
             Dictionary containing processing results and status
         """
         try:
-            # Set CUDA stream for background processing
-            original_stream = self._set_background_stream_context()
+            # Scope this frame's GPU work to the background stream. The pre-exec
+            # barrier (background stream waiting on the caller's queued work) was
+            # already armed by _start_next_frame_processing on the caller thread --
+            # see BaseOrchestrator._arm_background_handoff.
+            with self._background_stream_scope():
+                if not postprocessors:
+                    return {"result": input_tensor, "status": "success"}
 
-            if not postprocessors:
-                return {"result": input_tensor, "status": "success"}
+                # Check for cache hit using data_ptr + shape — O(1) vs torch.equal's O(N).
+                # TRT engines reuse the same output buffer each frame, so data_ptr identity
+                # reliably detects whether the input is the same buffer as last frame.
+                cache_hit = (
+                    self._last_input_ptr is not None
+                    and self._last_processed_result is not None
+                    and input_tensor.data_ptr() == self._last_input_ptr
+                    and input_tensor.shape == self._last_input_shape
+                )
 
-            # Check for cache hit using data_ptr + shape — O(1) vs torch.equal's O(N).
-            # TRT engines reuse the same output buffer each frame, so data_ptr identity
-            # reliably detects whether the input is the same buffer as last frame.
-            cache_hit = (
-                self._last_input_ptr is not None
-                and self._last_processed_result is not None
-                and input_tensor.data_ptr() == self._last_input_ptr
-                and input_tensor.shape == self._last_input_shape
-            )
+                if cache_hit:
+                    return {
+                        "result": self._last_processed_result,
+                        "status": "success",
+                        "cache_hit": True,
+                    }
 
-            if cache_hit:
-                return {
-                    "result": self._last_processed_result,
-                    "status": "success",
-                    "cache_hit": True,
-                }
+                # Update cache — store ptr + shape, no tensor clone needed
+                self._last_input_ptr = input_tensor.data_ptr()
+                self._last_input_shape = input_tensor.shape
 
-            # Update cache — store ptr + shape, no tensor clone needed
-            self._last_input_ptr = input_tensor.data_ptr()
-            self._last_input_shape = input_tensor.shape
+                # Process postprocessors in parallel if multiple, sequential if single
+                if len(postprocessors) > 1:
+                    result = self._process_postprocessors_parallel(input_tensor, postprocessors)
+                else:
+                    result = self._apply_single_postprocessor(input_tensor, postprocessors[0])
 
-            # Process postprocessors in parallel if multiple, sequential if single
-            if len(postprocessors) > 1:
-                result = self._process_postprocessors_parallel(input_tensor, postprocessors)
-            else:
-                result = self._apply_single_postprocessor(input_tensor, postprocessors[0])
+                # Cache the processed result for future cache hits
+                self._last_processed_result = result
 
-            # Cache the processed result for future cache hits
-            self._last_processed_result = result
-
-            return {"result": result, "status": "success"}
+                return {"result": result, "status": "success"}
 
         except Exception as e:
             logger.error(f"PostprocessingOrchestrator: Background processing failed: {e}")
@@ -162,8 +170,9 @@ class PostprocessingOrchestrator(BaseOrchestrator[torch.Tensor, torch.Tensor]):
                 "status": "error",
             }
         finally:
-            # Restore original CUDA stream
-            self._restore_stream_context(original_stream)
+            # Post-exec barrier, producer side: record the background stream's
+            # completion event for the consumer (_consume_background_handoff) to wait on.
+            self._finish_background_handoff()
 
     def _process_postprocessors_parallel(self, input_tensor: torch.Tensor, postprocessors: List[Any]) -> torch.Tensor:
         """

--- a/src/streamdiffusion/preprocessing/preprocessing_orchestrator.py
+++ b/src/streamdiffusion/preprocessing/preprocessing_orchestrator.py
@@ -119,93 +119,96 @@ class PreprocessingOrchestrator(BaseOrchestrator[ControlImage, List[Optional[tor
             Dictionary containing processing results and status
         """
         try:
-            # Set CUDA stream for background processing
-            original_stream = self._set_background_stream_context()
+            # Scope this frame's GPU work to the background stream. The pre-exec
+            # barrier (background stream waiting on the caller's queued work) was
+            # already armed by _start_next_frame_processing on the caller thread --
+            # see BaseOrchestrator._arm_background_handoff.
+            with self._background_stream_scope():
+                # Check if last argument is "ipadapter" processing type
+                if args and len(args) >= 5 and args[4] == "ipadapter":
+                    # Handle embedding preprocessing
+                    embedding_preprocessors = args[0]
+                    stream_width = args[2]
+                    stream_height = args[3]
 
-            # Check if last argument is "ipadapter" processing type
-            if args and len(args) >= 5 and args[4] == "ipadapter":
-                # Handle embedding preprocessing
-                embedding_preprocessors = args[0]
-                stream_width = args[2]
-                stream_height = args[3]
+                    # Prepare processing data
+                    control_variants = self._prepare_input_variants(control_image, thread_safe=True)
 
-                # Prepare processing data
-                control_variants = self._prepare_input_variants(control_image, thread_safe=True)
+                    # Process using existing IPAdapter logic
+                    try:
+                        results = self._process_ipadapter_preprocessors_parallel(
+                            embedding_preprocessors, control_variants, stream_width, stream_height
+                        )
+                        return {"results": results, "status": "success"}
+                    except Exception as e:
+                        import traceback
 
-                # Process using existing IPAdapter logic
-                try:
-                    results = self._process_ipadapter_preprocessors_parallel(
-                        embedding_preprocessors, control_variants, stream_width, stream_height
+                        traceback.print_exc()
+                        return {"error": str(e), "status": "error"}
+                elif hasattr(self, "_current_processing_mode") and self._current_processing_mode == "embedding":
+                    # Handle embedding preprocessing (legacy path)
+                    embedding_preprocessors = args[0]
+                    stream_width = args[2]
+                    stream_height = args[3]
+
+                    # Prepare processing data
+                    control_variants = self._prepare_input_variants(control_image, thread_safe=True)
+
+                    # Process using existing IPAdapter logic
+                    try:
+                        results = self._process_ipadapter_preprocessors_parallel(
+                            embedding_preprocessors, control_variants, stream_width, stream_height
+                        )
+                        return {"results": results, "status": "success"}
+                    except Exception as e:
+                        import traceback
+
+                        traceback.print_exc()
+                        return {"error": str(e), "status": "error"}
+                else:
+                    # Handle ControlNet preprocessing (default mode)
+                    preprocessors = args[0]
+                    scales = args[1]
+                    stream_width = args[2]
+                    stream_height = args[3]
+
+                    # Check if any processing is needed
+                    if not any(scale > 0 for scale in scales):
+                        return {"status": "success", "results": [None] * len(preprocessors)}
+                    # TODO: can we reuse similarity filter here?
+                    if (
+                        self._last_input_frame is not None
+                        and isinstance(control_image, (torch.Tensor, np.ndarray, Image.Image))
+                        and control_image is self._last_input_frame
+                    ):
+                        return {"status": "success", "results": []}  # Signal no update needed
+
+                    self._last_input_frame = control_image
+
+                    # Prepare processing data
+                    preprocessor_groups = self._group_preprocessors(preprocessors, scales)
+                    active_indices = [i for i, scale in enumerate(scales) if scale > 0]
+
+                    if not active_indices:
+                        return {"status": "success", "results": [None] * len(preprocessors)}
+
+                    # Optimize input preparation
+                    control_variants = self._prepare_input_variants(control_image, thread_safe=True)
+
+                    # Process using unified parallel logic
+                    processed_images = self._process_controlnet_preprocessors_parallel(
+                        preprocessor_groups, control_variants, stream_width, stream_height, preprocessors
                     )
-                    return {"results": results, "status": "success"}
-                except Exception as e:
-                    import traceback
 
-                    traceback.print_exc()
-                    return {"error": str(e), "status": "error"}
-            elif hasattr(self, "_current_processing_mode") and self._current_processing_mode == "embedding":
-                # Handle embedding preprocessing (legacy path)
-                embedding_preprocessors = args[0]
-                stream_width = args[2]
-                stream_height = args[3]
-
-                # Prepare processing data
-                control_variants = self._prepare_input_variants(control_image, thread_safe=True)
-
-                # Process using existing IPAdapter logic
-                try:
-                    results = self._process_ipadapter_preprocessors_parallel(
-                        embedding_preprocessors, control_variants, stream_width, stream_height
-                    )
-                    return {"results": results, "status": "success"}
-                except Exception as e:
-                    import traceback
-
-                    traceback.print_exc()
-                    return {"error": str(e), "status": "error"}
-            else:
-                # Handle ControlNet preprocessing (default mode)
-                preprocessors = args[0]
-                scales = args[1]
-                stream_width = args[2]
-                stream_height = args[3]
-
-                # Check if any processing is needed
-                if not any(scale > 0 for scale in scales):
-                    return {"status": "success", "results": [None] * len(preprocessors)}
-                # TODO: can we reuse similarity filter here?
-                if (
-                    self._last_input_frame is not None
-                    and isinstance(control_image, (torch.Tensor, np.ndarray, Image.Image))
-                    and control_image is self._last_input_frame
-                ):
-                    return {"status": "success", "results": []}  # Signal no update needed
-
-                self._last_input_frame = control_image
-
-                # Prepare processing data
-                preprocessor_groups = self._group_preprocessors(preprocessors, scales)
-                active_indices = [i for i, scale in enumerate(scales) if scale > 0]
-
-                if not active_indices:
-                    return {"status": "success", "results": [None] * len(preprocessors)}
-
-                # Optimize input preparation
-                control_variants = self._prepare_input_variants(control_image, thread_safe=True)
-
-                # Process using unified parallel logic
-                processed_images = self._process_controlnet_preprocessors_parallel(
-                    preprocessor_groups, control_variants, stream_width, stream_height, preprocessors
-                )
-
-                return {"results": processed_images, "status": "success"}
+                    return {"results": processed_images, "status": "success"}
 
         except Exception as e:
             logger.error(f"PreprocessingOrchestrator: Background processing failed: {e}")
             return {"error": str(e), "status": "error"}
         finally:
-            # Restore original CUDA stream
-            self._restore_stream_context(original_stream)
+            # Post-exec barrier, producer side: record the background stream's
+            # completion event for the consumer (_consume_background_handoff) to wait on.
+            self._finish_background_handoff()
 
     def _apply_current_frame_processing(
         self, preprocessors: List[Optional[Any]] = None, scales: List[float] = None, *args, **kwargs

--- a/src/streamdiffusion/preprocessing/processors/faceid_embedding.py
+++ b/src/streamdiffusion/preprocessing/processors/faceid_embedding.py
@@ -1,3 +1,4 @@
+import time
 from typing import Any, Tuple
 
 import torch
@@ -61,13 +62,22 @@ class FaceIDEmbeddingPreprocessor(IPAdapterEmbeddingPreprocessor):
             Tuple of (positive_embeds, negative_embeds) for FaceID conditioning
         """
         try:
+            # Wall-clock, not profiler.region(): profiler's CUDA-event timing only measures
+            # GPU kernel time, but the "update image" freeze is the render thread blocking on
+            # InsightFace's synchronous session.run() calls — CPU-thread stall, not GPU time.
+            # Also zero-config (no GPU_PROFILER=1 needed) so it's always visible in this log.
+            # Baseline measurement for the FaceID render-thread-freeze fix — see FaceID_PLAN.md
+            # cost-reduction patches (faceid_compat.py) and the plan's staged Stage 1/Stage 2 split.
+            _t0 = time.perf_counter()
             # Use the IP-Adapter's FaceID-specific embedding extraction
             image_embeds, negative_embeds = self.ipadapter.get_image_embeds(
                 images=[image], faceid_v2_weight=self.faceid_v2_weight
             )
+            _elapsed_ms = (time.perf_counter() - _t0) * 1000.0
 
             print(
-                f"FaceIDEmbeddingPreprocessor._process_core: Generated FaceID embeddings - positive: {image_embeds.shape}, negative: {negative_embeds.shape}"
+                f"FaceIDEmbeddingPreprocessor._process_core: Generated FaceID embeddings in "
+                f"{_elapsed_ms:.1f}ms - positive: {image_embeds.shape}, negative: {negative_embeds.shape}"
             )
 
             return image_embeds, negative_embeds

--- a/src/streamdiffusion/preprocessing/processors/hed_tensorrt.py
+++ b/src/streamdiffusion/preprocessing/processors/hed_tensorrt.py
@@ -124,6 +124,7 @@ class HEDTensorrtPreprocessor(SelfBuildingTRTPreprocessor):
                     "input": {0: "batch", 2: "height", 3: "width"},
                     "output": {0: "batch", 2: "height", 3: "width"},
                 },
+                dynamo=False,
             )
 
         logger.info(f"HEDTensorrtPreprocessor: ONNX exported → {onnx_path}")

--- a/src/streamdiffusion/preprocessing/processors/normal_bae_tensorrt.py
+++ b/src/streamdiffusion/preprocessing/processors/normal_bae_tensorrt.py
@@ -81,6 +81,7 @@ def _probe_normal_bae_onnx_export(device: str = "cuda") -> bool:
                 opset_version=17,
                 input_names=["input"],
                 output_names=["output"],
+                dynamo=False,
             )
         _TRT_STRATEGY_AVAILABLE = os.path.exists(tmp) and os.path.getsize(tmp) > 0
         if os.path.exists(tmp):
@@ -291,6 +292,7 @@ class NormalBaeTensorrtPreprocessor(SelfBuildingTRTPreprocessor):
                     "input": {0: "batch", 2: "height", 3: "width"},
                     "output": {0: "batch", 2: "height", 3: "width"},
                 },
+                dynamo=False,
             )
 
         logger.info(f"NormalBaeTensorrtPreprocessor: ONNX exported → {onnx_path}")

--- a/src/streamdiffusion/preprocessing/processors/realesrgan_trt.py
+++ b/src/streamdiffusion/preprocessing/processors/realesrgan_trt.py
@@ -294,6 +294,7 @@ class RealESRGANProcessor(BasePreprocessor):
                 opset_version=17,
                 export_params=True,
                 dynamic_axes=dynamic_axes,
+                dynamo=False,
             )
 
     def _setup_tensorrt(self):
@@ -327,10 +328,24 @@ class RealESRGANProcessor(BasePreprocessor):
             return
 
         try:
+            # Reuse the shared BUILD_TRT_LOGGER (see acceleration/tensorrt/utilities.py)
+            # instead of throwaway trt.Logger() instances. TRT registers exactly ONE
+            # ILogger globally (first trt.Builder/Runtime/Refitter wins), so a fresh
+            # logger here either loses that race silently or wins it and leaves the main
+            # engine builds without BUILD_TRT_LOGGER's benign myelin/l2tc noise filter.
+            # Falls back to a plain logger if the acceleration package isn't importable
+            # (e.g. a standalone preprocessor-only environment).
+            try:
+                from streamdiffusion.acceleration.tensorrt.utilities import BUILD_TRT_LOGGER
+
+                trt_logger = BUILD_TRT_LOGGER
+            except ImportError:
+                trt_logger = trt.Logger(trt.Logger.WARNING)
+
             # Create builder and network
-            builder = trt.Builder(trt.Logger(trt.Logger.WARNING))
+            builder = trt.Builder(trt_logger)
             network = builder.create_network()  # EXPLICIT_BATCH deprecated/ignored in TRT 10.x
-            parser = trt.OnnxParser(network, trt.Logger(trt.Logger.WARNING))
+            parser = trt.OnnxParser(network, trt_logger)
 
             # Parse ONNX model
             with open(self.onnx_path, "rb") as model:

--- a/src/streamdiffusion/preprocessing/processors/trt_base.py
+++ b/src/streamdiffusion/preprocessing/processors/trt_base.py
@@ -459,9 +459,23 @@ class SelfBuildingTRTPreprocessor(BasePreprocessor):
         if not onnx_path.exists():
             raise FileNotFoundError(f"ONNX model not found: {onnx_path}")
 
-        builder = trt.Builder(trt.Logger(trt.Logger.WARNING))
+        # Reuse the shared BUILD_TRT_LOGGER (see acceleration/tensorrt/utilities.py)
+        # instead of throwaway trt.Logger() instances. TRT registers exactly ONE
+        # ILogger globally (first trt.Builder/Runtime/Refitter wins), so a fresh
+        # logger here either loses that race silently or wins it and leaves the main
+        # engine builds without BUILD_TRT_LOGGER's benign myelin/l2tc noise filter.
+        # Falls back to a plain logger if the acceleration package isn't importable
+        # (e.g. a standalone preprocessor-only environment).
+        try:
+            from streamdiffusion.acceleration.tensorrt.utilities import BUILD_TRT_LOGGER
+
+            trt_logger = BUILD_TRT_LOGGER
+        except ImportError:
+            trt_logger = trt.Logger(trt.Logger.WARNING)
+
+        builder = trt.Builder(trt_logger)
         network = builder.create_network()
-        parser = trt.OnnxParser(network, trt.Logger(trt.Logger.WARNING))
+        parser = trt.OnnxParser(network, trt_logger)
 
         with open(onnx_path, "rb") as f:
             if not parser.parse(f.read()):

--- a/tests/unit/test_ipc_input_channel_order.py
+++ b/tests/unit/test_ipc_input_channel_order.py
@@ -1,0 +1,183 @@
+"""Tests for the R<->B channel-swap fix on the TD -> StreamDiffusion CUDA-IPC
+input path (`TouchDesignerManager._unpack_hwc_to_rgb` in td_manager.py).
+
+Root cause: TD's 8-bit 4-channel CUDA memory is BGRA-ordered (TD's own
+documented preference), and the output side (`StreamDiffusionWrapper._pack_bgra`,
+wrapper.py) already accounts for that with a `flip(-1)`. The input side did not
+-- it only stripped alpha (`gpu_frame[:, :, :3]`) with no channel-order
+correction -- so an 8-bit round trip came back with red and blue swapped.
+`_unpack_hwc_to_rgb` is the fix: the mirror of `_pack_bgra` on the consumer
+side, applying the same swap decision cuda-link's wire metadata supports
+(`FLAGS_BGRA`) with a dtype fallback for senders that don't set it.
+
+td_manager.py cannot be imported directly in a fast unit test -- it pulls in
+timm/controlnet_aux/torch-dynamo at import time (~8s) -- so this file follows
+the precedent in test_td_pending_params.py and freezes an exact replica of
+`_unpack_hwc_to_rgb` below. Keep it in sync with td_manager.py's copy (and its
+byte-identical Scripts/ mirror, checked at the bottom of this file); if the
+swap logic changes there, update it here too or these tests go stale silently.
+
+Round-trip tests pair this replica against the REAL
+`StreamDiffusionWrapper._pack_bgra` (imported directly -- wrapper.py is light
+enough to import, see test_ipc_pack_bgra_correctness.py) so the output-side and
+input-side halves of the wire contract are exercised together, not just each
+one's own self-consistency in isolation. Uses saturated primaries (R/G/B/W
+quadrants), not random data: test_ipc_pack_bgra_correctness.py's `randint`
+approach locks the pack's self-consistency but is blind to whether a matching
+unpack exists -- that blindness is how the underlying bug shipped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from streamdiffusion.wrapper import StreamDiffusionWrapper
+
+# Mirrors cuda_link.shm_protocol.FLAGS_BGRA (bit2: 4-channel uint8 source is
+# BGRA-ordered, not RGBA). Frozen here rather than imported so these tests
+# don't require cuda_link to be installed.
+FLAGS_BGRA = 0x0004
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA device required")
+DEVICES = ["cpu", pytest.param("cuda", marks=requires_cuda)]
+
+
+def _unpack_hwc_to_rgb(gpu_frame: torch.Tensor, flags: int) -> torch.Tensor:
+    """Frozen replica of TouchDesignerManager._unpack_hwc_to_rgb (td_manager.py).
+
+    Swap decision, in priority order:
+      1. flags & FLAGS_BGRA set          -> swap
+      2. flags == 0 and frame is uint8x4 -> swap (dtype fallback)
+      3. otherwise                        -> no swap
+    """
+    is_4ch = gpu_frame.ndim == 3 and gpu_frame.shape[2] == 4
+    should_swap = is_4ch and (bool(flags & FLAGS_BGRA) or (flags == 0 and gpu_frame.dtype == torch.uint8))
+    if is_4ch:
+        gpu_frame = gpu_frame[:, :, :3]
+    if should_swap:
+        gpu_frame = gpu_frame.flip(-1)
+    return gpu_frame
+
+
+def _rgbw_quadrants(size: int = 4, device: str = "cpu") -> torch.Tensor:
+    """(2*size, 2*size, 3) uint8 HWC tensor: R top-left, G top-right, B
+    bottom-left, W bottom-right -- the same saturated-primary pattern used to
+    observe the bug (green/white are invariant under R<->B, which is what rules
+    out a vertical flip as the explanation).
+    """
+    h = w = size
+    img = torch.zeros((2 * h, 2 * w, 3), dtype=torch.uint8, device=device)
+    img[:h, :w] = torch.tensor([255, 0, 0], dtype=torch.uint8, device=device)  # R top-left
+    img[:h, w:] = torch.tensor([0, 255, 0], dtype=torch.uint8, device=device)  # G top-right
+    img[h:, :w] = torch.tensor([0, 0, 255], dtype=torch.uint8, device=device)  # B bottom-left
+    img[h:, w:] = torch.tensor([255, 255, 255], dtype=torch.uint8, device=device)  # W bottom-right
+    return img
+
+
+# ---------------------------------------------------------------------------
+# Round-trip identity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_round_trip_identity_saturated_primaries(device):
+    """pack_bgra (output side) -> _unpack_hwc_to_rgb (input side) must be the
+    identity on the RGBW pattern, both via the dtype fallback (today's Python
+    td_exporter, which sets no flag) and via the explicit flag (e.g. cuda-link's
+    C++ TOP)."""
+    rgb = _rgbw_quadrants(device=device)
+    packed = torch.zeros((rgb.shape[0], rgb.shape[1], 4), dtype=torch.uint8, device=device)
+    packed[..., 3] = 255
+    StreamDiffusionWrapper._pack_bgra(rgb, packed)
+
+    recovered_fallback = _unpack_hwc_to_rgb(packed, flags=0)
+    assert torch.equal(recovered_fallback, rgb)
+
+    recovered_flagged = _unpack_hwc_to_rgb(packed, flags=FLAGS_BGRA)
+    assert torch.equal(recovered_flagged, rgb)
+
+
+def test_round_trip_fails_without_fix_documents_the_bug():
+    """Sanity check that this is a real bug, not a test artifact: stripping
+    alpha with no channel-order correction (the pre-fix behaviour) does not
+    recover the original RGB from a BGRA-ordered 4-channel uint8 frame, and
+    reproduces exactly the reported symptom -- red and blue swapped, green and
+    white unmoved."""
+    rgb = _rgbw_quadrants()
+    packed = torch.zeros((rgb.shape[0], rgb.shape[1], 4), dtype=torch.uint8)
+    packed[..., 3] = 255
+    StreamDiffusionWrapper._pack_bgra(rgb, packed)
+
+    pre_fix = packed[:, :, :3]  # strip alpha only -- the old td_manager.py behaviour
+    assert not torch.equal(pre_fix, rgb)
+    assert pre_fix[0, 0].tolist() == [0, 0, 255]  # red source read back as blue
+    assert pre_fix[0, -1].tolist() == rgb[0, -1].tolist()  # green: unmoved
+    assert pre_fix[-1, -1].tolist() == rgb[-1, -1].tolist()  # white: unmoved
+
+
+# ---------------------------------------------------------------------------
+# Helper truth table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "flags,dtype,should_swap",
+    [
+        pytest.param(FLAGS_BGRA, torch.uint8, True, id="flag_set-uint8"),
+        pytest.param(FLAGS_BGRA, torch.float32, True, id="flag_set-float32"),
+        pytest.param(0, torch.uint8, True, id="flag_clear-uint8_fallback"),
+        pytest.param(0, torch.float32, False, id="flag_clear-float32_no_swap"),
+    ],
+)
+def test_unpack_truth_table_4channel(flags, dtype, should_swap):
+    if dtype == torch.uint8:
+        frame = torch.tensor([[[10, 20, 30, 255]]], dtype=torch.uint8)
+        expected_swapped = torch.tensor([[[30, 20, 10]]], dtype=torch.uint8)
+    else:
+        frame = torch.tensor([[[0.1, 0.2, 0.3, 1.0]]], dtype=torch.float32)
+        expected_swapped = torch.tensor([[[0.3, 0.2, 0.1]]], dtype=torch.float32)
+    expected_unswapped = frame[:, :, :3]
+
+    result = _unpack_hwc_to_rgb(frame, flags)
+    expected = expected_swapped if should_swap else expected_unswapped
+    assert torch.equal(result, expected)
+
+
+def test_unpack_3channel_never_swaps_regardless_of_flags():
+    """FLAGS_BGRA is defined only for 4-channel uint8 sources (SHMProtocol.py);
+    a 3-channel (no-alpha) frame must pass through untouched either way."""
+    frame = torch.tensor([[[10, 20, 30]]], dtype=torch.uint8)
+    for flags in (0, FLAGS_BGRA):
+        assert torch.equal(_unpack_hwc_to_rgb(frame, flags), frame)
+
+
+# ---------------------------------------------------------------------------
+# Mirror parity -- the baked DAT mirror must carry the identical fix, or a
+# backend-only change is silently overridden at runtime. td_manager.py is not
+# yet registered in scripts/sync_td_mirror.py's PAIRS (only td_main.py and
+# syphon_utils.py are), so this checks it directly rather than via that tool's
+# test (test_td_mirror_sync.py).
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CANONICAL = _REPO_ROOT / "StreamDiffusionTD" / "td_manager.py"
+_MIRROR = _REPO_ROOT.parent / "Scripts" / "streamdiffusionTD__Text__td_manager__td.py"
+
+_skip_no_mirror = pytest.mark.skipif(
+    not _MIRROR.is_file(),
+    reason=f"{_MIRROR} not present (bare clone without the surrounding dev tree)",
+)
+
+
+@_skip_no_mirror
+def test_td_manager_mirror_matches_canonical():
+    assert _CANONICAL.is_file(), f"Canonical source not found: {_CANONICAL}"
+    canonical_text = _CANONICAL.read_text(encoding="utf-8")
+    mirror_text = _MIRROR.read_text(encoding="utf-8")
+    assert canonical_text == mirror_text, (
+        f"{_MIRROR.name} is out of sync with {_CANONICAL.name}. "
+        "Hand-apply the same edit to both files (not wired into sync_td_mirror.py)."
+    )


### PR DESCRIPTION
## What

Replaces a raw stream-context swap across all four preprocessing/postprocessing orchestrator
call sites with an explicit pre/post-event barrier protocol, and threads the orchestrators so
preprocessing work overlaps with the rest of the frame pipeline instead of serializing against
it.

## Changes

- **Event-barrier protocol**: `base_orchestrator.py` and its three concrete orchestrators
  (`pipeline_preprocessing_orchestrator.py`, `postprocessing_orchestrator.py`,
  `preprocessing_orchestrator.py`) previously swapped CUDA stream context directly around each
  call site. That's replaced with explicit pre-event/post-event pairs bracketing each
  handoff, so the consumer side has an actual ordering guarantee instead of relying on the
  swap's incidental timing.
  This branch was cut and tested standalone against `SDTD_040_beta_release` (cross-branch
  symbol audit + full unit suite, no import or symbol errors) — its orchestrator changes do not
  require `pr/trt-capture-stream-events`'s `utilities.py` changes to compile or run; the two are
  independent despite originating from the same fork commit.
- **`BUILD_TRT_LOGGER` dedup**: the TRT logger singleton was being constructed redundantly
  across the five TensorRT-backed processors (`faceid_embedding.py`, `hed_tensorrt.py`,
  `normal_bae_tensorrt.py`, `realesrgan_trt.py`, `trt_base.py`); now shared from one place.
- Threading changes to the orchestrators so preprocessing runs concurrently with the rest of the
  frame pipeline rather than blocking it.

## Cross-PR notes

- `preprocessing/processors/faceid_embedding.py`: also touched by PR 4
  (`pr/faceid-loader-hardening`) for FaceID correctness reasons unrelated to this PR's threading
  concern. Both changes are needed independently.
- **`test_ipc_input_channel_order.py`** pins `StreamDiffusionWrapper._pack_bgra`'s BGRA
  round-trip against a frozen replica of the TouchDesigner-side consumer. It does not import
  `td_manager.py` itself (that would pull in `timm`/`controlnet_aux`/`dynamo`) — its
  mirror-parity check is `skipif`-guarded on the referenced files' absence, so it's safe to run
  on a clean upstream clone with no TD component installed. The matching fix on the consumer
  side (`td_manager.py`'s IPC input-channel handling) ships separately to
  `dotsimulate/StreamDiffusionTD`, not in this repo — see that fork's forthcoming
  `fix/td-ipc-input-channel-order` PR.

## Tests

`tests/unit/test_ipc_input_channel_order.py` (described above). Orchestrator threading and
event-barrier behavior are otherwise covered by the existing orchestrator test surface, which is
unchanged in shape by this PR.

## Branch

`pr/perf-orchestrator-threading` -> `SDTD_040_beta_release`
