### PR TITLE
feat: make LoRA Weight a live runtime tensor

### DIFF
--- a/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
+++ b/src/streamdiffusion/acceleration/tensorrt/engine_manager.py
@@ -83,14 +83,25 @@ class EngineManager:
     def _lora_signature(self, lora_dict: Dict[str, float]) -> str:
         """Create a short, stable signature for a set of LoRAs.
 
-        Uses sorted basenames and weights, hashed to a short hex to avoid
-        long/invalid paths while keeping cache keys stable across runs.
+        Post-Workstream-A: LoRA weight is a live runtime tensor (lora_scale),
+        never baked into the engine, so it is deliberately EXCLUDED from this
+        signature -- changing a weight must reuse the cached engine, not
+        rebuild it (that's the entire point of the change). Basename alone is
+        NOT enough, though: two different files can share a name (e.g. several
+        "style.safetensors" trained on different runs), which would silently
+        load the wrong weights into a matching cache dir. File size + mtime
+        are cheap insurance against that collision.
         """
-        # Build canonical string of basename:weight pairs
         parts = []
-        for path, weight in sorted(lora_dict.items(), key=lambda x: str(x[0])):
-            base = Path(str(path)).name  # basename only
-            parts.append(f"{base}:{weight}")
+        for path, _weight in sorted(lora_dict.items(), key=lambda x: str(x[0])):
+            p = Path(str(path))
+            base = p.name  # basename only
+            try:
+                stat = p.stat()
+                size, mtime = stat.st_size, int(stat.st_mtime)
+            except OSError:
+                size, mtime = -1, -1
+            parts.append(f"{base}:{size}:{mtime}")
         canon = "|".join(parts)
         h = hashlib.sha1(canon.encode("utf-8")).hexdigest()[:10]
         return f"{len(lora_dict)}-{h}"
@@ -266,12 +277,22 @@ class EngineManager:
                 if ipadapter_tokens is not None:
                     prefix += f"--tokens{ipadapter_tokens}"
 
-                # Fused Loras - use concise hashed signature to avoid long/invalid paths.
-                # Only UNet engines bake LoRA weights; VAE and other standard engines are
-                # LoRA-agnostic, so scoping the suffix to UNET prevents redundant VAE rebuilds
-                # every time the LoRA dict changes.
+                # Live (unfused) LoRAs — concise hashed signature to avoid long/invalid
+                # paths. Only UNet engines carry LoRA adapters; VAE and other standard
+                # engines are LoRA-agnostic, so scoping the suffix to UNET prevents
+                # redundant VAE rebuilds every time the LoRA set changes.
+                #
+                # "--loradyn" is MANDATORY whenever a LoRA is loaded, not a defensive
+                # extra: Engine.infer silently drops any feed_dict key the loaded engine
+                # doesn't declare as a binding (utilities.py filtered_feed_dict), so
+                # feeding the new lora_scale tensor to a pre-Workstream-A engine (built
+                # with LoRA weights fused into the UNet, no lora_scale input at all)
+                # would not error -- it would just discard the tensor and reproduce the
+                # exact dead-slider bug this feature exists to fix. The tag's job is
+                # purely to fork every such stale engine into a fresh cache directory;
+                # its value never needs to change again after that one-time fork.
                 if lora_dict is not None and len(lora_dict) > 0:
-                    prefix += f"--lora-{self._lora_signature(lora_dict)}"
+                    prefix += f"--lora-{self._lora_signature(lora_dict)}--loradyn"
 
                 prefix += f"--use_cached_attn-{use_cached_attn}"
                 # FI suffix MUST come right after cached_attn so stale engines
@@ -646,6 +667,12 @@ class EngineManager:
             # number of IP-attention layers for runtime vector sizing
             if "num_ip_layers" in kwargs and kwargs["num_ip_layers"] is not None:
                 loaded_engine.num_ip_layers = kwargs["num_ip_layers"]
