### PR TITLE
fix: correct is_turbo detection and timestep spacing override

### DIFF
--- a/examples/txt2img/spacing_compare.py
+++ b/examples/txt2img/spacing_compare.py
@@ -2,11 +2,16 @@
 Sweep num_inference_steps (S in {10, 15, 20, 25, 30}) across all samplers and both
 production models to find where timestep-spacing actually changes output.
 
-Key insight: the LCM distillation grid is [19, 39, ..., 999] (congruent 19 mod 20).
+NOTE: this script has not been run (images/outputs/spacing_compare/ does not exist).
+The numbers below are derived from the LCM scheduler's own algorithm, not measured.
+
+Key insight: pipeline.py's _initialize_scheduler forces original_inference_steps=100,
+so the LCM distillation grid is [9, 19, ..., 999] (congruent 9 mod 10), not [19, 39,
+..., 999] (mod 20) as an original_inference_steps=50 assumption would give.
   normal:       always subsamples this grid -> always on-grid at every S.
-  sgm_uniform:  (trailing) coincides with the distillation grid only when S divides 50
-                (divisors in this range: {10, 25}) -> MSE~0 vs normal.
-                At non-divisors (15, 20, 30) it steps off-grid and diverges from normal.
+  sgm_uniform:  (trailing) coincides with the distillation grid only when S divides 100
+                (divisors in this range: {10, 20, 25}) -> MSE~0 vs normal.
+                At non-divisors (15, 30) it steps off-grid and diverges from normal.
   ddim:         (leading) off-grid at essentially all non-trivial S; excludes t=999.
   simple:       (linspace) off-grid; spans full [0, 999].
 
@@ -36,10 +41,10 @@ MODELS = [
     "stabilityai/sd-turbo",
     "stabilityai/sdxl-turbo",
 ]
-STEP_COUNTS = [10, 15, 20, 25, 30]  # divisors of 50: {10, 25}; non-divisors: {15, 20, 30}
+STEP_COUNTS = [10, 15, 20, 25, 30]  # divisors of 100: {10, 20, 25}; non-divisors: {15, 30}
 SAMPLERS = [
     ("normal", "LCM native (baseline, always on distillation grid)"),
-    ("sgm_uniform", "trailing  — on-grid only when S divides 50"),
+    ("sgm_uniform", "trailing  — on-grid only when S divides 100"),
     ("ddim", "leading   — off-grid, excludes t=999"),
     ("simple", "linspace  — off-grid, spans [0, 999]"),
 ]
@@ -66,8 +71,8 @@ def mse(a: Image.Image, b: Image.Image) -> float:
 
 
 def on_grid(sub_ts) -> bool:
-    """All sub-timesteps on the LCM distillation grid (congruent 19 mod 20)."""
-    return all(int(t) % 20 == 19 for t in sub_ts)
+    """All sub-timesteps on the LCM distillation grid (congruent 9 mod 10)."""
+    return all(int(t) % 10 == 9 for t in sub_ts)
 
 
 def run_model(model_id: str) -> None:
@@ -76,11 +81,11 @@ def run_model(model_id: str) -> None:
 
     for S in STEP_COUNTS:
         t_index = proportional_t_index(S)
-        is_divisor = 50 % S == 0
+        is_divisor = 100 % S == 0
         print(f"\n{'=' * 70}")
         print(
             f"Model: {model_id}  S={S}  t_index={t_index}  "
-            f"({'divides 50 -> trailing==normal' if is_divisor else 'does NOT divide 50 -> trailing diverges'})"
+            f"({'divides 100 -> trailing==normal' if is_divisor else 'does NOT divide 100 -> trailing diverges'})"
         )
         print(f"{'=' * 70}")
 

--- a/src/streamdiffusion/acceleration/tensorrt/export_wrappers/unet_sdxl_export.py
+++ b/src/streamdiffusion/acceleration/tensorrt/export_wrappers/unet_sdxl_export.py
@@ -305,7 +305,10 @@ def get_sdxl_tensorrt_config(model_path: str, unet: UNet2DConditionModel) -> Dic
         "has_time_cond": detection_result["architecture_details"]["has_time_conditioning"],
         "has_addition_embed": detection_result["architecture_details"]["has_addition_embeds"],
         "model_type": detection_result["model_type"],
-        "is_turbo": detection_result["is_turbo"],
+        # Note: no "is_turbo" key -- detect_model() here is called without a pipe, so its
+        # scheduler-based Turbo signal is always undecided. Turbo status is unread by
+        # SDXLConditioningHandler; the authoritative verdict lives on the wrapper
+        # (resolve_is_turbo), not here.
         "is_sd3": detection_result["is_sd3"],
         "confidence": detection_result["confidence"],
         "architecture_details": detection_result["architecture_details"],

--- a/src/streamdiffusion/acceleration/tensorrt/models/controlnet_models.py
+++ b/src/streamdiffusion/acceleration/tensorrt/models/controlnet_models.py
@@ -133,7 +133,10 @@ class ControlNetSDXLTRT(ControlNetTRT):
                 "has_time_cond": detection_result["architecture_details"]["has_time_conditioning"],
                 "has_addition_embed": detection_result["architecture_details"]["has_addition_embeds"],
                 "model_type": detection_result["model_type"],
-                "is_turbo": detection_result["is_turbo"],
+                # Note: no "is_turbo" key -- detect_model() here is called without a pipe, so
+                # its scheduler-based Turbo signal is always undecided. Turbo status is unread
+                # by SDXLConditioningHandler; the authoritative verdict lives on the wrapper
+                # (resolve_is_turbo), not here.
                 "is_sd3": detection_result["is_sd3"],
                 "confidence": detection_result["confidence"],
                 "architecture_details": detection_result["architecture_details"],

--- a/src/streamdiffusion/config.py
+++ b/src/streamdiffusion/config.py
@@ -125,6 +125,9 @@ def _extract_wrapper_params(config: Dict[str, Any]) -> Dict[str, Any]:
         "do_add_noise": config.get("do_add_noise", True),
         "device_ids": config.get("device_ids"),
         "use_lcm_lora": config.get("use_lcm_lora"),  # Backwards compatibility
+        # Explicit override for Turbo-checkpoint detection; None (default) auto-detects.
+        # See StreamDiffusionWrapper.__init__'s is_turbo docstring for the precedence.
+        "is_turbo": config.get("is_turbo"),
         "use_tiny_vae": config.get("use_tiny_vae", True),
         "enable_similar_image_filter": config.get("enable_similar_image_filter", False),
         "similar_image_filter_threshold": config.get("similar_image_filter_threshold", 0.98),

