### PR TITLE
fix: replace decommissioned NGC pypi mirror with pypi.nvidia.com

### DIFF
--- a/src/streamdiffusion/tools/install-tensorrt.py
+++ b/src/streamdiffusion/tools/install-tensorrt.py
@@ -28,9 +28,9 @@ def install(cu: Optional[Literal["11", "12"]] = get_cuda_major()):
         run_pip(f"install --extra-index-url https://pypi.nvidia.com {trt_package} --no-cache-dir")
 
     if not is_installed("polygraphy"):
-        run_pip("install polygraphy==0.49.26 --extra-index-url https://pypi.ngc.nvidia.com")
+        run_pip("install polygraphy==0.49.26 --extra-index-url https://pypi.nvidia.com")
     if not is_installed("onnx_graphsurgeon"):
-        run_pip("install onnx-graphsurgeon==0.6.1 --extra-index-url https://pypi.ngc.nvidia.com")
+        run_pip("install onnx-graphsurgeon==0.6.1 --extra-index-url https://pypi.nvidia.com")
     if platform.system() == "Windows" and not is_installed("pywin32"):
         run_pip("install pywin32==311")
     if platform.system() == "Windows" and not is_installed("triton"):


### PR DESCRIPTION
## Summary
- `pypi.ngc.nvidia.com` is decommissioned (NXDOMAIN). Replace both remaining references in `tools/install-tensorrt.py` with `pypi.nvidia.com`, the same index NVIDIA's own migration guidance points to and that `install-tensorrt.py` already uses elsewhere in the file.

## Evidence
```
nslookup pypi.ngc.nvidia.com                -> NXDOMAIN
https://pypi.nvidia.com/polygraphy/         -> 200, polygraphy-0.49.26-py2.py3-none-any.whl
https://pypi.nvidia.com/onnx-graphsurgeon/  -> 200, onnx_graphsurgeon-0.6.1-py2.py3-none-any.whl
```
Both pinned versions (`polygraphy==0.49.26`, `onnx-graphsurgeon==0.6.1`) exist on the replacement index — a drop-in swap, not a version change. Reproduced directly: uninstalled and reinstalled both packages via the patched `--extra-index-url https://pypi.nvidia.com` command, both succeeded.

Also verified end-to-end via a full from-scratch installer run against this change — no NGC/DNS noise in the install log.

## Companion PRs
Same NGC index swap, applied to the two other repos that independently hardcode it:
- dotsimulate/StreamDiffusion-installer#4
- dotsimulate/StreamDiffusionTD#8

🤖 Generated with [Claude Code](https://claude.com/claude-code)