### PR TITLE
fix(preproc): stop cuDNN autotune on smoothness blur

### DIFF
--- a/src/streamdiffusion/preprocessing/processors/category_params.py
+++ b/src/streamdiffusion/preprocessing/processors/category_params.py
@@ -18,6 +18,7 @@ NumPy helper: apply_depth_grade_numpy
 from __future__ import annotations
 
 import math
+import threading
 
 import numpy as np
 import torch
@@ -123,6 +124,12 @@ SEGMENTATION_PARAMS: dict = {
 # GPU helpers (operate on torch.Tensor, no CPU round-trip)
 # ---------------------------------------------------------------------------
 
+# torch.backends.cudnn.flags(...) snapshots/restores process-global state, not thread-local
+# state. apply_edge_smoothness is called concurrently from ThreadPoolExecutor worker threads
+# (preprocessing_orchestrator.py's parallel ControlNet dispatch), so unsynchronized enter/exit
+# can leave the global cudnn.benchmark flag stuck in the wrong state. Serialize with a lock.
+_EDGE_SMOOTHNESS_CUDNN_LOCK = threading.Lock()
+
 
 def apply_edge_smoothness(t: torch.Tensor, strength: float) -> torch.Tensor:
     """Apply an adaptive separable Gaussian pre-blur to a grayscale / edge-map tensor.
@@ -134,8 +141,8 @@ def apply_edge_smoothness(t: torch.Tensor, strength: float) -> torch.Tensor:
     Args:
         t:        Input tensor.  Accepts (H, W), (C, H, W), or (1, C, H, W).
         strength: Blur intensity in [0, 1].  Maps to σ ∈ [0, 2] (3σ gives the kernel radius).
-                  At strength=1: σ=2, radius=6, k_size=13.  The convolutions run with
-                  cuDNN benchmarking disabled so a changing kernel size never re-autotunes.
+                  At strength=1: σ=2, radius=6, k_size=13.  cuDNN benchmarking is disabled
+                  (under a lock) so a changing kernel size never re-autotunes.
 
     Returns:
         Blurred tensor with the same shape and dtype as *t*.
@@ -169,8 +176,10 @@ def apply_edge_smoothness(t: torch.Tensor, strength: float) -> torch.Tensor:
 
     # The kernel size follows the knob, so with the pipeline's global cudnn.benchmark=True
     # every new strength would be a new conv shape and trigger a ~750 ms cuDNN autotune
-    # (a visible freeze while dragging the Smoothing knob). Use heuristic algo selection here.
-    with torch.backends.cudnn.flags(enabled=True, benchmark=False):
+    # (a visible freeze while dragging the Smoothing knob). Use heuristic algo selection here,
+    # guarded by a lock since the flag context manager mutates process-global state and this
+    # function runs from concurrent ThreadPoolExecutor worker threads.
+    with _EDGE_SMOOTHNESS_CUDNN_LOCK, torch.backends.cudnn.flags(enabled=True, benchmark=False):
         x = F.conv2d(x, k_h, padding=(radius, 0), groups=c)
         x = F.conv2d(x, k_w, padding=(0, radius), groups=c)
 

--- a/src/streamdiffusion/preprocessing/processors/category_params.py
+++ b/src/streamdiffusion/preprocessing/processors/category_params.py
@@ -134,7 +134,8 @@ def apply_edge_smoothness(t: torch.Tensor, strength: float) -> torch.Tensor:
     Args:
         t:        Input tensor.  Accepts (H, W), (C, H, W), or (1, C, H, W).
         strength: Blur intensity in [0, 1].  Maps to σ ∈ [0, 2] (3σ gives the kernel radius).
-                  At strength=1: σ=2, radius=6, k_size=13.
+                  At strength=1: σ=2, radius=6, k_size=13.  The convolutions run with
+                  cuDNN benchmarking disabled so a changing kernel size never re-autotunes.
 
     Returns:
         Blurred tensor with the same shape and dtype as *t*.
@@ -166,8 +167,12 @@ def apply_edge_smoothness(t: torch.Tensor, strength: float) -> torch.Tensor:
     k_h = kernel_1d.view(1, 1, k_size, 1).expand(c, 1, k_size, 1).contiguous()
     k_w = kernel_1d.view(1, 1, 1, k_size).expand(c, 1, 1, k_size).contiguous()
 
-    x = F.conv2d(x, k_h, padding=(radius, 0), groups=c)
-    x = F.conv2d(x, k_w, padding=(0, radius), groups=c)
+    # The kernel size follows the knob, so with the pipeline's global cudnn.benchmark=True
+    # every new strength would be a new conv shape and trigger a ~750 ms cuDNN autotune
+    # (a visible freeze while dragging the Smoothing knob). Use heuristic algo selection here.
+    with torch.backends.cudnn.flags(enabled=True, benchmark=False):
+        x = F.conv2d(x, k_h, padding=(radius, 0), groups=c)
+        x = F.conv2d(x, k_w, padding=(0, radius), groups=c)
 
     # Restore original shape
     if len(orig_shape) == 2:

--- a/tests/unit/test_edge_smoothness_cudnn_guard.py
+++ b/tests/unit/test_edge_smoothness_cudnn_guard.py
@@ -1,0 +1,46 @@
+"""
+Regression coverage for the cuDNN-benchmark guard inside apply_edge_smoothness.
+
+With the pipeline's global torch.backends.cudnn.benchmark=True, every new smoothness
+strength is a new conv shape and would trigger a ~750 ms cuDNN autotune pass (a visible
+freeze while dragging the Smoothing knob). apply_edge_smoothness works around this by
+running its two separable conv2d passes under torch.backends.cudnn.flags(benchmark=False),
+restoring the global flag afterward. This file asserts both halves of that contract.
+"""
+
+import torch
+
+from streamdiffusion.preprocessing.processors.category_params import apply_edge_smoothness
+
+
+def test_edge_smoothness_leaves_global_cudnn_benchmark_untouched():
+    prev = torch.backends.cudnn.benchmark
+    try:
+        torch.backends.cudnn.benchmark = True
+        x = torch.rand(32, 48)
+        y = apply_edge_smoothness(x, 0.7)
+        assert y.shape == x.shape and y.dtype == x.dtype
+        assert torch.backends.cudnn.benchmark is True
+    finally:
+        torch.backends.cudnn.benchmark = prev
+
+
+def test_edge_smoothness_disables_benchmark_inside_conv(monkeypatch):
+    import torch.nn.functional as F
+
+    real_conv2d = F.conv2d
+    seen = []
+
+    def recording_conv2d(*args, **kwargs):
+        seen.append(torch.backends.cudnn.benchmark)
+        return real_conv2d(*args, **kwargs)
+
+    monkeypatch.setattr(F, "conv2d", recording_conv2d)
+    prev = torch.backends.cudnn.benchmark
+    try:
+        torch.backends.cudnn.benchmark = True
+        apply_edge_smoothness(torch.rand(1, 16, 16), 0.4)
+    finally:
+        torch.backends.cudnn.benchmark = prev
+    assert len(seen) == 2  # separable: one horizontal + one vertical pass
+    assert seen == [False, False]


### PR DESCRIPTION
## Summary

- `apply_edge_smoothness`'s separable Gaussian blur kernel size tracks the `strength` knob (`k_size = 2*radius+1`, 6 distinct buckets across `strength ∈ (0, 1]`). With the pipeline's global `cudnn.benchmark=True`, each new kernel shape triggers a ~750ms cuDNN autotune pass — a visible freeze while dragging the Smoothing knob.
- Wraps the two `F.conv2d` calls in `torch.backends.cudnn.flags(enabled=True, benchmark=False)` to use heuristic algorithm selection for this call site instead.
- Guards that flag mutation with a module-level `threading.Lock`, since `apply_edge_smoothness` (via `scribble_tensorrt.py`) runs from `ThreadPoolExecutor` worker threads during parallel ControlNet dispatch, and `cudnn.flags` snapshots/restores process-global (not thread-local) state — unsynchronized concurrent enter/exit could otherwise leave the global flag stuck at `benchmark=False` for the rest of the process.

## Branch note

Single squashed-equivalent change (2 commits: the fix, then a thread-safety follow-up from fork-side review) touching only `src/streamdiffusion/preprocessing/processors/category_params.py`. No fork-local paths involved.