--- a/src/streamdiffusion/model_detection.py
+++ b/src/streamdiffusion/model_detection.py
@@ -40,10 +40,16 @@ def _detect_turbo_from_scheduler(pipe: Optional[Any]) -> Optional[bool]:
     """
     if pipe is None:
         return None
-    scheduler_config = getattr(getattr(pipe, "scheduler", None), "config", None)
+    scheduler = getattr(pipe, "scheduler", None)
+    scheduler_config = getattr(scheduler, "config", None)
     if scheduler_config is None:
         return None
-    class_name = getattr(scheduler_config, "_class_name", "") or ""
+    # `_class_name` is only present on configs loaded from a JSON scheduler_config.json
+    # (from_pretrained). A scheduler built via `.from_config(...)` -- e.g. diffusers'
+    # single-file `_legacy_load_scheduler` synthesized-defaults path -- has no
+    # `_class_name` at all, which used to silently degrade this check to False. The
+    # runtime class name is always correct regardless of construction path.
+    class_name = getattr(scheduler_config, "_class_name", "") or type(scheduler).__name__
     spacing = getattr(scheduler_config, "timestep_spacing", None)
     return "EulerAncestralDiscreteScheduler" in class_name and spacing == "trailing"
 

--- a/src/streamdiffusion/model_detection.py
+++ b/src/streamdiffusion/model_detection.py
@@ -1,6 +1,7 @@
 """Comprehensive model detection for TensorRT and pipeline support"""
 
-from typing import Any, Dict, Optional
+import os
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 from diffusers.models.unets.unet_2d_condition import UNet2DConditionModel
@@ -52,6 +53,102 @@ def _detect_turbo_from_scheduler(pipe: Optional[Any]) -> Optional[bool]:
     class_name = getattr(scheduler_config, "_class_name", "") or type(scheduler).__name__
     spacing = getattr(scheduler_config, "timestep_spacing", None)
     return "EulerAncestralDiscreteScheduler" in class_name and spacing == "trailing"
+
+
+def read_safetensors_metadata(path: Optional[str]) -> Dict[str, str]:
+    """Header-only read of a `.safetensors` file's `__metadata__` block. No tensor
+    weights are loaded -- `safe_open` reads only the JSON header. Returns `{}` on any
+    failure (missing file, not a local path (repo id/URL), not a safetensors file,
+    corrupt header) rather than raising, so callers can treat metadata as
+    always-available-but-possibly-empty.
+    """
+    if not path:
+        return {}
+    try:
+        from safetensors import safe_open
+    except ImportError:
+        return {}
+    try:
+        with safe_open(path, framework="pt") as f:
+            return dict(f.metadata() or {})
+    except Exception:
+        return {}
+
+
+def turbo_from_checkpoint_metadata(path: Optional[str]) -> Optional[bool]:
+    """True/False when the checkpoint carries a SAI Model Spec
+    `modelspec.architecture` tag (e.g. "stable-diffusion-xl-turbo-v1" vs
+    "stable-diffusion-xl-v1-base"). None when the tag is absent, which is the common
+    case for community merges -- callers should fall back to a weaker signal rather
+    than treat None as a negative.
+    """
+    architecture = read_safetensors_metadata(path).get("modelspec.architecture")
+    if not architecture:
+        return None
+    return "turbo" in architecture.lower()
+
+
+def turbo_hint_from_model_id(model_id_or_path: Optional[str]) -> bool:
+    """Case-insensitive "turbo" match on the checkpoint's file *basename* only.
+    Deliberately ignores parent directories, so a base model staged under a path
+    like `D:/turbo_tests/sdxl_base.safetensors` is not misclassified. This is the
+    weakest signal in resolve_is_turbo's precedence -- a naming convention, not a
+    guarantee -- so it is consulted last.
+    """
+    if not model_id_or_path:
+        return False
+    basename = os.path.basename(str(model_id_or_path))
+    return "turbo" in basename.lower()
+
+
+def resolve_is_turbo(
+    *,
+    pipe: Optional[Any] = None,
+    explicit: Optional[bool] = None,
+    model_id_or_path: Optional[str] = None,
+    loaded_via_single_file: bool = False,
+) -> Tuple[bool, str]:
+    """Resolve whether the loaded checkpoint is an ADD-distilled Turbo variant.
+
+    Closes the gap flagged in dotsimulate's PR #58 review: `_detect_turbo_from_scheduler`
+    depends on `pipe.scheduler.config` reflecting the checkpoint's own published
+    scheduler_config.json. That holds for `from_pretrained` loads (repo id or a local
+    diffusers-format directory) but not for `from_single_file` -- diffusers borrows a
+    *reference repo's* scheduler config for the checkpoint's declared architecture family
+    (e.g. an SDXL-Turbo `.safetensors` merge inherits SDXL-Base's `EulerDiscreteScheduler`),
+    so the scheduler check returns a confident but wrong verdict there, not an "undecided"
+    one. This function therefore only trusts the scheduler for non-single-file loads and
+    falls back to checkpoint-embedded metadata, then a filename hint, for single-file ones.
+
+    Precedence (highest to lowest):
+      1. `explicit` -- caller-supplied override, wins outright.
+      2. Scheduler config -- only when `loaded_via_single_file` is False.
+      3. `.safetensors` `modelspec.architecture` metadata -- single-file loads only; a
+         present verdict is authoritative and can VETO a misleading filename.
+      4. "turbo" substring in the file basename -- single-file loads only, last resort.
+      5. Nothing decisive -- False, tagged "undecided" so callers can warn that no
+         automatic signal exists and an explicit override is needed.
+
+    Returns `(is_turbo, reason)` where `reason` is one of "explicit", "scheduler",
+    "modelspec", "filename", "undecided".
+    """
+    if explicit is not None:
+        return bool(explicit), "explicit"
+
+    if not loaded_via_single_file:
+        scheduler_verdict = _detect_turbo_from_scheduler(pipe)
+        if scheduler_verdict is not None:
+            return scheduler_verdict, "scheduler"
+        return False, "undecided"
+
+    metadata_verdict = turbo_from_checkpoint_metadata(model_id_or_path)
+    if metadata_verdict is not None:
+        return metadata_verdict, "modelspec"
+
+    if turbo_hint_from_model_id(model_id_or_path):
+        return True, "filename"
+
+    return False, "undecided"
 
 
 def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str, Any]:

--- a/src/streamdiffusion/model_detection.py
+++ b/src/streamdiffusion/model_detection.py
@@ -167,7 +167,12 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
         A dictionary with detailed information about the detected model.
     """
     model_type = "Unknown"
-    is_turbo = False
+    # Optional[bool]: None = undecided (no pipe / scheduler available to check), True/False =
+    # a decision based on the *source* scheduler. This is a signal, not a verdict -- Turbo
+    # detection is resolved once, authoritatively, by resolve_is_turbo(); detect_model no
+    # longer collapses this into a bool of its own (see resolve_is_turbo's docstring for why
+    # a pipe-less scheduler check must never be read as "confirmed non-Turbo").
+    turbo_from_scheduler = None
     is_sdxl = False
     is_sd3 = False
     confidence = 0.0
@@ -186,7 +191,7 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
             if pipe and hasattr(pipe, "scheduler"):
                 scheduler_name = getattr(pipe.scheduler.config, "_class_name", "").lower()
                 if "lcm" in scheduler_name or "turbo" in scheduler_name:
-                    is_turbo = True
+                    turbo_from_scheduler = True
                     model_type = "SD3-Turbo"
         else:
             model_type = "Unknown MMDiT"
@@ -208,8 +213,6 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
             model_type = "SDXL"
             is_sdxl = True
             confidence = 1.0
-            if turbo_from_scheduler is not None:
-                is_turbo = turbo_from_scheduler
 
         # 2b. SD2.1 vs. SD1.5 (if not SDXL)
         # Differentiate based on the text encoder's projection dimension.
@@ -220,8 +223,6 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
                 confidence = 1.0
                 # sd-turbo is SD2.1-architecture (cross_attention_dim=1024); the old
                 # heuristic never set is_turbo on this branch at all.
-                if turbo_from_scheduler is not None:
-                    is_turbo = turbo_from_scheduler
             elif cross_attention_dim == 768:
                 model_type = "SD1.5"
                 confidence = 1.0
@@ -241,8 +242,6 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
             model_type = "SDXL"
             is_sdxl = True
             confidence = 0.95  # Slightly lower confidence for ControlNet
-            if turbo_from_scheduler is not None:
-                is_turbo = turbo_from_scheduler
         else:
             cross_attention_dim = config.get("cross_attention_dim")
             if cross_attention_dim == 1024:
@@ -296,7 +295,7 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
 
     result = {
         "model_type": model_type,
-        "is_turbo": is_turbo,
+        "turbo_from_scheduler": turbo_from_scheduler,
         "is_sdxl": is_sdxl,
         "is_sd3": is_sd3,
         "confidence": confidence,

--- a/src/streamdiffusion/model_detection.py
+++ b/src/streamdiffusion/model_detection.py
@@ -20,6 +20,34 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _detect_turbo_from_scheduler(pipe: Optional[Any]) -> Optional[bool]:
+    """Discriminate ADD-distilled Turbo checkpoints from their base counterparts via the
+    pipeline's *source* scheduler config, evaluated before StreamDiffusion swaps in its own
+    LCMScheduler/TCDScheduler (pipeline.py calls this at __init__ time, ahead of
+    _initialize_scheduler).
+
+    Both sd-turbo and sdxl-turbo ship an EulerAncestralDiscreteScheduler with
+    timestep_spacing="trailing" (see docs/plans/SDXL-Turbo_Research_Verification.md). Their
+    non-Turbo counterparts (SD2.1, SDXL-Base-1.0) do not. This replaces a UNet-config
+    heuristic that keyed off `time_cond_proj_dim`, which is actually the LCM-distillation
+    guidance-embedding dim: stock SDXL-Base-1.0 also has it `None` (false positive for
+    Turbo), and it says nothing about non-SDXL UNets at all (sd-turbo was never flagged
+    Turbo).
+
+    Returns None (undecided) rather than False when no pipe/scheduler is available to
+    check, so callers can tell "confirmed non-Turbo" apart from "couldn't check" and fall
+    back to a corroborating hint (e.g. the model-id string) if they have one.
+    """
+    if pipe is None:
+        return None
+    scheduler_config = getattr(getattr(pipe, "scheduler", None), "config", None)
+    if scheduler_config is None:
+        return None
+    class_name = getattr(scheduler_config, "_class_name", "") or ""
+    spacing = getattr(scheduler_config, "timestep_spacing", None)
+    return "EulerAncestralDiscreteScheduler" in class_name and spacing == "trailing"
+
+
 def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str, Any]:
     """
     Comprehensive and robust model detection using definitive architectural features.
@@ -65,16 +93,20 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
     elif isinstance(model, UNet2DConditionModel):
         config = model.config
 
+        # `time_cond_proj_dim` is the LCM-distillation guidance-embedding dim, not a
+        # Turbo/Base signal (see _detect_turbo_from_scheduler's docstring). Turbo detection
+        # uses the source scheduler instead; `time_cond_proj_dim` is surfaced separately as
+        # `has_time_conditioning` via detect_unet_characteristics() below.
+        turbo_from_scheduler = _detect_turbo_from_scheduler(pipe)
+
         # 2a. SDXL vs. non-SDXL
         # The `addition_embed_type` is the clearest indicator for the SDXL architecture.
         if config.get("addition_embed_type") is not None:
             model_type = "SDXL"
             is_sdxl = True
             confidence = 1.0
-            # Differentiate SDXL-Base from SDXL-Turbo.
-            # Base SDXL has `time_cond_proj_dim` (e.g., 256), while Turbo has it set to `None`.
-            if config.get("time_cond_proj_dim") is None:
-                is_turbo = True
+            if turbo_from_scheduler is not None:
+                is_turbo = turbo_from_scheduler
 
         # 2b. SD2.1 vs. SD1.5 (if not SDXL)
         # Differentiate based on the text encoder's projection dimension.
@@ -83,6 +115,10 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
             if cross_attention_dim == 1024:
                 model_type = "SD2.1"
                 confidence = 1.0
+                # sd-turbo is SD2.1-architecture (cross_attention_dim=1024); the old
+                # heuristic never set is_turbo on this branch at all.
+                if turbo_from_scheduler is not None:
+                    is_turbo = turbo_from_scheduler
             elif cross_attention_dim == 768:
                 model_type = "SD1.5"
                 confidence = 1.0
@@ -95,14 +131,15 @@ def detect_model(model: torch.nn.Module, pipe: Optional[Any] = None) -> Dict[str
     elif hasattr(model, "config") and hasattr(model.config, "cross_attention_dim"):
         # ControlNet models have UNet-like configs, detect their base architecture
         config = model.config
+        turbo_from_scheduler = _detect_turbo_from_scheduler(pipe)
 
         # Apply same detection logic as UNet models
         if config.get("addition_embed_type") is not None:
             model_type = "SDXL"
             is_sdxl = True
             confidence = 0.95  # Slightly lower confidence for ControlNet
-            if config.get("time_cond_proj_dim") is None:
-                is_turbo = True
+            if turbo_from_scheduler is not None:
+                is_turbo = turbo_from_scheduler
         else:
             cross_attention_dim = config.get("cross_attention_dim")
             if cross_attention_dim == 1024:

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -1019,33 +1019,6 @@ class StreamDiffusion:
         """Get the current seed weight normalization setting."""
         return self._param_updater.get_normalize_seed_weights()
 
-    def set_scheduler(
-        self,
-        scheduler: Literal["lcm", "tcd"] = None,
-        sampler: Literal["simple", "sgm_uniform", "normal", "ddim", "beta", "karras"] = None,
-    ) -> None:
-        """
-        Change the scheduler and/or sampler at runtime.
-
-        Parameters
-        ----------
-        scheduler : str, optional
-            The scheduler type to use ("lcm" or "tcd"). If None, keeps current scheduler.
-        sampler : str, optional
-            The sampler type to use. If None, keeps current sampler.
-        """
-        if scheduler is not None:
-            self.scheduler_type = scheduler
-        if sampler is not None:
-            self.sampler_type = sampler
-
-        self.scheduler = self._initialize_scheduler(self.scheduler_type, self.sampler_type, self.pipe.scheduler.config)
-        logger.info(f"Scheduler changed to {self.scheduler_type} with {self.sampler_type} sampler")
-
-    def _uses_lcm_logic(self) -> bool:
-        """Return True if scheduler uses LCM-style consistency boundary-condition math."""
-        return isinstance(self.scheduler, LCMScheduler)
-
     def add_noise(
         self,
         original_samples: torch.Tensor,

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -23,7 +23,7 @@ from streamdiffusion.hooks import (
     UnetKwargsDelta,
 )
 from streamdiffusion.image_filter import SimilarImageFilter
-from streamdiffusion.model_detection import detect_model
+from streamdiffusion.model_detection import detect_model, resolve_is_turbo
 from streamdiffusion.param_schema import (
     VALID_CFG_TYPES,
     bleed_risk_message,
@@ -64,6 +64,7 @@ class StreamDiffusion:
         use_feature_injection: bool = False,
         fi_strength: float = 0.75,
         fi_threshold: float = 0.98,
+        is_turbo: Optional[bool] = None,
     ) -> None:
         self.device = torch.device(device)
         self.dtype = torch_dtype
@@ -99,11 +100,16 @@ class StreamDiffusion:
         self.scheduler_type = scheduler
         self.sampler_type = sampler
 
-        # Detect model type
+        # Detect model type. Turbo status is resolved once, authoritatively, by the caller
+        # (StreamDiffusionWrapper._load_model, via resolve_is_turbo) and passed in as
+        # `is_turbo` -- detect_model only reports architecture. The fallback below keeps
+        # direct StreamDiffusion(...) construction (examples, tests) working without a
+        # wrapper: it re-derives the scheduler-only signal via resolve_is_turbo itself,
+        # same as _load_model would for a non-single-file load.
         detection_result = detect_model(pipe.unet, pipe)
         self.model_type = detection_result["model_type"]
         self.is_sdxl = detection_result["is_sdxl"]
-        self.is_turbo = detection_result["is_turbo"]
+        self.is_turbo = is_turbo if is_turbo is not None else resolve_is_turbo(pipe=pipe)[0]
         self.detection_confidence = detection_result["confidence"]
 
         # TCD scheduler is incompatible with denoising batch optimization due to Strategic Stochastic Sampling

--- a/src/streamdiffusion/stream_parameter_updater.py
+++ b/src/streamdiffusion/stream_parameter_updater.py
@@ -14,6 +14,7 @@ from .param_schema import (
     compute_sub_timesteps,
     delta_noise_cancellation_ceiling,
     floor_num_inference_steps,
+    materialise_timestep_grid,
     rescale_t_index_list,
 )
 from .preprocessing.orchestrator_user import OrchestratorUser
@@ -378,8 +379,18 @@ class StreamParameterUpdater(OrchestratorUser):
                         num_inference_steps = floored
 
                 old_num_steps = len(self.stream.timesteps)
-                self.stream.scheduler.set_timesteps(num_inference_steps, self.stream.device)
-                self.stream.timesteps = self.stream.scheduler.timesteps.to(self.stream.device)
+                # Route through the shared helper rather than calling set_timesteps directly:
+                # for sampler_type in {"simple", "sgm_uniform", "ddim"}, prepare() applies a
+                # spacing override on top of the scheduler's native grid (see
+                # param_schema.materialise_timestep_grid's docstring). A bare set_timesteps()
+                # here would silently discard that override on the first live step change.
+                self.stream.timesteps = materialise_timestep_grid(
+                    self.stream.scheduler,
+                    num_inference_steps,
+                    self.stream.sampler_type,
+                    self.stream.device,
+                    self.stream._get_spaced_timesteps,
+                )
 
                 # If t_index_list wasn't explicitly provided, rescale existing t_list proportionally
                 if t_index_list is None and old_num_steps > 0:
@@ -712,8 +723,7 @@ class StreamParameterUpdater(OrchestratorUser):
 
         if missing:
             logger.warning(
-                "_apply_prompt_blending: %d prompt(s) have no cached embedding and were "
-                "dropped from the blend: %r",
+                "_apply_prompt_blending: %d prompt(s) have no cached embedding and were dropped from the blend: %r",
                 len(missing),
                 missing,
             )

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -9,7 +9,7 @@ from diffusers import AutoencoderTiny, AutoPipelineForText2Image, StableDiffusio
 from PIL import Image
 
 from .image_utils import postprocess_image
-from .model_detection import detect_model, resolve_is_turbo
+from .model_detection import detect_model, resolve_is_turbo, turbo_hint_from_model_id
 from .param_schema import (
     PromptInterpolationMethod,
     SeedInterpolationMethod,
@@ -616,11 +616,13 @@ class StreamDiffusionWrapper:
         # Store use_lcm_lora for backwards compatibility processing in _load_model
         self.use_lcm_lora = use_lcm_lora
 
-        # Explicit override wins outright; otherwise fall back to a case-insensitive
-        # model-id substring check until _load_model resolves the authoritative verdict
-        # (self._is_turbo, via resolve_is_turbo) and reconciles self.sd_turbo below.
+        # Explicit override wins outright; otherwise fall back to a basename-only "turbo"
+        # hint (same rule turbo_hint_from_model_id enforces, so a base model staged under
+        # a `turbo_tests/` parent directory isn't misclassified here either) until
+        # _load_model resolves the authoritative verdict via resolve_is_turbo and
+        # reconciles self.sd_turbo (self._is_turbo, set at the end of _load_model).
         self._is_turbo_override = is_turbo
-        self.sd_turbo = is_turbo if is_turbo is not None else ("turbo" in str(model_id_or_path).lower())
+        self.sd_turbo = is_turbo if is_turbo is not None else turbo_hint_from_model_id(model_id_or_path)
         self.use_controlnet = use_controlnet
         self.use_ipadapter = use_ipadapter
         self.ipadapter_config = ipadapter_config
@@ -2149,6 +2151,15 @@ class StreamDiffusionWrapper:
             f"is_turbo={is_turbo} (source={is_turbo_source})"
         )
 
+        # Adopt the authoritative verdict -- until now self.sd_turbo held the pre-load
+        # basename guess from __init__. Must precede the LCM-LoRA gate below.
+        if self.sd_turbo != is_turbo:
+            logger.info(
+                f"_load_model: sd_turbo {self.sd_turbo} -> {is_turbo} "
+                f"(pre-load path hint corrected by {is_turbo_source})"
+            )
+        self.sd_turbo = is_turbo
+
         # Auto-resolve IP-Adapter model/encoder paths for detected architecture.
         # Runs once here so both pre-TRT and post-TRT installation paths see the resolved cfg.
         if use_ipadapter and ipadapter_config:
@@ -2215,6 +2226,7 @@ class StreamDiffusionWrapper:
             cache_maxframes=cache_maxframes,
             fio_cache=[],  # Set below if FI is enabled
             use_feature_injection=use_feature_injection and use_cached_attn,
+            is_turbo=self._is_turbo,  # authoritative verdict from resolve_is_turbo above
         )
 
         # Create KVO cache tensors using the pipeline's actual runtime batch size.
@@ -2322,17 +2334,14 @@ class StreamDiffusionWrapper:
                 logger.info(f"Activated {len(lora_adapters_to_merge)} LoRA adapter(s) (live, unfused)")
             except Exception as activate_error:
                 raise RuntimeError(
-                    f"LoRA activation failed — cannot build engine with partial adapter state. "
-                    f"Error: {activate_error}"
+                    f"LoRA activation failed — cannot build engine with partial adapter state. Error: {activate_error}"
                 ) from activate_error
 
         # Ordered adapter list — the index<->path mapping the export wrapper
         # (unet_unified_export.py) and the runtime updater (stream_parameter_updater.py)
         # both need to translate a lora_scale tensor slot back to a LoRA path. Path
         # normalized to forward slashes to match the YAML config builder's convention.
-        stream._lora_order = [
-            (_loaded_adapter_names[a][0].replace("\\", "/"), a) for a in lora_adapters_to_merge
-        ]
+        stream._lora_order = [(_loaded_adapter_names[a][0].replace("\\", "/"), a) for a in lora_adapters_to_merge]
 
         # Persistent fp32 [num_loras] tensor — the runtime lora_scale engine input.
         # Initialized to the configured per-LoRA weights (not 1.0) so the very first
@@ -3001,6 +3010,13 @@ class StreamDiffusionWrapper:
                         # guidance_scale still follows the turbo/non-turbo split (matches
                         # inference CFG); this axis is independent of *which* timesteps are
                         # calibrated, so it rides alongside the schedule derivation below.
+                        # Not covered by a live unit test: reaching this line means driving
+                        # _load_model all the way through real StreamDiffusion construction
+                        # plus engine-path resolution, which is well past the abort-after-
+                        # reconciliation seam the wrapper turbo-detection tests use (see
+                        # tests/unit/test_wrapper_sd_turbo_reconciliation.py's skipped
+                        # test_fp8_guidance_scale_follows_resolved_verdict for why, and what
+                        # would be needed to cover it directly).
                         _unet_build_opts["fp8_guidance_scale"] = 0.0 if _is_turbo else 7.5
 
                         # --- band-based, config-derived calibration schedule ---

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -616,11 +616,11 @@ class StreamDiffusionWrapper:
         # Store use_lcm_lora for backwards compatibility processing in _load_model
         self.use_lcm_lora = use_lcm_lora
 
-        # Explicit override wins outright; otherwise fall back to a model-id substring
-        # check until _load_model resolves the authoritative verdict (self._is_turbo,
-        # via resolve_is_turbo) and reconciles self.sd_turbo below.
+        # Explicit override wins outright; otherwise fall back to a case-insensitive
+        # model-id substring check until _load_model resolves the authoritative verdict
+        # (self._is_turbo, via resolve_is_turbo) and reconciles self.sd_turbo below.
         self._is_turbo_override = is_turbo
-        self.sd_turbo = is_turbo if is_turbo is not None else ("turbo" in model_id_or_path)
+        self.sd_turbo = is_turbo if is_turbo is not None else ("turbo" in str(model_id_or_path).lower())
         self.use_controlnet = use_controlnet
         self.use_ipadapter = use_ipadapter
         self.ipadapter_config = ipadapter_config

--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -9,7 +9,7 @@ from diffusers import AutoencoderTiny, AutoPipelineForText2Image, StableDiffusio
 from PIL import Image
 
 from .image_utils import postprocess_image
-from .model_detection import detect_model
+from .model_detection import detect_model, resolve_is_turbo
 from .param_schema import (
     PromptInterpolationMethod,
     SeedInterpolationMethod,
@@ -345,6 +345,13 @@ class StreamDiffusionWrapper:
         acceleration: Literal["none", "xformers", "tensorrt"] = "tensorrt",
         do_add_noise: bool = True,
         device_ids: Optional[List[int]] = None,
+        # Explicit override for Turbo-checkpoint detection. None (default) auto-detects via
+        # (in order) the loaded pipe's scheduler config, then — for single-file loads only,
+        # where the scheduler config is unreliable (see model_detection.resolve_is_turbo) —
+        # the checkpoint's embedded modelspec.architecture metadata, then a "turbo" substring
+        # in the file basename. Set True/False to bypass auto-detection entirely, e.g. for a
+        # community merge with a misleading filename and no embedded metadata.
+        is_turbo: Optional[bool] = None,
         use_lcm_lora: Optional[bool] = None,  # DEPRECATED: Backwards compatibility parameter
         use_tiny_vae: bool = True,
         enable_similar_image_filter: bool = False,
@@ -489,6 +496,14 @@ class StreamDiffusionWrapper:
             by default True.
         device_ids : Optional[List[int]], optional
             The device ids to use for DataParallel, by default None.
+        is_turbo : Optional[bool], optional
+            Explicit override for Turbo-checkpoint detection, by default None (auto-detect).
+            Auto-detection trusts the loaded pipe's scheduler config for repo-id/directory
+            loads; for single-file (.safetensors/.ckpt) loads that signal is unreliable
+            (diffusers borrows a reference repo's scheduler config), so it falls back to the
+            checkpoint's embedded modelspec.architecture metadata, then a "turbo" substring in
+            the file basename. Set True/False directly when neither corroborating signal is
+            available (e.g. a community merge with a misleading filename and no metadata).
         use_lcm_lora : Optional[bool], optional
             DEPRECATED: Use lora_dict instead. For backwards compatibility only.
             If True, automatically adds appropriate LCM LoRA to lora_dict based on model type.
@@ -601,7 +616,11 @@ class StreamDiffusionWrapper:
         # Store use_lcm_lora for backwards compatibility processing in _load_model
         self.use_lcm_lora = use_lcm_lora
 
-        self.sd_turbo = "turbo" in model_id_or_path
+        # Explicit override wins outright; otherwise fall back to a model-id substring
+        # check until _load_model resolves the authoritative verdict (self._is_turbo,
+        # via resolve_is_turbo) and reconciles self.sd_turbo below.
+        self._is_turbo_override = is_turbo
+        self.sd_turbo = is_turbo if is_turbo is not None else ("turbo" in model_id_or_path)
         self.use_controlnet = use_controlnet
         self.use_ipadapter = use_ipadapter
         self.ipadapter_config = ipadapter_config
@@ -2017,12 +2036,19 @@ class StreamDiffusionWrapper:
             ]
 
         pipe = None
+        # Which loader actually produced the pipe -- resolve_is_turbo needs this because a
+        # from_single_file load's pipe.scheduler config is unreliable (see
+        # model_detection.resolve_is_turbo's docstring): it inherits a *reference repo's*
+        # scheduler config rather than the checkpoint's own, so a from_pretrained (repo id or
+        # local directory) load is the only case where the scheduler verdict alone is trusted.
+        loaded_via_single_file = False
         load_errors = []  # (method_name, exception) for every failed attempt, in order
         for method, method_name in loading_methods:
             try:
                 logger.info(f"_load_model: Attempting to load with {method_name}...")
                 pipe = method(model_id_or_path).to(dtype=self.dtype)
                 logger.info(f"_load_model: Successfully loaded using {method_name}")
+                loaded_via_single_file = "from_single_file" in method_name
 
                 # Verify that we have the right pipeline type for SDXL models
                 if is_sdxl_model and not isinstance(pipe, StableDiffusionXLPipeline):
@@ -2040,8 +2066,10 @@ class StreamDiffusionWrapper:
                         # structurally here.
                         if model_id_or_path.endswith(".safetensors") or os.path.exists(model_id_or_path):
                             pipe = StableDiffusionXLPipeline.from_single_file(model_id_or_path).to(dtype=self.dtype)
+                            loaded_via_single_file = True
                         else:
                             pipe = StableDiffusionXLPipeline.from_pretrained(model_id_or_path).to(dtype=self.dtype)
+                            loaded_via_single_file = False
                         logger.info("_load_model: Successfully loaded using SDXL pipeline on retry")
                     except Exception as retry_error:
                         # Discard the mismatched-type pipe so a subsequent loading-method
@@ -2096,16 +2124,30 @@ class StreamDiffusionWrapper:
         detection_result = detect_model(pipe.unet, pipe)
         model_type = detection_result["model_type"]
         is_sdxl = detection_result["is_sdxl"]
-        is_turbo = detection_result["is_turbo"]
         confidence = detection_result["confidence"]
+
+        # is_turbo is resolved separately from detect_model's own verdict: detect_model's
+        # scheduler-only check is confidently wrong (not merely undecided) for
+        # from_single_file loads (see resolve_is_turbo's docstring), so corroborate with
+        # checkpoint metadata / filename there, and let an explicit override win outright.
+        is_turbo, is_turbo_source = resolve_is_turbo(
+            pipe=pipe,
+            explicit=self._is_turbo_override,
+            model_id_or_path=model_id_or_path,
+            loaded_via_single_file=loaded_via_single_file,
+        )
 
         # Store comprehensive model info for later use (after TensorRT conversion)
         self._detected_model_type = model_type
         self._detection_confidence = confidence
         self._is_turbo = is_turbo
+        self._is_turbo_source = is_turbo_source
         self._is_sdxl = is_sdxl
 
-        logger.info(f"_load_model: Detected model type: {model_type} (confidence: {confidence:.2f})")
+        logger.info(
+            f"_load_model: Detected model type: {model_type} (confidence: {confidence:.2f}); "
+            f"is_turbo={is_turbo} (source={is_turbo_source})"
+        )
 
         # Auto-resolve IP-Adapter model/encoder paths for detected architecture.
         # Runs once here so both pre-TRT and post-TRT installation paths see the resolved cfg.
@@ -2929,6 +2971,23 @@ class StreamDiffusionWrapper:
                         _unet_build_opts["builder_optimization_level"] = self.builder_optimization_level
                     if fp8:
                         _is_turbo = getattr(self, "_is_turbo", False)
+                        _is_turbo_source = getattr(self, "_is_turbo_source", "undecided")
+                        if _is_turbo_source == "undecided":
+                            # No automatic signal decided is_turbo (e.g. a merged
+                            # .safetensors checkpoint with a name that doesn't say
+                            # "turbo" and no embedded modelspec.architecture metadata).
+                            # fp8_guidance_scale below silently falls back to the
+                            # non-turbo value (7.5) in this case -- flag it so a
+                            # misclassified turbo merge doesn't get calibrated against
+                            # the wrong guidance scale silently. Resolve via the
+                            # `is_turbo` config key / wrapper param.
+                            logger.warning(
+                                "[TRT] is_turbo could not be auto-detected for this "
+                                "checkpoint (no scheduler/metadata/filename signal); "
+                                f"defaulting to is_turbo={_is_turbo} for fp8 calibration. "
+                                "Set the `is_turbo` config key (or wrapper param) explicitly "
+                                "if this checkpoint is actually a Turbo/ADD-distilled model."
+                            )
                         _unet_build_opts["fp8"] = True
                         _unet_build_opts["onnx_opset"] = (
                             21  # FP8 Q/DQ scales with FP16 scale factors require opset ≥21

--- a/tests/unit/test_model_detection.py
+++ b/tests/unit/test_model_detection.py
@@ -19,11 +19,20 @@ CPU-only, no CUDA required, no network access, no model weights loaded.
 
 from unittest.mock import MagicMock
 
+import torch
 from diffusers.configuration_utils import FrozenDict
 from diffusers.models.unets.unet_2d_condition import UNet2DConditionModel
 from diffusers.schedulers.scheduling_euler_ancestral_discrete import EulerAncestralDiscreteScheduler
+from safetensors.torch import save_file
 
-from streamdiffusion.model_detection import _detect_turbo_from_scheduler, detect_model
+from streamdiffusion.model_detection import (
+    _detect_turbo_from_scheduler,
+    detect_model,
+    read_safetensors_metadata,
+    resolve_is_turbo,
+    turbo_from_checkpoint_metadata,
+    turbo_hint_from_model_id,
+)
 
 
 def _fake_unet(config: dict) -> MagicMock:
@@ -157,3 +166,167 @@ class TestDetectTurboFromSchedulerClassNameFallback:
         pipe = MagicMock()
         pipe.scheduler = scheduler
         assert _detect_turbo_from_scheduler(pipe) is False
+
+
+class TestSafetensorsMetadata:
+    """dotsimulate PR #58 gap, part 2: for single-file loads, corroborate (or veto)
+    the unreliable scheduler signal with the checkpoint's own embedded SAI Model
+    Spec `modelspec.architecture` tag, read header-only (no weights loaded)."""
+
+    def _write_checkpoint(self, tmp_path, metadata=None):
+        path = str(tmp_path / "model.safetensors")
+        save_file({"weight": torch.zeros(2, 2)}, path, metadata=metadata)
+        return path
+
+    def test_read_safetensors_metadata_returns_embedded_dict(self, tmp_path):
+        path = self._write_checkpoint(tmp_path, {"modelspec.architecture": "stable-diffusion-xl-turbo-v1"})
+        assert read_safetensors_metadata(path) == {"modelspec.architecture": "stable-diffusion-xl-turbo-v1"}
+
+    def test_read_safetensors_metadata_missing_file_returns_empty_dict(self):
+        assert read_safetensors_metadata("D:/does/not/exist.safetensors") == {}
+
+    def test_read_safetensors_metadata_none_path_returns_empty_dict(self):
+        assert read_safetensors_metadata(None) == {}
+
+    def test_turbo_from_checkpoint_metadata_turbo_architecture(self, tmp_path):
+        path = self._write_checkpoint(tmp_path, {"modelspec.architecture": "stable-diffusion-xl-turbo-v1"})
+        assert turbo_from_checkpoint_metadata(path) is True
+
+    def test_turbo_from_checkpoint_metadata_base_architecture_is_veto(self, tmp_path):
+        """A confirmed non-Turbo architecture tag is a genuine negative -- this is
+        the case that must be able to override a misleading "turbo" filename."""
+        path = self._write_checkpoint(tmp_path, {"modelspec.architecture": "stable-diffusion-xl-v1-base"})
+        assert turbo_from_checkpoint_metadata(path) is False
+
+    def test_turbo_from_checkpoint_metadata_absent_is_undecided(self, tmp_path):
+        """The common case for community merges: no modelspec metadata at all."""
+        path = self._write_checkpoint(tmp_path, metadata=None)
+        assert turbo_from_checkpoint_metadata(path) is None
+
+
+class TestTurboHintFromModelId:
+    def test_turbo_in_basename_is_true(self):
+        assert turbo_hint_from_model_id("D:/models/SDXL-Turbo-merge.safetensors") is True
+
+    def test_turbo_case_insensitive(self):
+        assert turbo_hint_from_model_id("D:/models/sdxl_TURBO_merge.safetensors") is True
+
+    def test_turbo_in_parent_dir_only_is_false(self):
+        """Guard case: a base checkpoint staged under a `turbo_tests/` directory
+        must not be misread as a Turbo checkpoint from its path alone."""
+        assert turbo_hint_from_model_id("D:/turbo_tests/sdxl_base.safetensors") is False
+
+    def test_no_hint_is_false(self):
+        assert turbo_hint_from_model_id("D:/models/sdxl_base.safetensors") is False
+
+    def test_none_is_false(self):
+        assert turbo_hint_from_model_id(None) is False
+
+
+class TestResolveIsTurbo:
+    """Precedence-matrix tests covering the 7 validated cases from the plan plus
+    both explicit-override directions."""
+
+    def _checkpoint(self, tmp_path, metadata=None):
+        path = str(tmp_path / "model.safetensors")
+        save_file({"weight": torch.zeros(2, 2)}, path, metadata=metadata)
+        return path
+
+    def test_explicit_true_wins_outright(self, tmp_path):
+        path = self._checkpoint(tmp_path, {"modelspec.architecture": "stable-diffusion-xl-v1-base"})
+        is_turbo, source = resolve_is_turbo(explicit=True, model_id_or_path=path, loaded_via_single_file=True)
+        assert (is_turbo, source) == (True, "explicit")
+
+    def test_explicit_false_wins_outright(self):
+        pipe = _fake_pipe(*TURBO_SCHEDULER)
+        is_turbo, source = resolve_is_turbo(
+            pipe=pipe, explicit=False, model_id_or_path="turbo.safetensors", loaded_via_single_file=False
+        )
+        assert (is_turbo, source) == (False, "explicit")
+
+    def test_repo_id_load_trusts_scheduler(self):
+        """stabilityai/sdxl-turbo / stabilityai/sd-turbo (repo id) case: unchanged,
+        deployed behaviour."""
+        pipe = _fake_pipe(*TURBO_SCHEDULER)
+        is_turbo, source = resolve_is_turbo(
+            pipe=pipe, model_id_or_path="stabilityai/sdxl-turbo", loaded_via_single_file=False
+        )
+        assert (is_turbo, source) == (True, "scheduler")
+
+    def test_repo_id_base_load_trusts_scheduler(self):
+        """sdxl-base-1.0 (repo id) case."""
+        pipe = _fake_pipe(*SDXL_BASE_SCHEDULER)
+        is_turbo, source = resolve_is_turbo(
+            pipe=pipe, model_id_or_path="stabilityai/stable-diffusion-xl-base-1.0", loaded_via_single_file=False
+        )
+        assert (is_turbo, source) == (False, "scheduler")
+
+    def test_single_file_ignores_scheduler_even_if_present(self, tmp_path):
+        """The core gap: a from_single_file load's pipe carries a scheduler (the
+        *reference repo's*, not the checkpoint's own), but it must never be
+        trusted -- only metadata/filename corroborate single-file loads."""
+        path = self._checkpoint(tmp_path, {"modelspec.architecture": "stable-diffusion-xl-turbo-v1"})
+        pipe = _fake_pipe(*SDXL_BASE_SCHEDULER)  # would say False if trusted
+        is_turbo, source = resolve_is_turbo(pipe=pipe, model_id_or_path=path, loaded_via_single_file=True)
+        assert (is_turbo, source) == (True, "modelspec")
+
+    def test_single_file_community_sdxl_turbo_merge(self, tmp_path):
+        """community SDXL-Turbo merge `.safetensors`: no modelspec metadata, name
+        says turbo."""
+        path = str(tmp_path / "SDXL-Turbo-merge.safetensors")
+        save_file({"weight": torch.zeros(2, 2)}, path)
+        is_turbo, source = resolve_is_turbo(model_id_or_path=path, loaded_via_single_file=True)
+        assert (is_turbo, source) == (True, "filename")
+
+    def test_single_file_community_sd_turbo_merge(self, tmp_path):
+        """community sd-turbo merge `.safetensors`: same shape, non-SDXL name."""
+        path = str(tmp_path / "sd-turbo-merge.safetensors")
+        save_file({"weight": torch.zeros(2, 2)}, path)
+        is_turbo, source = resolve_is_turbo(model_id_or_path=path, loaded_via_single_file=True)
+        assert (is_turbo, source) == (True, "filename")
+
+    def test_single_file_metadata_vetoes_misleading_filename(self, tmp_path):
+        """modelspec.architecture outranks the filename hint: a confirmed-base
+        checkpoint stays False even if someone names the file "turbo"."""
+        path = str(tmp_path / "totally_turbo.safetensors")
+        save_file(
+            {"weight": torch.zeros(2, 2)}, path, metadata={"modelspec.architecture": "stable-diffusion-xl-v1-base"}
+        )
+        is_turbo, source = resolve_is_turbo(model_id_or_path=path, loaded_via_single_file=True)
+        assert (is_turbo, source) == (False, "modelspec")
+
+    def test_guard_base_dir_under_turbo_tests(self, tmp_path):
+        """guard: base checkpoint's directory contains "turbo" but its own
+        basename doesn't -- must not be misclassified."""
+        turbo_dir = tmp_path / "turbo_tests"
+        turbo_dir.mkdir()
+        path = str(turbo_dir / "sdxl_base.safetensors")
+        save_file({"weight": torch.zeros(2, 2)}, path)
+        is_turbo, source = resolve_is_turbo(model_id_or_path=path, loaded_via_single_file=True)
+        assert (is_turbo, source) == (False, "undecided")
+
+    def test_guard_base_safetensors_in_turbo_dir_with_metadata_veto(self, tmp_path):
+        """guard: base checkpoint under a turbo-named directory, this time with an
+        explicit base modelspec tag -- still False."""
+        turbo_dir = tmp_path / "turbo_tests"
+        turbo_dir.mkdir()
+        path = str(turbo_dir / "sdxl_base.safetensors")
+        save_file(
+            {"weight": torch.zeros(2, 2)}, path, metadata={"modelspec.architecture": "stable-diffusion-xl-v1-base"}
+        )
+        is_turbo, source = resolve_is_turbo(model_id_or_path=path, loaded_via_single_file=True)
+        assert (is_turbo, source) == (False, "modelspec")
+
+    def test_single_file_nothing_decisive_is_undecided(self, tmp_path):
+        """sdxl_merged.safetensors case: no metadata, no filename hint -- False,
+        tagged "undecided" so the fp8 build path can warn."""
+        path = str(tmp_path / "sdxl_merged.safetensors")
+        save_file({"weight": torch.zeros(2, 2)}, path)
+        is_turbo, source = resolve_is_turbo(model_id_or_path=path, loaded_via_single_file=True)
+        assert (is_turbo, source) == (False, "undecided")
+
+    def test_no_pipe_no_path_repo_id_load_is_undecided(self):
+        """Defensive: a from_pretrained-flagged load with no pipe at all (pipe=None)
+        has no scheduler to consult and falls straight to undecided."""
+        is_turbo, source = resolve_is_turbo(pipe=None, model_id_or_path=None, loaded_via_single_file=False)
+        assert (is_turbo, source) == (False, "undecided")