+
+        # Live (unfused) LoRA — see unet_engine.py._check_use_lora(). num_loras sizes
+        # the lora_scale vector the runtime updater indexes into via stream._lora_order.
+        loaded_engine.use_lora = kwargs.get("use_lora_trt", False)
+        if kwargs.get("use_lora_trt", False):
+            loaded_engine.num_loras = kwargs.get("num_loras", 0)
 
     def get_or_load_controlnet_engine(
         self,

--- a/src/streamdiffusion/acceleration/tensorrt/export_wrappers/unet_unified_export.py
+++ b/src/streamdiffusion/acceleration/tensorrt/export_wrappers/unet_unified_export.py
@@ -1,7 +1,8 @@
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import torch
 from diffusers import UNet2DConditionModel
+from peft.tuners.tuners_utils import BaseTunerLayer
 
 from streamdiffusion._patches.diffusers_kvo_patch import apply as _apply_kvo_patch
 
@@ -52,6 +53,60 @@ def _collect_fi_processors(unet: UNet2DConditionModel) -> List:
     return procs
 
 
+def _collect_lora_layers(
+    unet: torch.nn.Module, lora_order: List[Tuple[str, str]]
+) -> Dict[str, List[Tuple[BaseTunerLayer, float]]]:
+    """Walk ``unet.named_modules()`` and, for every adapter name in ``lora_order``,
+    capture every ``BaseTunerLayer`` carrying that adapter along with its base PEFT
+    scaling (``lora_alpha / r``, established once by ``pipe.set_adapters(..., 1.0)``
+    at load time — see wrapper.py's live-adapter-activation block). ``_set_lora_scale``
+    multiplies this base value by the live ``lora_scale`` tensor every forward pass.
+
+    Fails loudly (``RuntimeError``) rather than shipping an inert slider: every touched
+    layer must be vanilla LoRA (no DoRA/other ``lora_variant``), unmerged, and not
+    adapter-disabled — the three states under which PEFT's ``scaling`` dict multiply is
+    bypassed entirely (``peft/tuners/lora/layer.py``'s forward()/merge()/unmerge()).
+    """
+    adapter_names = {adapter_name for _path, adapter_name in lora_order}
+    layers: Dict[str, List[Tuple[BaseTunerLayer, float]]] = {name: [] for name in adapter_names}
+
+    for module_path, module in unet.named_modules():
+        if not isinstance(module, BaseTunerLayer):
+            continue
+        for adapter_name in adapter_names:
+            if adapter_name not in module.scaling:
+                continue
+            if adapter_name in module.lora_variant:
+                raise RuntimeError(
+                    f"LoRA adapter '{adapter_name}' uses a non-vanilla PEFT variant "
+                    f"(e.g. DoRA) on module '{module_path}'. The runtime lora_scale "
+                    f"tensor only patches the vanilla scaling path "
+                    f"('result + lora_B(lora_A(x)) * scaling' in peft's layer.py) — a "
+                    f"variant adapter would silently ignore it and ship an inert slider. "
+                    f"Refusing to export rather than do that."
+                )
+            if module.merged:
+                raise RuntimeError(
+                    f"LoRA adapter '{adapter_name}' is merged into module '{module_path}'. "
+                    f"Dynamic lora_scale requires every adapter to stay live/unfused."
+                )
+            if module.disable_adapters:
+                raise RuntimeError(
+                    f"LoRA adapter '{adapter_name}' is disabled on module '{module_path}'. "
+                    f"Dynamic lora_scale requires every adapter to stay active."
+                )
+            layers[adapter_name].append((module, module.scaling[adapter_name]))
+
+    for adapter_name in adapter_names:
+        if not layers[adapter_name]:
+            raise RuntimeError(
+                f"LoRA adapter '{adapter_name}' was requested via lora_order but no PEFT "
+                f"BaseTunerLayer in the UNet carries it — nothing to scale."
+            )
+
+    return layers
+
+
 class UnifiedExportWrapper(torch.nn.Module):
     """
     Unified wrapper that composes wrappers for conditioning modules.
@@ -59,6 +114,7 @@ class UnifiedExportWrapper(torch.nn.Module):
     Positional args in ``forward`` (after the three base inputs) follow this order:
 
         ipadapter_scale  (optional, only when use_ipadapter=True; stripped before routing)
+        lora_scale       (optional, [N] fp32, only when num_loras>0; stripped before routing)
         kvo_cache_in_0 … kvo_cache_in_N     (kvo_cache_count tensors)
         fio_cache_in_<idx0> … fio_cache_in_<idxM>   (fi_layer_count tensors, FI only)
         fi_strength                          (scalar [1] fp32, FI only)
@@ -79,6 +135,7 @@ class UnifiedExportWrapper(torch.nn.Module):
         num_tokens: int = 4,
         kvo_cache_structure: Optional[List[int]] = None,
         fi_layer_count: int = 0,
+        lora_order: Optional[List[Tuple[str, str]]] = None,
         **kwargs,
     ):
         super().__init__()
@@ -90,6 +147,7 @@ class UnifiedExportWrapper(torch.nn.Module):
         self.unet = unet
         self.kvo_cache_structure = kvo_cache_structure
         self.fi_layer_count = fi_layer_count
+        self._lora_order: List[Tuple[str, str]] = lora_order or []
 
         # Precompute kvo cache count for arg-splitting in _basic_unet_forward
         self._kvo_cache_count: int = sum(sum(block) for block in kvo_cache_structure)
@@ -110,6 +168,14 @@ class UnifiedExportWrapper(torch.nn.Module):
             self.controlnet_wrapper = create_controlnet_wrapper(
                 self.unet, control_input_names, kvo_cache_structure, **controlnet_kwargs
             )
+
+        # Collect every PEFT BaseTunerLayer touched by a loaded LoRA adapter, capturing
+        # its base scaling (lora_alpha/r) and asserting the vanilla/unmerged/enabled
+        # invariants dynamic scaling depends on. Raises RuntimeError immediately on any
+        # violation — see _collect_lora_layers' docstring.
+        self._lora_layers: Dict[str, List[Tuple[BaseTunerLayer, float]]] = (
+            _collect_lora_layers(self.unet, self._lora_order) if self._lora_order else {}
+        )
 
         # Best-effort collection at construction time — may return [] if processors are
         # not yet installed (e.g. when wrapper.py constructs UnifiedExportWrapper before
@@ -154,6 +220,29 @@ class UnifiedExportWrapper(torch.nn.Module):
             proc._fi_cache = fi_slice
             proc._fi_strength = fi_strength
             proc._fi_threshold = fi_threshold
+
+    def _set_lora_scale(self, lora_scale: torch.Tensor) -> None:
+        """Write the live per-adapter weight into every PEFT layer's ``scaling`` dict
+        before the UNet forward.
+
+        Mirrors ``set_ipadapter_scale`` (unet_ipadapter_export.py) and ``_set_fi_cache``
+        above: the traced tensor is stashed directly on the consuming object (here,
+        PEFT's ``BaseTunerLayer.scaling`` dict, normally a plain float) so the ONNX
+        tracer follows the data edge without threading the argument through every
+        transformer block. ``base_scale`` is ``lora_alpha/r``, captured once at adapter-
+        activation time in wrapper.py — multiplying it back in here reproduces
+        ``fuse_lora(lora_scale=w)``'s exact math, just live instead of baked in.
+
+        NOTE: this assigns a tensor into a dict PEFT's own code treats as floats
+        (``LoraLayer.scaling``). Safe for the vanilla forward() multiply this class
+        guards for (see ``_collect_lora_layers``), but PEFT helpers such as
+        ``scale_layer``/``unscale_layer``/``scale_lora_layers`` are not called anywhere
+        in this codebase and would misbehave against a tensor value if that changes.
+        """
+        for i, (_path, adapter_name) in enumerate(self._lora_order):
+            weight = lora_scale[i]
+            for module, base_scale in self._lora_layers[adapter_name]:
+                module.scaling[adapter_name] = base_scale * weight
 
     def _basic_unet_forward(self, sample, timestep, encoder_hidden_states, *args, **kwargs):
         """Basic UNet forward that passes through all parameters to handle any model type.
@@ -257,6 +346,16 @@ class UnifiedExportWrapper(torch.nn.Module):
             # assign per-layer scale tensors into processors
             self.ipadapter_wrapper.set_ipadapter_scale(ipadapter_scale)
             # remove it from control args before passing to controlnet wrapper
+            args = args[1:]
+
+        if self._lora_order:
+            # lora_scale is appended right after ipadapter_scale (see class docstring)
+            if len(args) == 0:
+                raise RuntimeError("UnifiedExportWrapper: lora_scale tensor is required when LoRA adapters are loaded")
+            lora_scale = args[0]
+            if not isinstance(lora_scale, torch.Tensor):
+                raise TypeError(f"lora_scale must be a torch.Tensor, got {type(lora_scale)}")
+            self._set_lora_scale(lora_scale)
             args = args[1:]
 
         if self.controlnet_wrapper:

--- a/src/streamdiffusion/acceleration/tensorrt/models/models.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/models.py
@@ -453,6 +453,8 @@ class UNet(BaseModel):
         use_ipadapter=False,
         num_image_tokens=4,
         num_ip_layers: int = None,
+        use_lora: bool = False,
+        num_loras: int = 0,
         use_cached_attn: bool = False,
         cache_maxframes: int = 1,
         min_cache_maxframes: int = 1,
@@ -489,6 +491,14 @@ class UNet(BaseModel):
             self.text_maxlen = text_maxlen + self.num_image_tokens
             if self.num_ip_layers is None:
                 raise ValueError("UNet model requires num_ip_layers when use_ipadapter=True")
+
+        # Dynamic LoRA scale — a live [num_loras] fp32 vector, one entry per loaded
+        # adapter, index-aligned with stream._lora_order. See UnifiedExportWrapper /
+        # _collect_lora_layers for how the tensor value reaches PEFT's scaling dict.
+        self.use_lora = use_lora
+        self.num_loras = num_loras
+        if self.use_lora and self.num_loras <= 0:
+            raise ValueError("UNet model requires num_loras > 0 when use_lora=True")
 
         if self.use_control and self.unet_arch:
             self.control_inputs = self.get_control(image_height, image_width)
@@ -673,6 +683,8 @@ class UNet(BaseModel):
                 logging.getLogger(__name__).debug(f"TRT Models: get_input_names with ipadapter -> {base_names}")
             except Exception:
                 pass
+        if self.use_lora:
+            base_names.append("lora_scale")
         if self.use_control and self.control_inputs:
             control_names = sorted(self.control_inputs.keys())
             base_names = base_names + control_names
@@ -722,6 +734,9 @@ class UNet(BaseModel):
                 )
             except Exception:
                 pass
+
+        if self.use_lora:
+            base_axes["lora_scale"] = {0: "L_lora"}
 
         if self.use_control and self.control_inputs:
             for name, shape_spec in self.control_inputs.items():
@@ -831,6 +846,14 @@ class UNet(BaseModel):
             except Exception:
                 pass
 
+        if self.use_lora:
+            # scalar per-adapter vector, length fixed to num_loras
+            profile["lora_scale"] = [
+                (1,),
+                (self.num_loras,),
+                (self.num_loras,),
+            ]
+
         if self.use_control and self.control_inputs:
             # Use the actual calculated spatial dimensions for each ControlNet input
             # Each control input has its own specific spatial resolution based on UNet architecture
@@ -899,6 +922,9 @@ class UNet(BaseModel):
             except Exception:
                 pass
 
+        if self.use_lora:
+            shape_dict["lora_scale"] = (self.num_loras,)
+
         if self.use_control and self.control_inputs:
             # Use the actual calculated spatial dimensions for each ControlNet input
             for name, shape_spec in self.control_inputs.items():
@@ -963,6 +989,9 @@ class UNet(BaseModel):
 
         if self.use_ipadapter:
             base_inputs.append(torch.ones(self.num_ip_layers, dtype=torch.float32, device=self.device))
+
+        if self.use_lora:
+            base_inputs.append(torch.ones(self.num_loras, dtype=torch.float32, device=self.device))
 
         if self.use_control and self.control_inputs:
             control_inputs = []

--- a/src/streamdiffusion/acceleration/tensorrt/runtime_engines/unet_engine.py
+++ b/src/streamdiffusion/acceleration/tensorrt/runtime_engines/unet_engine.py
@@ -33,6 +33,7 @@ class UNet2DConditionModelEngine:
 
         # Cache expensive attribute lookups to avoid repeated getattr calls
         self._use_ipadapter_cached = None
+        self._use_lora_cached = None
 
         # Pre-compute ControlNet input names to avoid string formatting in hot paths
         # Support up to 20 ControlNet inputs (more than enough for typical use cases)
@@ -97,6 +98,12 @@ class UNet2DConditionModelEngine:
         if self._use_ipadapter_cached is None:
             self._use_ipadapter_cached = getattr(self, "use_ipadapter", False)
         return self._use_ipadapter_cached
+
+    def _check_use_lora(self) -> bool:
+        """Cache live-LoRA detection to avoid repeated getattr calls"""
+        if self._use_lora_cached is None:
+            self._use_lora_cached = getattr(self, "use_lora", False)
+        return self._use_lora_cached
 
     def __call__(
         self,
@@ -181,6 +188,21 @@ class UNet2DConditionModelEngine:
                 raise TypeError("ipadapter_scale must be a torch.Tensor")
             shape_dict["ipadapter_scale"] = ip_scale.shape
             input_dict["ipadapter_scale"] = ip_scale
+
+        # Handle LoRA runtime scale vector if engine was built with live (unfused)
+        # LoRA adapters. lora_scale is required whenever use_lora is set — a stale
+        # engine built before this metadata existed would never have use_lora=True,
+        # so this branch only fires for engines that actually declare the binding.
+        if self._check_use_lora():
+            if "lora_scale" not in kwargs:
+                logger.error("UNet2DConditionModelEngine: lora_scale missing but required (use_lora=True)")
+                raise RuntimeError("UNet2DConditionModelEngine: lora_scale is required for live-LoRA engines")
+            lora_scale = kwargs["lora_scale"]
+            if not isinstance(lora_scale, torch.Tensor):
+                logger.error(f"UNet2DConditionModelEngine: lora_scale has wrong type: {type(lora_scale)}")
+                raise TypeError("lora_scale must be a torch.Tensor")
+            shape_dict["lora_scale"] = lora_scale.shape
+            input_dict["lora_scale"] = lora_scale
 
         # Handle ControlNet inputs if provided
         if controlnet_conditioning is not None:

--- a/src/streamdiffusion/param_schema.py
+++ b/src/streamdiffusion/param_schema.py
@@ -1,7 +1,7 @@
 """Single source of truth for the runtime-tunable StreamDiffusion parameter set.
 
-This module owns parameter *identity* — the 26 names accepted by
-:meth:`StreamDiffusionWrapper.update_stream_params`, which of those 24 are
+This module owns parameter *identity* — the 27 names accepted by
+:meth:`StreamDiffusionWrapper.update_stream_params`, which of those 25 are
 forwarded to :meth:`StreamParameterUpdater.update_stream_params`, and each
 param's *construction-time* default (the value a fresh wrapper gets when the
 key is absent from config — see ``config._extract_wrapper_params`` and
@@ -105,12 +105,16 @@ PARAMS: Tuple[ParamSpec, ...] = (
     ParamSpec("cn_cache_decay", 0.0),
     ParamSpec("fi_strength", 0.75),
     ParamSpec("fi_threshold", 0.98),
+    # {lora_path: weight} — live per-adapter LoRA weight dial. See
+    # StreamParameterUpdater._update_lora_weights; resolved against
+    # stream._lora_order (index<->path mapping set once at load time).
+    ParamSpec("lora_weights", None),
 )
 
-# All 26 params the wrapper accepts, in wrapper signature order.
+# All 27 params the wrapper accepts, in wrapper signature order.
 PARAM_NAMES: Tuple[str, ...] = tuple(p.name for p in PARAMS)
 
-# The 24 params forwarded to the updater, in updater signature order
+# The 25 params forwarded to the updater, in updater signature order
 # (a contiguous subsequence of PARAM_NAMES once use_safety_checker /
 # safety_checker_threshold are removed).
 UPDATER_PARAM_NAMES: Tuple[str, ...] = tuple(p.name for p in PARAMS if p.updater)

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -231,6 +231,15 @@ class StreamDiffusion:
         # warp attenuation and vice versa.
         self._fi_strength_base: float = fi_strength
 
+        # Runtime-adjustable LoRA weight — a [num_loras] fp32 vector, one entry per
+        # loaded adapter, index-aligned with stream._lora_order. LoRA loading happens
+        # in wrapper.py._load_model *after* this constructor returns (adapters are
+        # discovered from lora_dict there, not here), so this starts None and is set
+        # for real by that call once _lora_order is known. Unlike fi_strength there is
+        # no per-frame recomputation in unet_step — only stream_parameter_updater
+        # mutates it in place (CUDA-graph-safe: same device address across frames).
+        self._lora_scale_tensor: Optional[torch.Tensor] = None
+
         # Pre-allocated CUDA timing events — reused every frame via .record()
         self._timing_start = torch.cuda.Event(enable_timing=True)
         self._timing_end = torch.cuda.Event(enable_timing=True)
@@ -1215,6 +1224,7 @@ class StreamDiffusion:
                             fio_cache=self.fio_cache,
                             fi_strength=self._fi_strength_tensor,
                             fi_threshold=self._fi_threshold_tensor,
+                            lora_scale=self._lora_scale_tensor,
                             **extra_kwargs,
                             # For TRT engines, ensure SDXL cond shapes match engine builds; if engine expects 81 tokens (77+4), append dummy image tokens when none
                             **added_cond_kwargs,  # SDXL conditioning as kwargs
@@ -1273,6 +1283,7 @@ class StreamDiffusion:
                     ip_scale_kw["fio_cache"] = self.fio_cache
                     ip_scale_kw["fi_strength"] = self._fi_strength_tensor
                     ip_scale_kw["fi_threshold"] = self._fi_threshold_tensor
+                    ip_scale_kw["lora_scale"] = self._lora_scale_tensor
 
                 _unet_result = self.unet(
                     x_t_latent_plus_uc,

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -240,6 +240,12 @@ class StreamDiffusion:
         # mutates it in place (CUDA-graph-safe: same device address across frames).
         self._lora_scale_tensor: Optional[torch.Tensor] = None
 
+        # Ordered (path, adapter_name) list wrapper.py._load_model populates once LoRA
+        # adapters are discovered from lora_dict — the index<->path mapping consumed by
+        # unet_unified_export.py and stream_parameter_updater.py. Declared here (not just
+        # assigned dynamically in wrapper.py) so static type checking can resolve it.
+        self._lora_order: List[Tuple[str, str]] = []
+
         # Pre-allocated CUDA timing events — reused every frame via .record()
         self._timing_start = torch.cuda.Event(enable_timing=True)
         self._timing_end = torch.cuda.Event(enable_timing=True)

--- a/src/streamdiffusion/stream_parameter_updater.py
+++ b/src/streamdiffusion/stream_parameter_updater.py
@@ -51,7 +51,12 @@ class StreamParameterUpdater(OrchestratorUser):
         # Atomic update lock for deterministic, thread-safe runtime updates
         self._update_lock = threading.RLock()
         # Prompt blending caches
-        self._prompt_cache: Dict[int, Dict] = {}
+        # Keyed by prompt text (not list position): dedupes repeated prompt
+        # text across positions, survives Promptblock() skipping an empty
+        # concept (which shifts every later index), and needs no reindexing
+        # on insert/remove/reorder. See _cache_prompt_embeddings /
+        # _apply_prompt_blending.
+        self._prompt_cache: Dict[str, Dict] = {}
         self._current_prompt_list: List[Tuple[str, float]] = []
         self._current_negative_prompt: str = ""
         self._prompt_cache_stats = CacheStats()
@@ -320,6 +325,7 @@ class StreamParameterUpdater(OrchestratorUser):
         cn_cache_decay: Optional[float] = None,
         fi_strength: Optional[float] = None,
         fi_threshold: Optional[float] = None,
+        lora_weights: Optional[Dict[str, float]] = None,
     ) -> None:
         """Update streaming parameters efficiently in a single call."""
 
@@ -564,6 +570,77 @@ class StreamParameterUpdater(OrchestratorUser):
                     self.stream._fi_threshold_tensor.fill_(float(fi_threshold))
                     logger.info(f"update_stream_params: fi_threshold -> {fi_threshold:.6f}")
 
+            # LoRA weight — live dial, see _update_lora_weights for the TRT/PyTorch split.
+            if lora_weights is not None:
+                self._update_lora_weights(lora_weights)
+
+    def _update_lora_weights(self, lora_weights: Dict[str, float]) -> None:
+        """
+        Update the live runtime weight for one or more loaded LoRA adapters.
+
+        Args:
+            lora_weights: {lora_path: weight} — paths are matched against
+                          stream._lora_order (set once at load time in
+                          wrapper.py._load_model) after normalizing to forward
+                          slashes, mirroring that module's own convention. A path
+                          that isn't currently loaded is logged and skipped rather
+                          than raising — an OSC client a frame ahead of a LoRA
+                          reload/removal should not kill the stream.
+        """
+        lora_order = getattr(self.stream, "_lora_order", None)
+        if not lora_order:
+            logger.warning("update_stream_params: lora_weights given but no LoRA adapters are loaded")
+            return
+
+        tensor = getattr(self.stream, "_lora_scale_tensor", None)
+        if tensor is None:
+            # Should be impossible whenever _lora_order is non-empty (wrapper.py
+            # allocates both together), but guard rather than crash the stream.
+            logger.warning("update_stream_params: lora_weights given but _lora_scale_tensor is not allocated")
+            return
+
+        # Resolve path -> index once so both update targets below (the TRT tensor
+        # and, for PyTorch, PEFT's own scaling dict) apply the identical value.
+        resolved: Dict[int, float] = {}
+        for raw_path, weight in lora_weights.items():
+            norm_path = str(raw_path).replace("\\", "/")
+            for idx, (lora_name, _adapter_name) in enumerate(lora_order):
+                if lora_name == norm_path:
+                    resolved[idx] = float(weight)
+                    break
+            else:
+                logger.warning(f"update_stream_params: lora_weights path not found in loaded adapters: {raw_path!r}")
+
+        if not resolved:
+            return
+
+        # TensorRT path: write straight into the persistent [num_loras] tensor in
+        # place (same device address every frame -- CUDA-graph-safe). The export
+        # wrapper's _set_lora_scale (unet_unified_export.py) multiplies this
+        # against each adapter's base_scaling = lora_alpha/r on every forward
+        # call, so an in-place write here is enough for TRT.
+        for idx, weight in resolved.items():
+            tensor[idx] = weight
+
+        # Non-TensorRT path: there is no export wrapper to apply that multiply --
+        # stream.unet is the live PyTorch UNet, and its PEFT LoraLayers read
+        # self.scaling[adapter] fresh every forward(). Re-issue set_adapters()
+        # with the full current vector (tensor is now the source of truth for
+        # every adapter, not just the ones just written) so PyTorch gets the
+        # same live-dial behavior as TRT (see wrapper.py's matching comment at
+        # the original set_adapters() activation call).
+        is_tensorrt_engine = hasattr(self.stream.unet, "engine") and hasattr(self.stream.unet, "stream")
+        if not is_tensorrt_engine:
+            adapter_names = [adapter_name for _lora_name, adapter_name in lora_order]
+            current_weights = [float(tensor[i].item()) for i in range(len(lora_order))]
+            try:
+                self.stream.pipe.set_adapters(adapter_names, adapter_weights=current_weights)
+            except Exception as e:
+                logger.warning(f"update_stream_params: failed to re-apply LoRA weights on PyTorch UNet: {e}")
+
+        for idx, weight in resolved.items():
+            logger.info(f"update_stream_params: LoRA '{lora_order[idx][0]}' weight -> {weight:.4f}")
+
     @torch.inference_mode()
     def _update_blended_prompts(
         self,
@@ -583,26 +660,36 @@ class StreamParameterUpdater(OrchestratorUser):
         self._apply_prompt_blending(prompt_interpolation_method)
 
     def _cache_prompt_embeddings(self, prompt_list: List[Tuple[str, float]], negative_prompt: str) -> None:
-        """Cache prompt embeddings for efficient reuse."""
-        for idx, (prompt_text, weight) in enumerate(prompt_list):
-            if idx not in self._prompt_cache or self._prompt_cache[idx]["text"] != prompt_text:
-                # Cache miss - encode the prompt
-                self._prompt_cache_stats.record_miss()
-                encoder_output = self.stream.pipe.encode_prompt(
-                    prompt=prompt_text,
-                    device=self.stream.device,
-                    num_images_per_prompt=1,
-                    do_classifier_free_guidance=False,
-                    negative_prompt=negative_prompt,
-                )
-                # Evict oldest entry if cache is full
-                if len(self._prompt_cache) >= 32:
-                    oldest_key = next(iter(self._prompt_cache))
-                    del self._prompt_cache[oldest_key]
-                self._prompt_cache[idx] = {"embed": encoder_output[0], "text": prompt_text}
-            else:
+        """Cache prompt embeddings for efficient reuse.
+
+        Keyed by prompt text rather than list position, so a weight-only
+        change or a reorder never triggers a re-encode, and duplicate prompt
+        text at different positions shares one cached embedding. The eviction
+        cap floors at 32 (the original limit) but grows to this call's own
+        list length, so a single legitimate prompt_list can never be made to
+        self-evict entries it still needs mid-call -- eviction still only
+        removes the oldest-inserted (FIFO) entries not referenced by this call.
+        """
+        cache_cap = max(32, len(prompt_list))
+        for prompt_text, _weight in prompt_list:
+            if prompt_text in self._prompt_cache:
                 # Cache hit
                 self._prompt_cache_stats.record_hit()
+                continue
+            # Cache miss - encode the prompt
+            self._prompt_cache_stats.record_miss()
+            encoder_output = self.stream.pipe.encode_prompt(
+                prompt=prompt_text,
+                device=self.stream.device,
+                num_images_per_prompt=1,
+                do_classifier_free_guidance=False,
+                negative_prompt=negative_prompt,
+            )
+            # Evict oldest entry if cache is full
+            if len(self._prompt_cache) >= cache_cap:
+                oldest_key = next(iter(self._prompt_cache))
+                del self._prompt_cache[oldest_key]
+            self._prompt_cache[prompt_text] = {"embed": encoder_output[0]}
 
     def _apply_prompt_blending(
         self, prompt_interpolation_method: Literal["average", "slerp", "cosine_weighted"]
@@ -613,11 +700,23 @@ class StreamParameterUpdater(OrchestratorUser):
 
         embeddings = []
         weights = []
+        missing = []
 
-        for idx, (prompt_text, weight) in enumerate(self._current_prompt_list):
-            if idx in self._prompt_cache:
-                embeddings.append(self._prompt_cache[idx]["embed"])
+        for prompt_text, weight in self._current_prompt_list:
+            cached = self._prompt_cache.get(prompt_text)
+            if cached is not None:
+                embeddings.append(cached["embed"])
                 weights.append(weight)
+            else:
+                missing.append(prompt_text)
+
+        if missing:
+            logger.warning(
+                "_apply_prompt_blending: %d prompt(s) have no cached embedding and were "
+                "dropped from the blend: %r",
+                len(missing),
+                missing,
+            )
 
         if not embeddings:
             logger.warning("_apply_prompt_blending: Warning: No cached embeddings found")
@@ -1413,33 +1512,10 @@ class StreamParameterUpdater(OrchestratorUser):
         old_prompt, weight = self._current_prompt_list[index]
         self._current_prompt_list[index] = (new_prompt, weight)
 
-        # Cache the new prompt embedding
+        # Cache the new prompt embedding. Keyed by text, so this is a hit if
+        # new_prompt is already cached (e.g. reused elsewhere in the list) and
+        # a miss otherwise -- no separate lookup-or-encode dance needed here.
         self._cache_prompt_embeddings([(new_prompt, weight)], self._current_negative_prompt)
-
-        # Update cache index to point to the new prompt
-        if index in self._prompt_cache and self._prompt_cache[index]["text"] != new_prompt:
-            # Find if this prompt is already cached elsewhere
-            existing_cache_key = None
-            for cache_idx, cache_data in self._prompt_cache.items():
-                if cache_data["text"] == new_prompt:
-                    existing_cache_key = cache_idx
-                    break
-
-            if existing_cache_key is not None:
-                # Reuse existing cached embedding
-                self._prompt_cache[index] = self._prompt_cache[existing_cache_key].copy()
-                self._prompt_cache_stats.record_hit()
-            else:
-                # Encode new prompt
-                self._prompt_cache_stats.record_miss()
-                encoder_output = self.stream.pipe.encode_prompt(
-                    prompt=new_prompt,
-                    device=self.stream.device,
-                    num_images_per_prompt=1,
-                    do_classifier_free_guidance=False,
-                    negative_prompt=self._current_negative_prompt,
-                )
-                self._prompt_cache[index] = {"embed": encoder_output[0], "text": new_prompt}
 
         # Recompute blended embeddings with updated prompt
         self._apply_prompt_blending(prompt_interpolation_method)
@@ -1458,19 +1534,11 @@ class StreamParameterUpdater(OrchestratorUser):
     ) -> None:
         """Add a new prompt to the current list."""
         prompt_interpolation_method = prompt_interpolation_method or self._last_prompt_interpolation_method
-        new_index = len(self._current_prompt_list)
         self._current_prompt_list.append((prompt, weight))
 
-        # Cache the new prompt
-        encoder_output = self.stream.pipe.encode_prompt(
-            prompt=prompt,
-            device=self.stream.device,
-            num_images_per_prompt=1,
-            do_classifier_free_guidance=False,
-            negative_prompt=self._current_negative_prompt,
-        )
-        self._prompt_cache[new_index] = {"embed": encoder_output[0], "text": prompt}
-        self._prompt_cache_stats.record_miss()
+        # Cache the new prompt (hit if this text is already cached elsewhere
+        # in the list, miss otherwise -- same helper update_stream_params uses).
+        self._cache_prompt_embeddings([(prompt, weight)], self._current_negative_prompt)
 
         # Recompute blended embeddings
         self._apply_prompt_blending(prompt_interpolation_method)
@@ -1490,15 +1558,10 @@ class StreamParameterUpdater(OrchestratorUser):
             logger.warning("remove_prompt_at_index: Warning: Cannot remove last prompt")
             return
 
-        # Remove from current list
+        # Remove from current list. The cache is keyed by prompt text, not
+        # position, so no reindexing is needed (unlike _seed_cache below,
+        # which is still index-keyed and uses _reindex_cache after a removal).
         self._current_prompt_list.pop(index)
-
-        # Remove from cache and reindex
-        if index in self._prompt_cache:
-            del self._prompt_cache[index]
-
-        # Shift cache indices down
-        self._prompt_cache = self._reindex_cache(self._prompt_cache, index)
 
         # Recompute blended embeddings
         self._apply_prompt_blending(prompt_interpolation_method)

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -1015,6 +1015,8 @@ class StreamDiffusionWrapper:
         # Feature Injection live-tunable params (in-place tensor update, no engine rebuild)
         fi_strength: Optional[float] = None,
         fi_threshold: Optional[float] = None,
+        # LoRA weight — live tensor update, no engine rebuild (see _lora_scale_tensor)
+        lora_weights: Optional[Dict[str, float]] = None,
     ) -> None:
         """
         Update streaming parameters efficiently in a single call.
@@ -1083,6 +1085,12 @@ class StreamDiffusionWrapper:
             Feature Injection blend weight alpha (0.0-1.0).
         fi_threshold : Optional[float]
             Feature Injection cosine-similarity gate (0.0-1.0).
+        lora_weights : Optional[Dict[str, float]]
+            {lora_path: weight} for one or more currently-loaded LoRA adapters.
+            Applied as a live runtime dial (in-place tensor write for TensorRT,
+            direct PEFT set_adapters() re-application otherwise) — no engine
+            rebuild. A path not among the LoRAs loaded at stream construction is
+            logged and skipped; loading a *new* LoRA still requires a restart.
         """
         # Skip re-encoding if the incoming prompt_list is identical to the cached one.
         # OSC delivers list-of-lists from JSON; normalise to (str, float) tuples before
@@ -1131,6 +1139,7 @@ class StreamDiffusionWrapper:
                 cn_cache_decay=cn_cache_decay,
                 fi_strength=fi_strength,
                 fi_threshold=fi_threshold,
+                lora_weights=lora_weights,
             )
         finally:
             if needs_encoding:
@@ -2212,7 +2221,12 @@ class StreamDiffusionWrapper:
             # per-frame base * warp-attenuation write uses the actually-configured strength.
             stream._fi_strength_base = float(fi_strength)
 
-        # Load and properly merge LoRA weights using the standard diffusers approach
+        # Load LoRA weights as live PEFT adapters — never fused/merged into UNet weights.
+        # Fusing (fuse_lora + unload_lora_weights, the pre-A1 approach) baked the scale
+        # into fp16 weights permanently, which is exactly what made `Weight` a
+        # restart-required parameter that forced a full engine rebuild on every change.
+        # Keeping the adapters live and routing the scale through a runtime tensor (see
+        # _set_lora_scale in unet_unified_export.py) is what makes it a live dial instead.
         lora_adapters_to_merge = []
         lora_scales_to_merge = []
         # adapter_name → (lora_name, lora_scale) for only successfully loaded adapters (G1 fix)
@@ -2224,20 +2238,12 @@ class StreamDiffusionWrapper:
                 adapter_name = f"custom_lora_{i}"
                 logger.info(f"_load_model: Loading LoRA '{lora_name}' with scale {lora_scale}")
 
-                # G8 fix: scale-0 fuse is a mathematical no-op (W + 0·ΔW = W), so skip
-                # loading and fusing entirely.  The entry is also excluded from
-                # _loaded_adapter_names so the G1 block at the end of the loop naturally
-                # drops it from the engine cache signature — a lora_dict with only
-                # zero-scale entries collapses to None and reuses the baseline UNet engine.
-                # Note: negative scales are valid (subtract the LoRA delta), so skip == 0
-                # exactly, not <= 0.
-                if lora_scale == 0:
-                    logger.info(
-                        f"_load_model: Skipping zero-scale LoRA '{lora_name}' — "
-                        "no effect on weights; engine will match baseline cache"
-                    )
-                    continue
-
+                # A1: a zero-scale LoRA must still be loaded and baked into the graph as
+                # an adapter — the scale is now a live tensor that can be raised later
+                # without a rebuild. The old G8 skip-on-zero short-circuit (and its
+                # "reuses the baseline engine" behavior) is retired: under dynamic weight,
+                # skipping zero would make 0 a trap door that still needs a rebuild to
+                # leave. Note: negative scales are valid (subtract the LoRA delta).
                 try:
                     # Load LoRA weights with unique adapter name
                     stream.load_lora(lora_name, adapter_name=adapter_name)
@@ -2250,31 +2256,57 @@ class StreamDiffusionWrapper:
                     # Drop this entry — do NOT carry it into the engine cache key (G1 fix)
                     continue
 
-        # Merge all LoRA adapters using the proper diffusers method
+        # Activate every loaded adapter. For TensorRT, this only establishes each
+        # adapter's base_scaling = lora_alpha/r baseline via PEFT's set_scale() — the
+        # *live* per-adapter scale is applied per forward call as a runtime tensor
+        # (_set_lora_scale multiplies this baseline by the traced lora_scale input), so
+        # unit weight is passed here deliberately, not lora_scale.
+        #
+        # Non-TensorRT builds (acceleration="none"/"xformers") never construct an
+        # export wrapper, so nothing would ever apply that multiply — PEFT's own
+        # forward() reads self.scaling[adapter] fresh every call, so applying the
+        # actual configured weight directly here is both correct and sufficient (a
+        # free live-adjustable LoRA for that path, no runtime tensor needed). Applying
+        # unit weight there instead would silently strand every non-TRT LoRA at
+        # baseline strength — a regression versus the old fuse_lora(lora_scale=w).
+        # Re-applied again after a TensorRT OOM fallback below, since that swaps
+        # stream.unet back to the raw PyTorch module after this ran the TRT branch.
         if lora_adapters_to_merge:
+            _lora_adapter_weights = (
+                [1.0] * len(lora_adapters_to_merge) if acceleration == "tensorrt" else lora_scales_to_merge
+            )
             try:
-                for adapter_name, scale in zip(lora_adapters_to_merge, lora_scales_to_merge):
-                    logger.info(f"Merging individual LoRA: {adapter_name} with scale {scale}")
-                    stream.pipe.fuse_lora(lora_scale=scale, adapter_names=[adapter_name])
-
-                # Clean up after individual merging
-                stream.pipe.unload_lora_weights()
-                logger.info("Successfully merged LoRAs individually")
-
-            except Exception as fuse_error:
-                # Partial fusion leaves UNet weights in an ambiguous state; baking a TRT engine
-                # from this state creates a permanently mislabeled or corrupted engine (G1 fix).
-                try:
-                    stream.pipe.unload_lora_weights()
-                except Exception:
-                    logger.debug("LoRA cleanup: unload_lora_weights() failed after merge failure", exc_info=True)
+                stream.pipe.set_adapters(lora_adapters_to_merge, adapter_weights=_lora_adapter_weights)
+                logger.info(f"Activated {len(lora_adapters_to_merge)} LoRA adapter(s) (live, unfused)")
+            except Exception as activate_error:
                 raise RuntimeError(
-                    f"LoRA fusion failed — cannot build TRT engine with partial UNet state. Error: {fuse_error}"
-                ) from fuse_error
+                    f"LoRA activation failed — cannot build engine with partial adapter state. "
+                    f"Error: {activate_error}"
+                ) from activate_error
 
-        # G1 fix: Correct lora_dict to only contain successfully fused LoRAs so that
+        # Ordered adapter list — the index<->path mapping the export wrapper
+        # (unet_unified_export.py) and the runtime updater (stream_parameter_updater.py)
+        # both need to translate a lora_scale tensor slot back to a LoRA path. Path
+        # normalized to forward slashes to match the YAML config builder's convention.
+        stream._lora_order = [
+            (_loaded_adapter_names[a][0].replace("\\", "/"), a) for a in lora_adapters_to_merge
+        ]
+
+        # Persistent fp32 [num_loras] tensor — the runtime lora_scale engine input.
+        # Initialized to the configured per-LoRA weights (not 1.0) so the very first
+        # frame reproduces the old fuse_lora(lora_scale=w) result exactly; later
+        # updates come from stream_parameter_updater, which mutates this in place
+        # (same device address across frames, CUDA-graph-safe — mirrors
+        # _fi_strength_tensor/_fi_threshold_tensor above).
+        stream._lora_scale_tensor = (
+            torch.tensor(lora_scales_to_merge, dtype=torch.float32, device=stream.device)
+            if lora_adapters_to_merge
+            else None
+        )
+
+        # G1 fix: Correct lora_dict to only contain successfully loaded LoRAs so that
         # get_engine_path() computes the correct engine cache signature.  Any LoRA that
-        # failed to load was never merged into UNet weights; the engine must NOT carry
+        # failed to load was never activated as an adapter; the engine must NOT carry
         # its signature in the cache path.
         if lora_dict is not None:
             fused_lora_dict = {
@@ -2571,7 +2603,12 @@ class StreamDiffusionWrapper:
                 )
                 logger.debug(f"compile_and_load_engine: use_ipadapter_trt={use_ipadapter_trt}, tokens={num_tokens}")
 
-                # Note: LoRA weights have already been merged permanently during model loading
+                # LoRA adapters stay live/unfused (see the load-time block above) — their
+                # scale is a runtime engine input (lora_scale) rather than a baked-in
+                # weight, so num_loras/lora_order below flow into both the wrapper and
+                # the UNet model_config that declares the graph input.
+                use_lora_trt = bool(getattr(stream, "_lora_order", None))
+                num_loras = len(stream._lora_order) if use_lora_trt else 0
 
                 # CRITICAL: Install IPAdapter module BEFORE TensorRT compilation to ensure processors are baked into engines
                 if use_ipadapter and ipadapter_config and not hasattr(stream, "_ipadapter_module"):
@@ -2676,6 +2713,7 @@ class StreamDiffusionWrapper:
                     use_ipadapter=use_ipadapter_trt,
                     control_input_names=None,
                     num_tokens=num_tokens,
+                    lora_order=stream._lora_order if use_lora_trt else None,
                 )
 
                 num_ip_layers = None
@@ -2700,6 +2738,8 @@ class StreamDiffusionWrapper:
                     use_ipadapter=use_ipadapter_trt,
                     num_image_tokens=num_tokens,
                     num_ip_layers=num_ip_layers if use_ipadapter_trt else None,
+                    use_lora=use_lora_trt,
+                    num_loras=num_loras,
                     image_height=self.height,
                     image_width=self.width,
                     use_cached_attn=use_cached_attn,
@@ -2725,6 +2765,7 @@ class StreamDiffusionWrapper:
                     num_tokens=num_tokens,
                     kvo_cache_structure=kvo_cache_structure,
                     fi_layer_count=getattr(unet_model, "fi_cache_count", 0),
+                    lora_order=stream._lora_order if use_lora_trt else None,
                 )
 
                 if use_cached_attn:
@@ -3047,6 +3088,8 @@ class StreamDiffusionWrapper:
                         use_ipadapter_trt=use_ipadapter_trt,
                         unet_arch=unet_arch,
                         num_ip_layers=num_ip_layers if use_ipadapter_trt else None,
+                        use_lora_trt=use_lora_trt,
+                        num_loras=num_loras,
                         engine_build_options=_unet_build_opts,
                     )
                     if load_engine:
@@ -3092,6 +3135,25 @@ class StreamDiffusionWrapper:
                             if hasattr(stream, "pipe") and hasattr(stream.pipe, "unet"):
                                 stream.unet = stream.pipe.unet
                                 logger.info("PyTorch UNet fallback successful")
+                                # The set_adapters() call above this TRT attempt used
+                                # unit weight (base_scaling only), expecting the export
+                                # wrapper to multiply the runtime tensor in. There is no
+                                # export wrapper on this PyTorch fallback path, so
+                                # re-apply the actual configured weights directly —
+                                # otherwise every loaded LoRA silently runs at baseline
+                                # strength instead of its configured Weight.
+                                if lora_adapters_to_merge:
+                                    try:
+                                        stream.pipe.set_adapters(
+                                            lora_adapters_to_merge, adapter_weights=lora_scales_to_merge
+                                        )
+                                        logger.info(
+                                            "Re-applied configured LoRA weight(s) directly for PyTorch OOM fallback"
+                                        )
+                                    except Exception as lora_reapply_error:
+                                        logger.warning(
+                                            f"Failed to re-apply LoRA weights after OOM fallback: {lora_reapply_error}"
+                                        )
                             else:
                                 raise RuntimeError("No PyTorch UNet available for fallback")
                         except Exception as fallback_error:
@@ -3356,7 +3418,8 @@ class StreamDiffusionWrapper:
                 logger.error("Failed to install IPAdapterModule")
                 raise
 
-        # Note: LoRA weights have already been merged permanently during model loading
+        # Note: LoRA weights stay live/unfused (see the load-time adapter-activation
+        # block) — weight is a runtime tensor (lora_scale), not baked into UNet weights.
 
         # Install pipeline hook modules (Phase 4: Configuration Integration)
         if image_preprocessing_config and image_preprocessing_config.get("enabled", True):

--- a/tests/unit/test_engine_path_ipadapter_suffixes.py
+++ b/tests/unit/test_engine_path_ipadapter_suffixes.py
@@ -191,3 +191,108 @@ class TestFp8RecipeTagOrthogonalToIpAdapterSuffixes:
         )
 
         assert len({neither, noattn, noip, both}) == 4
+
+
+class TestUnetPathLoraSuffix:
+    """Workstream A / A5: get_engine_path's LoRA cache-key suffix (_lora_signature)
+    deliberately EXCLUDES weight -- dragging the runtime `Weight` slider must reuse the
+    cached engine, not rebuild it, which is the entire point of making LoRA weight a
+    live tensor instead of something fused into the exported UNet graph. It must still
+    fork on the file's actual identity though: several coexisting LoRA files can share a
+    basename (e.g. multiple training-run checkpoints all saved as
+    sepiagraph_woolsey.safetensors in different folders), so basename alone would
+    silently load the wrong weights into a matching cache dir. size+mtime is the guard
+    against that collision.
+    """
+
+    def test_unet_path_same_when_lora_weight_changes(self, tmp_path):
+        lora_file = tmp_path / "style_a.safetensors"
+        lora_file.write_bytes(b"fake-lora-weights")
+        em = _make_engine_manager()
+        path_low = em.get_engine_path(
+            engine_type=EngineType.UNET, is_faceid=False, lora_dict={str(lora_file): 0.3}, **_BASE_KWARGS
+        )
+        path_high = em.get_engine_path(
+            engine_type=EngineType.UNET, is_faceid=False, lora_dict={str(lora_file): 0.9}, **_BASE_KWARGS
+        )
+
+        assert path_low == path_high
+
+    def test_unet_path_differs_when_lora_file_changes(self, tmp_path):
+        file_a = tmp_path / "style_a.safetensors"
+        file_b = tmp_path / "style_b.safetensors"
+        file_a.write_bytes(b"fake-lora-weights-a")
+        file_b.write_bytes(b"fake-lora-weights-b")
+        em = _make_engine_manager()
+        path_a = em.get_engine_path(
+            engine_type=EngineType.UNET, is_faceid=False, lora_dict={str(file_a): 0.5}, **_BASE_KWARGS
+        )
+        path_b = em.get_engine_path(
+            engine_type=EngineType.UNET, is_faceid=False, lora_dict={str(file_b): 0.5}, **_BASE_KWARGS
+        )
+
+        assert path_a != path_b
+
+    def test_unet_path_differs_when_basename_collides_but_content_differs(self, tmp_path):
+        """Same basename, different folders/content (the sepiagraph_* scenario) must
+        still fork -- basename-only signing would silently alias them."""
+        dir_a = tmp_path / "run_a"
+        dir_b = tmp_path / "run_b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        file_a = dir_a / "style.safetensors"
+        file_b = dir_b / "style.safetensors"
+        file_a.write_bytes(b"a" * 100)
+        file_b.write_bytes(b"b" * 250)
+        em = _make_engine_manager()
+        path_a = em.get_engine_path(
+            engine_type=EngineType.UNET, is_faceid=False, lora_dict={str(file_a): 0.5}, **_BASE_KWARGS
+        )
+        path_b = em.get_engine_path(
+            engine_type=EngineType.UNET, is_faceid=False, lora_dict={str(file_b): 0.5}, **_BASE_KWARGS
+        )
+
+        assert path_a != path_b
+
+    def test_unet_path_no_lora_and_empty_lora_dict_are_equivalent(self):
+        em = _make_engine_manager()
+        path_none = em.get_engine_path(engine_type=EngineType.UNET, is_faceid=False, lora_dict=None, **_BASE_KWARGS)
+        path_empty = em.get_engine_path(engine_type=EngineType.UNET, is_faceid=False, lora_dict={}, **_BASE_KWARGS)
+
+        assert path_none == path_empty
+
+    def test_unet_path_forks_on_lora_presence(self, tmp_path):
+        lora_file = tmp_path / "style_a.safetensors"
+        lora_file.write_bytes(b"fake-lora-weights")
+        em = _make_engine_manager()
+        path_none = em.get_engine_path(engine_type=EngineType.UNET, is_faceid=False, lora_dict=None, **_BASE_KWARGS)
+        path_lora = em.get_engine_path(
+            engine_type=EngineType.UNET, is_faceid=False, lora_dict={str(lora_file): 1.0}, **_BASE_KWARGS
+        )
+
+        assert path_none != path_lora
+
+    def test_unet_path_is_deterministic_with_lora(self, tmp_path):
+        """Same LoRA config -> same path, so a previously-built engine is reused."""
+        lora_file = tmp_path / "style_a.safetensors"
+        lora_file.write_bytes(b"fake-lora-weights")
+        em = _make_engine_manager()
+        kwargs = dict(_BASE_KWARGS, engine_type=EngineType.UNET, is_faceid=False, lora_dict={str(lora_file): 0.5})
+
+        path_a = em.get_engine_path(**kwargs)
+        path_b = em.get_engine_path(**kwargs)
+
+        assert path_a == path_b
+
+    def test_vae_paths_unaffected_by_lora_dict(self, tmp_path):
+        lora_file = tmp_path / "style_a.safetensors"
+        lora_file.write_bytes(b"fake-lora-weights")
+        em = _make_engine_manager()
+        path_none = em.get_engine_path(
+            engine_type=EngineType.VAE_DECODER, is_faceid=False, lora_dict=None, **_BASE_KWARGS
+        )
+        path_lora = em.get_engine_path(
+            engine_type=EngineType.VAE_DECODER, is_faceid=False, lora_dict={str(lora_file): 0.7}, **_BASE_KWARGS
+        )
+
+        assert path_none == path_lora

--- a/tests/unit/test_param_schema.py
+++ b/tests/unit/test_param_schema.py
@@ -37,10 +37,10 @@ WRAPPER_ONLY_PARAMS = {"use_safety_checker", "safety_checker_threshold"}
 
 class TestParamNames:
     def test_param_names_count(self):
-        assert len(PARAM_NAMES) == 26
+        assert len(PARAM_NAMES) == 27
 
     def test_updater_param_names_count(self):
-        assert len(UPDATER_PARAM_NAMES) == 24
+        assert len(UPDATER_PARAM_NAMES) == 25
 
     def test_updater_param_names_is_ordered_subsequence_of_param_names(self):
         """Dropping the two wrapper-only names from PARAM_NAMES, in place,
@@ -115,6 +115,7 @@ class TestDefaultsGolden:
             "image_postprocessing_config",
             "latent_preprocessing_config",
             "latent_postprocessing_config",
+            "lora_weights",
         ):
             assert DEFAULTS[name] is None
 

--- a/tests/unit/test_td_pending_params.py
+++ b/tests/unit/test_td_pending_params.py
@@ -78,6 +78,7 @@ class _Manager:
         "fi_threshold",
         "cn_cache_interval",
         "cn_cache_decay",
+        "lora_weights",
     }
 
     def __init__(self):