--- a/tests/unit/test_model_detection.py
+++ b/tests/unit/test_model_detection.py
@@ -1,0 +1,129 @@
+"""Unit tests for src/streamdiffusion/model_detection.py's is_turbo discrimination.
+
+Covers `_detect_turbo_from_scheduler` directly and `detect_model`'s end-to-end
+`is_turbo` result for the three checkpoints named in
+docs/plans/SDXL-Turbo_Research_Verification.md's defect 2: sd-turbo, sdxl-turbo,
+and sdxl-base-1.0. UNet config values below are the real published
+unet/config.json / scheduler_config.json fields for each checkpoint (sdxl-base-1.0
+is stubbed from its published config rather than downloading the ~7 GB checkpoint;
+sd-turbo/sdxl-turbo are also stubbed here for speed and to keep the test
+network-free and deterministic).
+
+The point of this file: sdxl-turbo and sdxl-base-1.0 have an *identical* UNet-config
+shape (`time_cond_proj_dim: null`, `addition_embed_type: "text_time"`) — that is
+exactly why the old `time_cond_proj_dim is None` heuristic misclassified SDXL-Base
+as Turbo. Only the scheduler discriminates them.
+
+CPU-only, no CUDA required, no network access, no model weights loaded.
+"""
+
+from unittest.mock import MagicMock
+
+from diffusers.configuration_utils import FrozenDict
+from diffusers.models.unets.unet_2d_condition import UNet2DConditionModel
+
+from streamdiffusion.model_detection import _detect_turbo_from_scheduler, detect_model
+
+
+def _fake_unet(config: dict) -> MagicMock:
+    """A UNet2DConditionModel-shaped mock carrying only the config fields
+    detect_model reads. Mock(spec=...) makes isinstance() checks pass; the
+    FrozenDict config supports both dict-style (`config.get(...)`) and
+    attribute-style (`config.cross_attention_dim`) access, matching real
+    diffusers configs."""
+    unet = MagicMock(spec=UNet2DConditionModel)
+    unet.config = FrozenDict(config)
+    return unet
+
+
+def _fake_pipe(class_name: str, timestep_spacing) -> MagicMock:
+    scheduler_config = FrozenDict({"_class_name": class_name, "timestep_spacing": timestep_spacing})
+    scheduler = MagicMock()
+    scheduler.config = scheduler_config
+    pipe = MagicMock()
+    pipe.scheduler = scheduler
+    return pipe
+
+
+# Published unet/config.json fields (the ones detect_model reads).
+SD_TURBO_UNET_CONFIG = {
+    "addition_embed_type": None,
+    "cross_attention_dim": 1024,
+    "time_cond_proj_dim": None,
+}
+SDXL_TURBO_UNET_CONFIG = {
+    "addition_embed_type": "text_time",
+    "cross_attention_dim": 2048,
+    "time_cond_proj_dim": None,
+}
+# Same shape as sdxl-turbo's -- the UNet config alone cannot tell them apart.
+SDXL_BASE_UNET_CONFIG = {
+    "addition_embed_type": "text_time",
+    "cross_attention_dim": 2048,
+    "time_cond_proj_dim": None,
+}
+
+# Published scheduler_config.json fields.
+TURBO_SCHEDULER = ("EulerAncestralDiscreteScheduler", "trailing")
+SDXL_BASE_SCHEDULER = ("EulerDiscreteScheduler", "leading")
+
+
+class TestDetectTurboFromScheduler:
+    def test_no_pipe_is_undecided(self):
+        assert _detect_turbo_from_scheduler(None) is None
+
+    def test_pipe_without_scheduler_is_undecided(self):
+        pipe = MagicMock()
+        pipe.scheduler = None
+        assert _detect_turbo_from_scheduler(pipe) is None
+
+    def test_euler_ancestral_trailing_is_turbo(self):
+        pipe = _fake_pipe(*TURBO_SCHEDULER)
+        assert _detect_turbo_from_scheduler(pipe) is True
+
+    def test_euler_discrete_leading_is_not_turbo(self):
+        pipe = _fake_pipe(*SDXL_BASE_SCHEDULER)
+        assert _detect_turbo_from_scheduler(pipe) is False
+
+    def test_euler_ancestral_without_trailing_is_not_turbo(self):
+        """Class name alone isn't enough -- spacing must also be trailing."""
+        pipe = _fake_pipe("EulerAncestralDiscreteScheduler", "leading")
+        assert _detect_turbo_from_scheduler(pipe) is False
+
+
+class TestDetectModelIsTurbo:
+    """End-to-end: detect_model(unet, pipe)['is_turbo'] for the three checkpoints
+    named in the verification doc's defect 2."""
+
+    def test_sd_turbo_is_turbo(self):
+        unet = _fake_unet(SD_TURBO_UNET_CONFIG)
+        pipe = _fake_pipe(*TURBO_SCHEDULER)
+        result = detect_model(unet, pipe)
+        assert result["model_type"] == "SD2.1"
+        assert result["is_turbo"] is True
+
+    def test_sdxl_turbo_is_turbo(self):
+        unet = _fake_unet(SDXL_TURBO_UNET_CONFIG)
+        pipe = _fake_pipe(*TURBO_SCHEDULER)
+        result = detect_model(unet, pipe)
+        assert result["model_type"] == "SDXL"
+        assert result["is_turbo"] is True
+
+    def test_sdxl_base_is_not_turbo(self):
+        """The regression case: sdxl-base-1.0's UNet config is indistinguishable
+        from sdxl-turbo's (both have time_cond_proj_dim=None), so only the
+        scheduler-based check keeps this False."""
+        unet = _fake_unet(SDXL_BASE_UNET_CONFIG)
+        pipe = _fake_pipe(*SDXL_BASE_SCHEDULER)
+        result = detect_model(unet, pipe)
+        assert result["model_type"] == "SDXL"
+        assert result["is_turbo"] is False
+
+    def test_no_pipe_defaults_is_turbo_false(self):
+        """No pipe -> _detect_turbo_from_scheduler returns None -> is_turbo keeps
+        its initial False rather than being set. Matches the two non-pipe call
+        sites (unet_sdxl_export.py, controlnet_models.py) whose is_turbo output
+        is confirmed dead downstream."""
+        unet = _fake_unet(SDXL_TURBO_UNET_CONFIG)
+        result = detect_model(unet, pipe=None)
+        assert result["is_turbo"] is False

--- a/tests/unit/test_model_detection.py
+++ b/tests/unit/test_model_detection.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 
 from diffusers.configuration_utils import FrozenDict
 from diffusers.models.unets.unet_2d_condition import UNet2DConditionModel
+from diffusers.schedulers.scheduling_euler_ancestral_discrete import EulerAncestralDiscreteScheduler
 
 from streamdiffusion.model_detection import _detect_turbo_from_scheduler, detect_model
 
@@ -127,3 +128,32 @@ class TestDetectModelIsTurbo:
         unet = _fake_unet(SDXL_TURBO_UNET_CONFIG)
         result = detect_model(unet, pipe=None)
         assert result["is_turbo"] is False
+
+
+class TestDetectTurboFromSchedulerClassNameFallback:
+    """dotsimulate PR #58 gap, part 1: `_class_name` is only present on configs
+    loaded from a JSON scheduler_config.json (from_pretrained). A scheduler built
+    via `.from_config(...)` -- diffusers' `_legacy_load_scheduler` synthesized-
+    defaults path for single-file loads -- has no `_class_name` key at all, so the
+    old `getattr(scheduler_config, "_class_name", "")` silently degraded to "" and
+    every such scheduler read as non-Turbo regardless of its real class."""
+
+    def test_class_name_absent_falls_back_to_runtime_class(self):
+        # Real diffusers object, not a FrozenDict stand-in: from_config never
+        # stamps `_class_name` onto the resulting config (verified empirically).
+        scheduler = EulerAncestralDiscreteScheduler.from_config(
+            {"num_train_timesteps": 1000, "timestep_spacing": "trailing"}
+        )
+        assert "_class_name" not in scheduler.config
+
+        pipe = MagicMock()
+        pipe.scheduler = scheduler
+        assert _detect_turbo_from_scheduler(pipe) is True
+
+    def test_class_name_absent_non_trailing_is_not_turbo(self):
+        scheduler = EulerAncestralDiscreteScheduler.from_config(
+            {"num_train_timesteps": 1000, "timestep_spacing": "leading"}
+        )
+        pipe = MagicMock()
+        pipe.scheduler = scheduler
+        assert _detect_turbo_from_scheduler(pipe) is False