@@ -305,7 +306,7 @@ class TestValidParamsMatchesSchema(unittest.TestCase):
     Drift lock (Stage 2 Increment 4): td_manager.py's runtime whitelist (now
     `set(param_schema.PARAM_NAMES)` in the real module -- see
     StreamDiffusionTD/td_manager.py::_apply_parameters) must stay exactly
-    the 26-name set param_schema.py owns. _Manager.VALID_PARAMS above is a
+    the 27-name set param_schema.py owns. _Manager.VALID_PARAMS above is a
     frozen replica of the *pre-refactor* literal list, kept here so this
     file never needs to import the real td_manager.py (CUDA/TD deps -- see
     module docstring). If param_schema.PARAM_NAMES ever adds/removes/renames

--- a/tests/unit/test_unet_call_backend_gate.py
+++ b/tests/unit/test_unet_call_backend_gate.py
@@ -5,14 +5,16 @@ feature-injection kwargs to a non-TRT (eager PyTorch) UNet.
 ``import streamdiffusion`` monkeypatches diffusers' ``UNet2DConditionModel.forward``
 (see ``_patches/diffusers_kvo_patch.py``) to add exactly one new kwarg, ``kvo_cache``,
 for StreamV2V cached-attention. It does *not* add ``fio_cache`` / ``fi_strength`` /