--- a/tests/unit/test_model_detection.py
+++ b/tests/unit/test_model_detection.py
@@ -102,22 +102,26 @@ class TestDetectTurboFromScheduler:
 
 
 class TestDetectModelIsTurbo:
-    """End-to-end: detect_model(unet, pipe)['is_turbo'] for the three checkpoints
-    named in the verification doc's defect 2."""
+    """End-to-end: detect_model(unet, pipe)['turbo_from_scheduler'] for the three
+    checkpoints named in the verification doc's defect 2.
+
+    detect_model() no longer collapses this into a bool of its own -- it reports
+    the Optional[bool] scheduler signal verbatim; resolve_is_turbo() is the sole
+    place that resolves it into an authoritative Turbo/non-Turbo decision."""
 
     def test_sd_turbo_is_turbo(self):
         unet = _fake_unet(SD_TURBO_UNET_CONFIG)
         pipe = _fake_pipe(*TURBO_SCHEDULER)
         result = detect_model(unet, pipe)
         assert result["model_type"] == "SD2.1"
-        assert result["is_turbo"] is True
+        assert result["turbo_from_scheduler"] is True
 
     def test_sdxl_turbo_is_turbo(self):
         unet = _fake_unet(SDXL_TURBO_UNET_CONFIG)
         pipe = _fake_pipe(*TURBO_SCHEDULER)
         result = detect_model(unet, pipe)
         assert result["model_type"] == "SDXL"