-``fi_threshold`` — feature-injection is TensorRT-engine-only
+``fi_threshold`` / ``lora_scale`` — feature-injection and the live LoRA-weight dial
+are both TensorRT-engine-only
 (``acceleration/tensorrt/runtime_engines/unet_engine.py``,
 ``UNet2DConditionModelEngine.__call__``).
 
 ``StreamDiffusion.unet_step()`` (pipeline.py) has two model-family branches. The SDXL
-branch gates the FI kwargs behind ``self._check_unet_tensorrt()``; the SD1.5/2.1
-branch did not, and unconditionally passed all four cache kwargs to ``self.unet(...)``.
-On any non-TRT backend (``acceleration: none``/``xformers``/``sfast``) this raised:
+branch gates the FI/LoRA kwargs behind ``self._check_unet_tensorrt()``; the SD1.5/2.1
+branch did not, and unconditionally passed all four cache kwargs to ``self.unet(...)``
+(``lora_scale`` was added later, already correctly gated the same way). On any non-TRT
+backend (``acceleration: none``/``xformers``/``sfast``) the original bug raised:
 
     UNet2DConditionModel.forward() got an unexpected keyword argument 'fio_cache'
 
@@ -119,6 +121,7 @@ def _make_pipeline(unet, *, prompt_tokens: int = 4) -> StreamDiffusion:
     sd.fio_cache: List[torch.Tensor] = []
     sd._fi_strength_tensor: Optional[torch.Tensor] = None
     sd._fi_threshold_tensor: Optional[torch.Tensor] = None