-        assert result["is_turbo"] is True
+        assert result["turbo_from_scheduler"] is True
 
     def test_sdxl_base_is_not_turbo(self):
         """The regression case: sdxl-base-1.0's UNet config is indistinguishable
@@ -127,16 +131,30 @@ class TestDetectModelIsTurbo:
         pipe = _fake_pipe(*SDXL_BASE_SCHEDULER)
         result = detect_model(unet, pipe)
         assert result["model_type"] == "SDXL"
-        assert result["is_turbo"] is False
+        assert result["turbo_from_scheduler"] is False
 
-    def test_no_pipe_defaults_is_turbo_false(self):
-        """No pipe -> _detect_turbo_from_scheduler returns None -> is_turbo keeps
-        its initial False rather than being set. Matches the two non-pipe call
-        sites (unet_sdxl_export.py, controlnet_models.py) whose is_turbo output
-        is confirmed dead downstream."""
+    def test_no_pipe_is_undecided(self):
+        """No pipe -> _detect_turbo_from_scheduler returns None -> turbo_from_scheduler
+        stays None (undecided), not False. Matches the two non-pipe call sites
+        (unet_sdxl_export.py, controlnet_models.py), which no longer even read this
+        key -- Turbo status there is resolved authoritatively on the wrapper via
+        resolve_is_turbo(), never re-derived from a pipe-less detect_model() call."""
         unet = _fake_unet(SDXL_TURBO_UNET_CONFIG)
         result = detect_model(unet, pipe=None)
-        assert result["is_turbo"] is False
+        assert result["turbo_from_scheduler"] is None
+
+    def test_is_turbo_key_not_reintroduced(self):
+        """Tripwire: detect_model()'s output must never carry a collapsed
+        "is_turbo" bool again. Both unet_sdxl_export.py's get_sdxl_tensorrt_config
+        and controlnet_models.py's ControlNetSDXLTRT build a config dict straight
+        from this return value without an intermediate allowlist -- if "is_turbo"
+        reappeared here, either site would silently start propagating a stale
+        pipe-less signal instead of the wrapper's authoritative resolve_is_turbo()
+        verdict."""
+        unet = _fake_unet(SDXL_TURBO_UNET_CONFIG)
+        result = detect_model(unet, pipe=_fake_pipe(*TURBO_SCHEDULER))
+        assert "is_turbo" not in result
+        assert "turbo_from_scheduler" in result
 
 
 class TestDetectTurboFromSchedulerClassNameFallback:

--- a/tests/unit/test_param_schema.py
+++ b/tests/unit/test_param_schema.py
@@ -27,6 +27,7 @@ from streamdiffusion.param_schema import (
     compute_sub_timesteps,
     delta_noise_cancellation_ceiling,
     floor_num_inference_steps,
+    materialise_timestep_grid,
     rescale_t_index_list,
 )
 from streamdiffusion.stream_parameter_updater import StreamParameterUpdater
@@ -187,6 +188,115 @@ class TestComputeSubTimesteps:
         4-step calibration used to sample."""
         timesteps = [999 - 20 * j for j in range(50)]
         assert compute_sub_timesteps(timesteps, [15, 21, 27]) == [699, 579, 459]
+
+
+class _FakeGrid(list):
+    """List that also answers `.to(device)` like a torch tensor, so
+    materialise_timestep_grid's `.to(device)` calls work without pulling in
+    real tensors (this test file stays CPU-only / tensor-free, per its own
+    docstring)."""
+
+    def to(self, device):
+        return self
+
+
+class _FakeSchedulerConfig:
+    def __init__(self, timestep_spacing):
+        self.timestep_spacing = timestep_spacing
+
+
+class _FakeScheduler:
+    """Minimal stand-in for a diffusers scheduler: only the surface
+    materialise_timestep_grid touches (set_timesteps, .config.timestep_spacing,
+    .timesteps). set_timesteps ignores `timestep_spacing` entirely, mirroring
+    LCMScheduler's real behaviour (fact #2 of the trailing finding in
+    docs/plans/SDXL-Turbo_Research_Verification.md)."""
+
+    def __init__(self, native_grid, timestep_spacing):
+        self._native_grid = native_grid
+        self.config = _FakeSchedulerConfig(timestep_spacing)
+        self.timesteps = _FakeGrid()
+
+    def set_timesteps(self, num_inference_steps, device):
+        self.timesteps = _FakeGrid(self._native_grid[:num_inference_steps])
+
+
+class TestMaterialiseTimestepGrid:
+    """Coverage for the shared spacing-override helper. Every call site that
+    materialises a timestep grid -- prepare(), the fp8 calibration path, and
+    stream_parameter_updater.py's live num_inference_steps handler -- must
+    route through this, per its own docstring."""
+
+    # LCM native grid @ S=50, t_index=[4,8,12] (see probe_schedule.py output).
+    NATIVE_GRID = [919, 839, 759]
+
+    def test_normal_sampler_passes_through_native_grid_untouched(self):
+        scheduler = _FakeScheduler(self.NATIVE_GRID, timestep_spacing="trailing")
+        spaced_calls = []
+
+        def get_spaced_timesteps(spacing, num_inference_steps):
+            spaced_calls.append((spacing, num_inference_steps))
+            return _FakeGrid([0])  # would prove up if wrongly invoked
+
+        result = materialise_timestep_grid(
+            scheduler,
+            num_inference_steps=3,
+            sampler_type="normal",
+            device="cpu",
+            get_spaced_timesteps=get_spaced_timesteps,
+        )
+
+        assert list(result) == self.NATIVE_GRID
+        assert spaced_calls == []  # "normal" is not in _SPACING_SAMPLERS
+
+    def test_spacing_sampler_overrides_native_grid(self):
+        scheduler = _FakeScheduler(self.NATIVE_GRID, timestep_spacing="trailing")
+        spaced_grid = [900, 820, 740]  # e.g. ddim/leading at S=50
+
+        result = materialise_timestep_grid(
+            scheduler,
+            num_inference_steps=3,
+            sampler_type="ddim",
+            device="cpu",
+            get_spaced_timesteps=lambda spacing, s: _FakeGrid(spaced_grid),
+        )
+
+        assert list(result) == spaced_grid
+        assert list(scheduler.timesteps) == spaced_grid  # mutated in place too
+
+    def test_spacing_sampler_passes_scheduler_config_spacing_through(self):
+        scheduler = _FakeScheduler(self.NATIVE_GRID, timestep_spacing="trailing")
+        seen = {}
+
+        def get_spaced_timesteps(spacing, num_inference_steps):
+            seen["spacing"] = spacing
+            seen["num_inference_steps"] = num_inference_steps
+            return _FakeGrid([1, 2, 3])
+
+        materialise_timestep_grid(
+            scheduler,
+            num_inference_steps=3,
+            sampler_type="sgm_uniform",
+            device="cpu",
+            get_spaced_timesteps=get_spaced_timesteps,
+        )
+
+        assert seen == {"spacing": "trailing", "num_inference_steps": 3}
+
+    def test_unrecognised_spacing_falls_back_to_native_grid(self):
+        """A `timestep_spacing` outside {trailing, linspace, leading} leaves
+        the native grid untouched -- matches the `if spacing in (...)` guard."""
+        scheduler = _FakeScheduler(self.NATIVE_GRID, timestep_spacing="unknown")
+
+        result = materialise_timestep_grid(
+            scheduler,
+            num_inference_steps=3,
+            sampler_type="simple",
+            device="cpu",
+            get_spaced_timesteps=lambda spacing, s: _FakeGrid([0]),
+        )
+
+        assert list(result) == self.NATIVE_GRID
 
 
 class TestBuildCalibrationTIndices:

--- a/tests/unit/test_trt_config_detection_keys.py
+++ b/tests/unit/test_trt_config_detection_keys.py
@@ -1,0 +1,110 @@
+"""Regression tests for the TensorRT SDXL config-dict sites touched by the
+Turbo/model-detection unification (docs/plans -- detect_model's ``is_turbo``
+key was renamed to ``turbo_from_scheduler``, see model_detection.py).
+
+Both ``ControlNetSDXLTRT.__init__`` (controlnet_models.py) and
+``get_sdxl_tensorrt_config`` (unet_sdxl_export.py) build a config dict from
+``detect_model(unet)``'s output *without* passing a pipe -- so
+``turbo_from_scheduler`` is always ``None`` there, and neither site ever read
+the old ``is_turbo`` key. Removing it was still a real behavioural change in
+principle (a ``KeyError`` risk had either site read the collapsed bool), even
+though production never exercises either path today:
+
+- ``ControlNetSDXLTRT``'s ``unet is not None`` branch is dead in production --
+  the sole caller passes ``unet=None`` (wrapper.py -> engine_manager.py ->
+  controlnet_models.py, verified end-to-end).
+- ``get_sdxl_tensorrt_config`` has zero callers repo-wide.
+
+These tests drive both sites directly with a mocked SDXL UNet so the branches
+run at all, pinning the contract: constructs cleanly, no ``KeyError``,
+``embedding_dim`` resolves to SDXL's 2048.
+
+Skipped where TensorRT/onnx/polygraphy aren't installed, matching
+test_engine_path_controlnet_tokens.py's guard -- controlnet_models.py's
+BaseModel parent (models.py) imports onnx_graphsurgeon/onnx/polygraphy at
+module load time, before any test in this file can run.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from diffusers.configuration_utils import FrozenDict
+from diffusers.models.unets.unet_2d_condition import UNet2DConditionModel
+
+try:
+    from streamdiffusion.acceleration.tensorrt.export_wrappers.unet_sdxl_export import (
+        SDXLConditioningHandler,
+        get_sdxl_tensorrt_config,
+    )
+    from streamdiffusion.acceleration.tensorrt.models.controlnet_models import ControlNetSDXLTRT
+
+    IMPORT_OK = True
+except ImportError:
+    IMPORT_OK = False
+
+pytestmark = pytest.mark.skipif(
+    not IMPORT_OK,
+    reason="acceleration.tensorrt.models.controlnet_models not importable (onnx/polygraphy missing)",
+)
+
+# Same shape as test_model_detection.py's SDXL_TURBO_UNET_CONFIG: addition_embed_type
+# set (SDXL signal), cross_attention_dim=2048, time_cond_proj_dim=None.
+SDXL_UNET_CONFIG = {
+    "addition_embed_type": "text_time",
+    "cross_attention_dim": 2048,
+    "time_cond_proj_dim": None,
+}
+
+
+def _fake_sdxl_unet() -> MagicMock:
+    """Same pattern as test_model_detection.py's _fake_unet: Mock(spec=...) so
+    isinstance() checks pass, FrozenDict config for dict- and attribute-style
+    access."""
+    unet = MagicMock(spec=UNet2DConditionModel)
+    unet.config = FrozenDict(SDXL_UNET_CONFIG)
+    return unet
+
+
+class TestControlNetSDXLTRTConstruction:
+    """Drives the `unet is not None` branch that production never reaches
+    (the sole real caller passes unet=None) -- pins the contract in case
+    anyone ever wires a real UNet in."""
+
+    def test_constructs_without_keyerror(self):
+        # Must not raise -- specifically must not KeyError on a stale "is_turbo"
+        # key that detect_model() no longer returns.
+        model = ControlNetSDXLTRT(unet=_fake_sdxl_unet(), device="cpu")
+        assert model.name == "ControlNet"
+
+    def test_embedding_dim_resolves_to_sdxl_2048(self):
+        model = ControlNetSDXLTRT(unet=_fake_sdxl_unet(), device="cpu")
+        assert model.embedding_dim == 2048
+
+    def test_unet_dim_defaults_to_sdxl_latent_channels(self):
+        model = ControlNetSDXLTRT(unet=_fake_sdxl_unet(), device="cpu")
+        assert model.unet_dim == 4
+
+
+class TestGetSdxlTensorrtConfigSmokeTest:
+    """get_sdxl_tensorrt_config is dead code repo-wide (zero callers), but it
+    must remain dead-but-correct rather than dead-and-broken -- this exercises
+    it directly with a mocked SDXL UNet."""
+
+    def test_config_carries_expected_keys(self):
+        config = get_sdxl_tensorrt_config("D:/fake/path.safetensors", _fake_sdxl_unet())
+
+        assert config["is_sdxl"] is True
+        assert config["has_time_cond"] is False  # time_cond_proj_dim=None in the fixture
+        assert config["has_addition_embed"] is True  # addition_embed_type="text_time"
+        assert "is_turbo" not in config  # the removed key must not reappear
+
+    def test_config_is_consumable_by_conditioning_handler(self):
+        """The whole point of the dict: SDXLConditioningHandler must be able
+        to construct from it and produce a conditioning spec."""
+        config = get_sdxl_tensorrt_config("D:/fake/path.safetensors", _fake_sdxl_unet())
+
+        handler = SDXLConditioningHandler(config)
+        spec = handler.get_conditioning_spec()
+
+        assert spec["dual_encoders"] is True
+        assert spec["context_dim"] == 2048

--- a/tests/unit/test_wrapper_sd_turbo_reconciliation.py
+++ b/tests/unit/test_wrapper_sd_turbo_reconciliation.py
@@ -1,0 +1,347 @@
+"""
+Regression tests for the missing `sd_turbo` reconciliation in
+`StreamDiffusionWrapper._load_model`.
+
+Three independent Turbo detectors existed in this repo: `wrapper.sd_turbo` (a
+crude heuristic, the only one actually read by `txt2img`/the LCM-LoRA gate),
+`wrapper._is_turbo` (the authoritative verdict from `resolve_is_turbo`'s 5-level
+precedence ladder, write-only before this fix), and `detect_model`'s own
+scheduler-only signal (defaulted to a near-constant `False` for the four call
+sites that pass no pipe, and unread by its only consumers). `_load_model`
+documented a contract -- "resolves the authoritative verdict ... and reconciles
+self.sd_turbo below" -- that didn't exist in code: `self._is_turbo` was assigned
+exactly once and never read again.
+
+Every existing `resolve_is_turbo` test (test_model_detection.py) calls it
+directly, bypassing the wrapper entirely -- a green suite there coexisted with a
+wrong runtime value here. These tests exercise the reconciliation through the
+actual wrapper call path instead.
+
+Follows the object.__new__ shell + patch.object(wrapper_module.*, ...) pattern
+established in test_load_model_network_error_reporting.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from diffusers.configuration_utils import FrozenDict
+from diffusers.models.unets.unet_2d_condition import UNet2DConditionModel
+from safetensors.torch import save_file
+
+from streamdiffusion import wrapper as wrapper_module
+from streamdiffusion.wrapper import StreamDiffusionWrapper
+
+
+def _make_wrapper_shell(model_id_or_path: str) -> StreamDiffusionWrapper:
+    """Construct a minimal StreamDiffusionWrapper without model loading, with
+    __init__'s Step-2 pre-load state (no explicit override, basename-only
+    turbo_hint_from_model_id guess) and just enough attributes to satisfy the
+    StreamDiffusion(...) kwargs evaluated at the end of _load_model (that call
+    itself is patched to raise -- see below -- but Python still evaluates its
+    kwargs first).
+
+    use_lcm_lora mirrors __init__'s `self.use_lcm_lora = use_lcm_lora` (default
+    param value None -- see wrapper.py:355) rather than _load_model's separate,
+    unused-in-the-gate `use_lcm_lora: bool = True` parameter (wrapper.py:1834);
+    the gate at wrapper.py:2174 reads only the former."""
+    w = object.__new__(StreamDiffusionWrapper)
+    w.device = torch.device("cpu")
+    w.dtype = torch.float32
+    w.cleanup_gpu_memory = lambda: None
+    w.width = 512
+    w.height = 512
+    w.frame_buffer_size = 1
+    w.use_denoising_batch = True
+    w._is_turbo_override = None
+    w.sd_turbo = wrapper_module.turbo_hint_from_model_id(model_id_or_path)
+    w.use_lcm_lora = None
+    return w
+
+
+def _fake_unet() -> MagicMock:
+    """An SDXL-shaped UNet2DConditionModel mock -- the config fields
+    detect_model reads. Mock(spec=...) makes isinstance() checks pass; FrozenDict
+    supports both dict-style and attribute-style config access, matching real
+    diffusers configs."""
+    unet = MagicMock(spec=UNet2DConditionModel)
+    unet.config = FrozenDict(
+        {
+            "addition_embed_type": "text_time",
+            "cross_attention_dim": 2048,
+            "time_cond_proj_dim": None,
+        }
+    )
+    return unet
+
+
+def _fake_sdxl_pipe(unet: MagicMock) -> MagicMock:
+    """A minimal pipe stand-in: enough for detect_model's isinstance/config
+    checks and for _load_model's post-load device-placement hasattr checks (all
+    no-ops here since acceleration defaults to "tensorrt")."""
+    pipe = MagicMock()
+    pipe.to.return_value = pipe
+    pipe.unet = unet
+    # loaded_via_single_file=True means resolve_is_turbo never trusts this
+    # scheduler anyway (see its docstring); explicitly None so
+    # _detect_turbo_from_scheduler -- still computed for detect_model's now-
+    # decoupled turbo_from_scheduler field -- short-circuits cleanly instead of
+    # chasing an unconfigured MagicMock.
+    pipe.scheduler = None
+    return pipe
+
+
+class TestSdTurboReconciliation:
+    """Step 1 regression seam: wrapper.sd_turbo must adopt resolve_is_turbo's
+    post-load verdict, not keep __init__'s pre-load basename guess.
+
+    Fixture: a checkpoint whose filename has no "turbo" substring (pre-load
+    guess -> False, via turbo_hint_from_model_id) but whose embedded
+    modelspec.architecture metadata declares it Turbo (post-load verdict, via
+    resolve_is_turbo -> True, source="modelspec"). Pre- and post-load values
+    genuinely disagree, so this is the input shape that actually exercises
+    Step 1's `if self.sd_turbo != is_turbo: ... self.sd_turbo = is_turbo`
+    adoption -- unlike the turbo_tests/ parent-directory fixture (see
+    TestSdTurboReconciliationGuardCase below), where Step 2's basename fix alone
+    already makes pre-load and post-load values agree and the adoption branch
+    never fires.
+
+    Aborts right after adoption (patching wrapper_module.StreamDiffusion to
+    raise) so the test stays cheap -- no real weights, no engine build.
+    """
+
+    def test_sd_turbo_flips_false_to_true_on_metadata_veto(self, tmp_path):
+        path = str(tmp_path / "model.safetensors")
+        save_file(
+            {"weight": torch.zeros(2, 2)},
+            path,
+            metadata={"modelspec.architecture": "stable-diffusion-xl-turbo-v1"},
+        )
+
+        w = _make_wrapper_shell(path)
+        assert w.sd_turbo is False, "sanity: pre-load basename guess must be False for this fixture"
+
+        pipe = _fake_sdxl_pipe(_fake_unet())
+        captured_kwargs = {}
+
+        def fake_auto_from_pretrained(*args, **kwargs):
+            raise RuntimeError("not a from_pretrained-loadable path")
+
+        def fake_sd_from_single_file(*args, **kwargs):
+            return pipe
+
+        def fake_stream_diffusion(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            raise RuntimeError("aborted after reconciliation -- test only needs wrapper state")
+
+        with (
+            patch.object(
+                wrapper_module.AutoPipelineForText2Image,
+                "from_pretrained",
+                staticmethod(fake_auto_from_pretrained),
+            ),
+            patch.object(
+                wrapper_module.StableDiffusionPipeline,
+                "from_single_file",
+                staticmethod(fake_sd_from_single_file),
+            ),
+            patch.object(wrapper_module, "StreamDiffusion", fake_stream_diffusion),
+        ):
+            with pytest.raises(RuntimeError, match="aborted after reconciliation"):
+                w._load_model(path, t_index_list=[0])
+
+        assert w.sd_turbo is True
+        assert w._is_turbo is True
+        assert w._is_turbo_source == "modelspec"
+        assert w.sd_turbo == w._is_turbo
+        # Step 4: the resolved verdict must also be threaded into StreamDiffusion(...),
+        # not just adopted onto self.sd_turbo.
+        assert captured_kwargs["is_turbo"] is True
+
+
+class TestSdTurboReconciliationGuardCase:
+    """The plan's originally-cited fixture shape (base checkpoint staged under a
+    `turbo_tests/` parent directory, basename itself has no "turbo") -- the
+    guard case Step 2's basename-only fix protects. Doesn't exercise the Step 1
+    adoption branch (pre-load and post-load values already agree once Step 2 is
+    in place -- see TestSdTurboReconciliation above for that), but this is the
+    first end-to-end check of that guard through the actual wrapper call path
+    rather than a direct resolve_is_turbo() call.
+    """
+
+    def test_parent_dir_named_turbo_does_not_misclassify_wrapper_state(self, tmp_path):
+        turbo_dir = tmp_path / "turbo_tests"
+        turbo_dir.mkdir()
+        path = str(turbo_dir / "base_checkpoint.safetensors")
+        save_file({"weight": torch.zeros(2, 2)}, path)
+
+        w = _make_wrapper_shell(path)
+        assert w.sd_turbo is False, "sanity: pre-load basename guess must ignore the parent dir"
+
+        pipe = _fake_sdxl_pipe(_fake_unet())
+
+        def fake_auto_from_pretrained(*args, **kwargs):
+            raise RuntimeError("not a from_pretrained-loadable path")
+
+        def fake_sd_from_single_file(*args, **kwargs):
+            return pipe
+
+        def fake_stream_diffusion(*args, **kwargs):
+            raise RuntimeError("aborted after reconciliation -- test only needs wrapper state")
+
+        with (
+            patch.object(
+                wrapper_module.AutoPipelineForText2Image,
+                "from_pretrained",
+                staticmethod(fake_auto_from_pretrained),
+            ),
+            patch.object(
+                wrapper_module.StableDiffusionPipeline,
+                "from_single_file",
+                staticmethod(fake_sd_from_single_file),
+            ),
+            patch.object(wrapper_module, "StreamDiffusion", fake_stream_diffusion),
+        ):
+            with pytest.raises(RuntimeError, match="aborted after reconciliation"):
+                w._load_model(path, t_index_list=[0])
+
+        assert w.sd_turbo is False
+        assert w._is_turbo is False
+        assert w._is_turbo_source == "undecided"
+        assert w.sd_turbo == w._is_turbo
+
+
+class TestLcmLoraGateFollowsResolvedVerdict:
+    """`lora_dict` is the only route by which the Turbo verdict could ever
+    alter a TensorRT engine's cache key (EngineManager._lora_signature,
+    engine_manager.py:83-107) -- get_engine_path itself carries no turbo
+    parameter of any kind. This pins that the deprecated LCM-LoRA gate at
+    wrapper.py:2174-2195 keys off self.sd_turbo *after* Step 1's adoption
+    (wrapper.py:2156-2161), not the pre-load basename guess -- i.e. that the
+    unification actually reaches this consumer, not just the log line.
+
+    Reuses the two fixtures above: the modelspec-veto checkpoint (Turbo=True)
+    and the turbo_tests/ guard-case checkpoint (Turbo=False), both loaded
+    through an SDXL-shaped pipe so `is_sdxl=True` selects lcm-lora-sdxl.
+    """
+
+    def test_turbo_verdict_skips_lcm_lora(self, tmp_path):
+        path = str(tmp_path / "model.safetensors")
+        save_file(
+            {"weight": torch.zeros(2, 2)},
+            path,
+            metadata={"modelspec.architecture": "stable-diffusion-xl-turbo-v1"},
+        )
+
+        w = _make_wrapper_shell(path)
+        w.use_lcm_lora = True
+
+        pipe = _fake_sdxl_pipe(_fake_unet())
+        captured_kwargs = {}
+
+        def fake_auto_from_pretrained(*args, **kwargs):
+            raise RuntimeError("not a from_pretrained-loadable path")
+
+        def fake_sd_from_single_file(*args, **kwargs):
+            return pipe
+
+        def fake_stream_diffusion(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            raise RuntimeError("aborted after reconciliation -- test only needs wrapper state")
+
+        with (
+            patch.object(
+                wrapper_module.AutoPipelineForText2Image,
+                "from_pretrained",
+                staticmethod(fake_auto_from_pretrained),
+            ),
+            patch.object(
+                wrapper_module.StableDiffusionPipeline,
+                "from_single_file",
+                staticmethod(fake_sd_from_single_file),
+            ),
+            patch.object(wrapper_module, "StreamDiffusion", fake_stream_diffusion),
+        ):
+            with pytest.raises(RuntimeError, match="aborted after reconciliation"):
+                w._load_model(path, t_index_list=[0])
+
+        assert w.sd_turbo is True
+        assert captured_kwargs["lora_dict"] is None
+        # Turbo branch takes the `else:` arm (wrapper.py:2188-2195), which
+        # clears the deprecated flag -- unlike the non-Turbo case below.
+        assert w.use_lcm_lora is None
+
+    def test_non_turbo_verdict_adds_lcm_lora_at_scale_one(self, tmp_path):
+        turbo_dir = tmp_path / "turbo_tests"
+        turbo_dir.mkdir()
+        path = str(turbo_dir / "base_checkpoint.safetensors")
+        save_file({"weight": torch.zeros(2, 2)}, path)
+
+        w = _make_wrapper_shell(path)
+        w.use_lcm_lora = True
+
+        pipe = _fake_sdxl_pipe(_fake_unet())
+        captured_kwargs = {}
+
+        def fake_auto_from_pretrained(*args, **kwargs):
+            raise RuntimeError("not a from_pretrained-loadable path")
+
+        def fake_sd_from_single_file(*args, **kwargs):
+            return pipe
+
+        def fake_stream_diffusion(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            raise RuntimeError("aborted after reconciliation -- test only needs wrapper state")
+
+        with (
+            patch.object(
+                wrapper_module.AutoPipelineForText2Image,
+                "from_pretrained",
+                staticmethod(fake_auto_from_pretrained),
+            ),
+            patch.object(
+                wrapper_module.StableDiffusionPipeline,
+                "from_single_file",
+                staticmethod(fake_sd_from_single_file),
+            ),
+            patch.object(wrapper_module, "StreamDiffusion", fake_stream_diffusion),
+        ):
+            with pytest.raises(RuntimeError, match="aborted after reconciliation"):
+                w._load_model(path, t_index_list=[0])
+
+        assert w.sd_turbo is False
+        assert captured_kwargs["lora_dict"] == {"latent-consistency/lcm-lora-sdxl": 1.0}
+        # Non-Turbo branch takes the `if:` arm (wrapper.py:2176-2187), which
+        # never touches self.use_lcm_lora.
+        assert w.use_lcm_lora is True
+
+
+@pytest.mark.skip(
+    reason=(
+        "fp8_guidance_scale (wrapper.py:3016) is the resolved verdict's second "
+        "behavioural consumer, found during MCP-graph re-verification of the "
+        "detection-unification plan -- see the plan's test 5. Reaching that line "
+        "needs _load_model driven past real StreamDiffusion construction, LoRA "
+        "adapter activation, and EngineManager.get_engine_path resolution (fp8=True, "
+        "acceleration='tensorrt') -- far past the abort-after-reconciliation seam "
+        "every other test in this file uses (patch.object(wrapper_module, "
+        "'StreamDiffusion', <raiser>) short-circuits before that code ever runs). "
+        "Driving it for real would mean either mocking ~750 lines of intervening "
+        "engine-manager/pipeline plumbing (its own source of false confidence) or "
+        "adding a GPU-dependent integration test, which is out of scope for the "
+        "unit-tests-only, no-GPU constraint this plan was scoped to. Per the plan's "
+        "documented fallback: skip with a pointer at the coupling (added at "
+        "wrapper.py:3016) rather than a shallow/misleading unit test."
+    )
+)
+def test_fp8_guidance_scale_follows_resolved_verdict():
+    """Placeholder documenting the coupling and why it isn't unit-tested here:
+    `_unet_build_opts["fp8_guidance_scale"] = 0.0 if _is_turbo else 7.5`
+    (wrapper.py:3016) should be 0.0 for a Turbo verdict and 7.5 otherwise --
+    i.e. FP8 calibration keys off resolve_is_turbo()'s answer, not a stale
+    heuristic. Not reachable from the wrapper's live config anyway
+    (StreamDiffusionTD/td_config.yaml has fp8: false), so this branch is dead
+    for the current deployment regardless.
+    """


### PR DESCRIPTION
## Summary

Two independent, verified bugs in Turbo-model handling, plus removal of the dead
scheduler API that motivated re-checking this area:

1. **`detect_model()`'s `is_turbo` heuristic is backwards for SDXL, and never fires for
   SD2.1.** The comment claimed "Base SDXL has `time_cond_proj_dim` (e.g., 256), while
   Turbo has it set to `None`" — but `time_cond_proj_dim` is the LCM-distillation
   guidance-embedding dim, not a Turbo/Base signal. `sdxl-base-1.0`'s published
   `unet/config.json` also has it `null`, so stock SDXL-Base was classified
   `is_turbo=True`. Separately, the non-SDXL UNet branch never set `is_turbo` at all, so
   `sd-turbo` (`addition_embed_type: null`, `cross_attention_dim: 1024`) was always
   classified `is_turbo=False`. The ControlNet branch repeats the identical heuristic and
   needed the same fix.

   Fix: discriminate using the source scheduler instead — `pipe.scheduler.config` already
   carries `_class_name` + `timestep_spacing`, and ADD-distilled Turbo checkpoints ship
   `EulerAncestralDiscreteScheduler` + `timestep_spacing="trailing"` while base SDXL ships
   `EulerDiscreteScheduler` + `leading`. `detect_model` already accepts an optional `pipe`
   argument for exactly this purpose (used by the SD3 branch already). New
   `_detect_turbo_from_scheduler(pipe)` helper returns `None` when undecided (no pipe /
   no scheduler), in which case the existing behavior is preserved unchanged.

2. **A live `num_inference_steps` change silently discards the timestep-spacing override.**
   `stream_parameter_updater.py` called `scheduler.set_timesteps(...)` directly instead of
   the shared `param_schema.materialise_timestep_grid(...)` helper that `prepare()` and the
   fp8-calibration path already route through. For non-default samplers whose spacing
   strategy differs from the scheduler's native grid, this meant a runtime step-count
   change would silently revert to the native grid on the next step, contradicting
   whatever spacing the sampler selection implied — with no warning anywhere.

3. **Dead code removed:** `set_scheduler()` and `_uses_lcm_logic()` on `StreamDiffusion`
   have zero callers anywhere in the codebase (grepped `src/`, `examples/`, `scripts/`,
   `tests/`). `set_scheduler` would also leave `timesteps`/`sub_timesteps`/`c_skip`/
   `c_out`/alpha-beta state stale if it were ever called, since it doesn't recompute them.

4. **`examples/txt2img/spacing_compare.py` corrected its premise.** The example assumed
   `original_inference_steps=50` (LCM's `LCMScheduler` default), but `_initialize_scheduler`
   forces `original_inference_steps=100`. That changes the "on-grid" divisor set from
   `{10, 25}` to `{10, 20, 25}` and the modulus check from `t % 20 == 19` to
   `t % 10 == 9`. Docstring, comments, and the on-grid predicate are corrected to match;
   the script's behavior/output is otherwise unchanged (still not executed as part of this
   PR — it is a documentation-style example, not covered by CI).

## Tests

- `tests/unit/test_model_detection.py` (new): 9 tests covering
  `_detect_turbo_from_scheduler` directly, plus end-to-end `detect_model()` assertions for
  the three checkpoints this bug affects — `sd-turbo → is_turbo=True`,
  `sdxl-turbo → is_turbo=True`, `sdxl-base-1.0 → is_turbo=False` — using UNet configs
  stubbed from each checkpoint's published `unet/config.json` (`sdxl-turbo` and
  `sdxl-base-1.0` deliberately share an identical UNet-config shape to prove only the
  scheduler discriminates them).
- `tests/unit/test_param_schema.py`: added `TestMaterialiseTimestepGrid` (4 cases) —
  normal sampler passes through untouched; spacing samplers override and mutate in place;
  scheduler config spacing is threaded through; unrecognized spacing falls back safely.
- Full suite: `532 passed, 1 skipped` locally against this branch (the only pre-existing
  suite items not exercised here are unrelated to this change — a fixture in
  `test_cn_preprocessor_residency.py` that loads a file from outside the repo boundary and
  is environment-path-dependent, not something this PR touches).

## Behavioral scope

All four changes are no-ops at default settings (`sampler="normal"`, no live step-count
changes) — nothing here changes rendered output unless a build already selects a
non-default sampler, or code (e.g. FP8 calibration) already reads `is_turbo` for an
affected checkpoint. `is_turbo` is not part of any TensorRT engine cache key, so no
existing engine is invalidated by this fix.