+    sd._lora_scale_tensor: Optional[torch.Tensor] = None  # live LoRA-weight dial; None == no LoRA loaded
     sd.use_feature_injection = False  # read by unet_step's FI-attenuation hot path
     sd._fi_strength_base = 0.0
     sd.fx_frame_transform = None
@@ -156,30 +159,32 @@ class TestSd15Sd21UnetCallBackendGate:
 
     def test_non_tensorrt_unet_receives_no_feature_injection_kwargs(self):
         """The patched PyTorch UNet only understands kvo_cache; fio_cache/fi_strength/
-        fi_threshold must never reach it, TRT-only or not."""
+        fi_threshold/lora_scale must never reach it, TRT-only or not."""
         recording_unet = _RecordingUnet(_make_tiny_unet())
         sd = _make_pipeline(recording_unet)
 
         _call_unet_step(sd)
 
         assert "kvo_cache" in recording_unet.last_kwargs
-        for key in ("fio_cache", "fi_strength", "fi_threshold"):
+        for key in ("fio_cache", "fi_strength", "fi_threshold", "lora_scale"):
             assert key not in recording_unet.last_kwargs, (
                 f"non-TRT UNet call must not receive {key!r}; got kwargs={sorted(recording_unet.last_kwargs)}"
             )
 
     def test_tensorrt_engine_still_receives_feature_injection_kwargs(self):
-        """Regression guard: the fix must not remove FI support from the real TRT path."""
+        """Regression guard: the fix must not remove FI/LoRA-scale support from the
+        real TRT path."""
         fake_engine = _FakeTrtEngine()
         sd = _make_pipeline(fake_engine)
         sd._fi_strength_tensor = torch.tensor(0.5)
         sd._fi_threshold_tensor = torch.tensor(0.1)
+        sd._lora_scale_tensor = torch.tensor([1.0])
         sd.use_feature_injection = True
         sd._fi_strength_base = 0.5
 
         _call_unet_step(sd)
 
-        for key in ("kvo_cache", "fio_cache", "fi_strength", "fi_threshold"):
+        for key in ("kvo_cache", "fio_cache", "fi_strength", "fi_threshold", "lora_scale"):
             assert key in fake_engine.last_kwargs, (
                 f"TRT engine call must still receive {key!r}; got kwargs={sorted(fake_engine.last_kwargs)}"
             )

--- a/tests/unit/test_unet_unified_export_lora_guard.py
+++ b/tests/unit/test_unet_unified_export_lora_guard.py
@@ -1,0 +1,64 @@
+"""
+Workstream A / A9: unit coverage for _collect_lora_layers' loud-failure guard.
+
+The guard (unet_unified_export.py:79-105) exists to stop the runtime lora_scale
+tensor from silently becoming a no-op slider -- the exact bug class this whole
+workstream exists to end. It had no test. Uses real peft LoraLayer instances
+(not mocks) via inject_adapter_in_model, so the test tracks peft's actual
+merged/disable_adapters/lora_variant state machine rather than an assumption
+about it.
+"""
+
+import pytest
+import torch.nn as nn
+from peft import LoraConfig, inject_adapter_in_model
+
+from streamdiffusion.acceleration.tensorrt.export_wrappers.unet_unified_export import (
+    _collect_lora_layers,
+)
+
+
+class _TinyUnet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.to_q = nn.Linear(8, 8, bias=False)
+
+
+def _make_adapted(use_dora=False, adapter_name="default"):
+    config = LoraConfig(r=4, lora_alpha=4, target_modules=["to_q"], use_dora=use_dora)
+    return inject_adapter_in_model(config, _TinyUnet(), adapter_name=adapter_name)
+
+
+def test_vanilla_lora_collects_successfully():
+    model = _make_adapted()
+    layers = _collect_lora_layers(model, [("dummy.safetensors", "default")])
+    assert list(layers.keys()) == ["default"]
+    module, base_scaling = layers["default"][0]
+    assert module is model.to_q
+    assert base_scaling == pytest.approx(4 / 4)  # lora_alpha / r
+
+
+def test_dora_adapter_raises_loudly():
+    model = _make_adapted(use_dora=True)
+    with pytest.raises(RuntimeError, match="non-vanilla PEFT variant"):
+        _collect_lora_layers(model, [("dummy.safetensors", "default")])
+
+
+def test_merged_adapter_raises_loudly():
+    model = _make_adapted()
+    model.to_q.merge()  # type: ignore[attr-defined]  -- inject_adapter_in_model swaps to_q for a lora.Linear
+    with pytest.raises(RuntimeError, match="is merged into module"):
+        _collect_lora_layers(model, [("dummy.safetensors", "default")])
+
+
+def test_disabled_adapter_raises_loudly():
+    model = _make_adapted()
+    model.to_q.enable_adapters(False)  # type: ignore[attr-defined]  -- see test_merged_adapter_raises_loudly
+    with pytest.raises(RuntimeError, match="is disabled on module"):
+        _collect_lora_layers(model, [("dummy.safetensors", "default")])
+
+
+def test_unmatched_adapter_name_raises_nothing_to_scale():
+    model = _make_adapted()
+    with pytest.raises(RuntimeError, match="nothing to scale"):
+        _collect_lora_layers(model, [("dummy.safetensors", "not_the_real_adapter")])


### PR DESCRIPTION
## What

Dragging the LoRA **Weight** slider in TouchDesigner previously triggered a full TensorRT
engine rebuild (~440s) because LoRA weight was baked into the engine at build time via
`fuse_lora`. This PR makes LoRA weight a live runtime input instead, so weight changes apply
instantly on every acceleration backend, TensorRT included.

## Changes

- **Unfuse LoRA adapters**: `set_adapters` at unit scale instead of `fuse_lora`, routing the
  runtime scale through PEFT's per-layer `scaling` dict via a new ONNX graph input
  (`lora_scale`), fed as a pre-allocated tensor at inference time the same way
  `fi_strength`/`ipadapter_scale` already work.
- **Engine cache key**: drops LoRA weight from the TensorRT engine cache key (folds in file
  size + mtime instead of basename, since checkpoints commonly collide on name) and tags
  dynamic-LoRA engines with `--loradyn` so a stale fused engine can never silently swallow the
  new input.
- **OSC**: adds the `lora_weights` parameter and wires it through the existing coalescer.
- **Loud failure, not silent no-op**: adapters with non-vanilla variants (e.g. DoRA), already
  merged into base weights, or disabled at build time now raise at load time instead of
  silently ignoring the slider.
- `StreamDiffusion._lora_order` declared as a class attribute (`pipeline.py`) so static typing
  sees the attribute `wrapper.py` sets dynamically -- fixes 4 pyrefly missing-attribute errors
  the dynamic-weight change introduced.

## Tests

`tests/unit/test_engine_path_ipadapter_suffixes.py`, `test_param_schema.py`,
`test_td_pending_params.py`, `test_unet_call_backend_gate.py`,
`test_unet_unified_export_lora_guard.py` (new -- DoRA/merged/disabled failure-guard coverage).
83 passed locally.

## Branch

`pr/lora-dynamic-weight` -> `SDTD_040_beta_release`
