### PR TITLE
fix(pose): letterboxed OpenPose-18 canvas rendering + YOLO-NAS TRT engine builder

### DIFF
--- a/src/streamdiffusion/preprocessing/processors/category_params.py
+++ b/src/streamdiffusion/preprocessing/processors/category_params.py
@@ -78,15 +78,17 @@ POSE_DRAW_PARAMS: dict = {
     },
     "joint_thickness": {
         "type": "int",
-        "default": 10,
+        "default": 4,
         "range": [1, 30],
-        "description": "Thickness of skeleton limb lines (pixels).",
+        "description": "Half-width of the filled skeleton limb ellipses (pixels). Default matches "
+        "the OpenPose rendering convention xinsir/controlnet-openpose-sdxl-1.0 was trained on.",
     },
     "keypoint_radius": {
         "type": "int",
-        "default": 10,
+        "default": 4,
         "range": [1, 30],
-        "description": "Radius of keypoint dots (pixels).",
+        "description": "Radius of keypoint dots (pixels). Default matches the OpenPose rendering "
+        "convention xinsir/controlnet-openpose-sdxl-1.0 was trained on.",
     },
 }
 

--- a/src/streamdiffusion/preprocessing/processors/pose_tensorrt.py
+++ b/src/streamdiffusion/preprocessing/processors/pose_tensorrt.py
@@ -228,7 +228,8 @@ def show_predictions_from_batch_format(
     keypoint_radius: int = 4,
     canvas_width: int = 640,
     canvas_height: int = 640,
-    letterbox_scale: float = 1.0,
+    letterbox_scale_x: float = 1.0,
+    letterbox_scale_y: float = 1.0,
     letterbox_pad_x: int = 0,
     letterbox_pad_y: int = 0,
 ):
@@ -239,16 +240,20 @@ def show_predictions_from_batch_format(
         keypoint_threshold:  Confidence cutoff for drawing joints (category-standard param).
         joint_thickness:     Skeleton limb ellipse half-width, in pixels.
         keypoint_radius:     Keypoint dot radius in pixels.
-        canvas_width:        Output canvas width, in pixels. Should match the caller's
-                              get_target_dimensions() so no further resize is needed -- a
-                              mismatch crops/misplaces the skeleton silently (no exception).
-        canvas_height:       Output canvas height, in pixels. See canvas_width.
-        letterbox_scale:     Scale factor from `_letterbox_resize` that produced the
-                              detection-space image. Joints from iterate_over_batch_predictions
-                              are in that padded square's pixel space, not the original frame's;
-                              this (with the pad offsets below) maps them back.
-        letterbox_pad_x:     Horizontal letterbox padding (pixels) to undo.
-        letterbox_pad_y:     Vertical letterbox padding (pixels) to undo.
+        canvas_width:        Output canvas width, in pixels.
+        canvas_height:       Output canvas height, in pixels.
+        letterbox_scale_x:   Combined per-axis scale mapping detection-space (the letterboxed
+                              detect_resolution square) directly to this canvas: undoes
+                              `_letterbox_resize`'s scale, then rescales the original frame to
+                              (canvas_width, canvas_height) -- the same squash the base class's
+                              `_ensure_target_size` applies to every other preprocessor's output.
+                              The original frame's own size is *not* necessarily canvas_width x
+                              canvas_height (that's the pipeline's configured resolution, not the
+                              source frame's), so this must not be conflated with the plain
+                              `1/letterbox_scale` undo.
+        letterbox_scale_y:   Combined per-axis scale, vertical. See letterbox_scale_x.
+        letterbox_pad_x:     Horizontal letterbox padding (pixels) to undo, applied before scale.
+        letterbox_pad_y:     Vertical letterbox padding (pixels) to undo, applied before scale.
 
     The canvas is allocated uint8, not the numpy float64 default: cv2.LINE_AA (used by
     PoseVisualization.draw_skeleton) is silently a no-op on float64 images -- measured 2 unique pixel
@@ -268,11 +273,15 @@ def show_predictions_from_batch_format(
     try:
         pred_joints = pred_joints.astype(np.float32, copy=True)
 
-        # Undo the letterbox: joints are in the padded detect_resolution-square's pixel space,
-        # not the original frame's -- see _letterbox_resize.
-        if letterbox_scale != 1.0 or letterbox_pad_x or letterbox_pad_y:
-            pred_joints[..., 0] = (pred_joints[..., 0] - letterbox_pad_x) / letterbox_scale
-            pred_joints[..., 1] = (pred_joints[..., 1] - letterbox_pad_y) / letterbox_scale
+        # Undo the letterbox directly into canvas space: joints are in the padded
+        # detect_resolution-square's pixel space, not this canvas's -- see _letterbox_resize
+        # and the letterbox_scale_x/y docstring above (this is NOT a plain 1/letterbox_scale
+        # undo -- that would land joints in the original frame's own pixel space, which is a
+        # different rectangle than (canvas_width, canvas_height) whenever the source frame's
+        # resolution doesn't happen to match the pipeline's configured output resolution).
+        if letterbox_scale_x != 1.0 or letterbox_scale_y != 1.0 or letterbox_pad_x or letterbox_pad_y:
+            pred_joints[..., 0] = (pred_joints[..., 0] - letterbox_pad_x) * letterbox_scale_x
+            pred_joints[..., 1] = (pred_joints[..., 1] - letterbox_pad_y) * letterbox_scale_y
 
         # Remap COCO-17 -> OpenPose-18 (see OPENPOSE18_FROM_COCO17). "neck" (index 1) is
         # synthesized as the shoulder midpoint, gated on the *lower* of the two shoulder
@@ -389,6 +398,7 @@ class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
 
         image_tensor = torch.from_numpy(np.array(image)).float() / 255.0
         image_tensor = image_tensor.permute(2, 0, 1).unsqueeze(0)
+        _, _, orig_height, orig_width = image_tensor.shape
 
         image_resized, letterbox_scale, pad_x, pad_y = _letterbox_resize(image_tensor, detect_resolution)
 
@@ -406,6 +416,12 @@ class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
         joint_thickness = int(self.params.get("joint_thickness", 4))
         keypoint_radius = int(self.params.get("keypoint_radius", 4))
 
+        # Compose the letterbox undo with the (possibly anisotropic) squash from the source
+        # frame's own resolution to the pipeline's configured canvas resolution -- these are
+        # independent quantities, see letterbox_scale_x/y's docstring.
+        letterbox_scale_x = (target_width / orig_width) / letterbox_scale
+        letterbox_scale_y = (target_height / orig_height) / letterbox_scale
+
         try:
             pose_image = show_predictions_from_batch_format(
                 predictions,
@@ -414,7 +430,8 @@ class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
                 keypoint_radius=keypoint_radius,
                 canvas_width=target_width,
                 canvas_height=target_height,
-                letterbox_scale=letterbox_scale,
+                letterbox_scale_x=letterbox_scale_x,
+                letterbox_scale_y=letterbox_scale_y,
                 letterbox_pad_x=pad_x,
                 letterbox_pad_y=pad_y,
             )
@@ -446,6 +463,7 @@ class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
 
         detect_resolution = self.params.get("detect_resolution", 640)
         target_width, target_height = self.get_target_dimensions()
+        _, _, orig_height, orig_width = image_tensor.shape
 
         image_resized, letterbox_scale, pad_x, pad_y = _letterbox_resize(image_tensor, detect_resolution)
 
@@ -460,6 +478,11 @@ class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
         joint_thickness = int(self.params.get("joint_thickness", 4))
         keypoint_radius = int(self.params.get("keypoint_radius", 4))
 
+        # Compose the letterbox undo with the squash from the source frame's own resolution to
+        # the pipeline's configured canvas resolution -- see letterbox_scale_x/y's docstring.
+        letterbox_scale_x = (target_width / orig_width) / letterbox_scale
+        letterbox_scale_y = (target_height / orig_height) / letterbox_scale
+
         try:
             pose_image = show_predictions_from_batch_format(
                 predictions,
@@ -468,7 +491,8 @@ class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
                 keypoint_radius=keypoint_radius,
                 canvas_width=target_width,
                 canvas_height=target_height,
-                letterbox_scale=letterbox_scale,
+                letterbox_scale_x=letterbox_scale_x,
+                letterbox_scale_y=letterbox_scale_y,
                 letterbox_pad_x=pad_x,
                 letterbox_pad_y=pad_y,
             )

--- a/src/streamdiffusion/preprocessing/processors/pose_tensorrt.py
+++ b/src/streamdiffusion/preprocessing/processors/pose_tensorrt.py
@@ -1,5 +1,6 @@
 # NOTE: ported from https://github.com/yuvraj108c/ComfyUI-YoloNasPose-Tensorrt
 
+import math
 import os
 
 import cv2
@@ -14,7 +15,15 @@ from .trt_base import TENSORRT_AVAILABLE, TensorRTEngine  # shared engine wrappe
 
 
 class PoseVisualization:
-    """Pose drawing utilities ported from ComfyUI YoloNasPose node"""
+    """Pose drawing utilities.
+
+    Rendering convention ported from controlnet_aux.open_pose.util.draw_bodypose (filled
+    tapered-ellipse limbs at 60% color intensity, full-intensity color-coded joint dots) --
+    the convention xinsir/controlnet-openpose-sdxl-1.0 was actually trained on. The previous
+    cv2.line/hard-coded-green-circle rendering, plus a final cv2.addWeighted(overlay, 0.75,
+    image, 0.25, 0) blend that silently dimmed every stroke to 75% intensity, produced an
+    off-distribution, mislabeled skeleton (see plan Finding 3).
+    """
 
     @staticmethod
     def draw_skeleton(
@@ -22,31 +31,44 @@ class PoseVisualization:
         keypoints,
         edge_links,
         edge_colors,
-        joint_thickness=10,
-        keypoint_radius=10,
+        joint_thickness=4,
+        keypoint_radius=4,
         keypoint_threshold=0.5,
     ):
-        """Draw pose skeleton on image"""
-        overlay = image.copy()
+        """Draw one pose directly onto `image` (mutated in place, and returned).
 
-        # Draw edges/links between keypoints
+        No alpha blend: `image` is drawn on at full intensity (limb fill color is 60% per the
+        OpenPose convention above, not a canvas-wide blend).
+        """
+        # Draw limbs as filled, tapered ellipse polygons
         for (kp1, kp2), color in zip(edge_links, edge_colors):
-            if kp1 < len(keypoints) and kp2 < len(keypoints):
-                # Check if both keypoints are valid (confidence > threshold)
-                if len(keypoints[kp1]) >= 3 and len(keypoints[kp2]) >= 3:
-                    conf1, conf2 = keypoints[kp1][2], keypoints[kp2][2]
-                    if conf1 > keypoint_threshold and conf2 > keypoint_threshold:
-                        p1 = (int(keypoints[kp1][0]), int(keypoints[kp1][1]))
-                        p2 = (int(keypoints[kp2][0]), int(keypoints[kp2][1]))
-                        cv2.line(overlay, p1, p2, color=color, thickness=joint_thickness, lineType=cv2.LINE_AA)
+            if kp1 >= len(keypoints) or kp2 >= len(keypoints):
+                continue
+            j1, j2 = keypoints[kp1], keypoints[kp2]
+            if len(j1) < 3 or len(j2) < 3:
+                continue
+            if j1[2] <= keypoint_threshold or j2[2] <= keypoint_threshold:
+                continue
+            x1, y1 = float(j1[0]), float(j1[1])
+            x2, y2 = float(j2[0]), float(j2[1])
+            mid_x, mid_y = (x1 + x2) / 2.0, (y1 + y2) / 2.0
+            length = ((x1 - x2) ** 2 + (y1 - y2) ** 2) ** 0.5
+            angle = math.degrees(math.atan2(y1 - y2, x1 - x2))
+            polygon = cv2.ellipse2Poly(
+                (int(mid_x), int(mid_y)), (int(length / 2), joint_thickness), int(angle), 0, 360, 1
+            )
+            dimmed_color = [int(c * 0.6) for c in color]
+            cv2.fillConvexPoly(image, polygon, dimmed_color, lineType=cv2.LINE_AA)
 
-        # Draw keypoints
-        for keypoint in keypoints:
-            if len(keypoint) >= 3 and keypoint[2] > keypoint_threshold:
-                x, y = int(keypoint[0]), int(keypoint[1])
-                cv2.circle(overlay, (x, y), keypoint_radius, (0, 255, 0), -1, cv2.LINE_AA)
+        # Draw keypoints as full-intensity dots, colour-coded per joint index (not
+        # hard-coded green -- OpenPose ControlNets key limb/joint identity off colour).
+        for keypoint, color in zip(keypoints, edge_colors):
+            if len(keypoint) < 3 or keypoint[2] <= keypoint_threshold:
+                continue
+            x, y = int(keypoint[0]), int(keypoint[1])
+            cv2.circle(image, (x, y), keypoint_radius, color, -1, cv2.LINE_AA)
 
-        return cv2.addWeighted(overlay, 0.75, image, 0.25, 0)
+        return image
 
     @staticmethod
     def draw_poses(
@@ -54,8 +76,8 @@ class PoseVisualization:
         poses,
         edge_links,
         edge_colors,
-        joint_thickness=10,
-        keypoint_radius=10,
+        joint_thickness=4,
+        keypoint_radius=4,
         keypoint_threshold=0.5,
     ):
         """Draw multiple poses on image"""
@@ -95,59 +117,144 @@ def iterate_over_batch_predictions(predictions, batch_size):
         yield image_index, pred_boxes, pred_scores, pred_joints
 
 
-# precompute edge links define skeleton connections (COCO format)
-edge_links = [
-    [0, 17],
-    [13, 15],
-    [14, 16],
-    [12, 14],
-    [12, 17],
-    [5, 6],
-    [11, 13],
-    [7, 9],
-    [5, 7],
-    [17, 11],
-    [6, 8],
-    [8, 10],
-    [1, 3],
-    [0, 1],
-    [0, 2],
-    [2, 4],
+def _letterbox_resize(image_tensor: torch.Tensor, target: int):
+    """Aspect-ratio-preserving resize of a (1,3,H,W) [0,1] tensor into a (1,3,target,target)
+    square, padded with black.
+
+    Replaces the previous unconditional F.interpolate(..., size=(target, target)) square
+    resize, which anisotropically stretched non-square frames (e.g. 640x384 -> 640x640 is a
+    1.67x vertical stretch) before pose detection -- distorting the subject the detector sees
+    and, after the compensating squash back to the output aspect ratio, turning skeleton
+    circles/limb widths anisotropic (plan Finding 3e). Padding uses black (0) rather than the
+    conventional YOLO grey (114/255): the engine's original training pad colour isn't known
+    here, and an all-black region is the safer default against spurious detections.
+
+    Returns:
+        (padded_tensor, scale, pad_x, pad_y) -- callers map detection-space keypoints back to
+        the original frame via `(x - pad_x) / scale`, `(y - pad_y) / scale`.
+    """
+    _, _, h, w = image_tensor.shape
+    scale = min(target / h, target / w)
+    new_h, new_w = max(1, round(h * scale)), max(1, round(w * scale))
+    resized = F.interpolate(image_tensor, size=(new_h, new_w), mode="bilinear", align_corners=False)
+    pad_x = (target - new_w) // 2
+    pad_y = (target - new_h) // 2
+    padded = image_tensor.new_zeros((image_tensor.shape[0], image_tensor.shape[1], target, target))
+    padded[:, :, pad_y : pad_y + new_h, pad_x : pad_x + new_w] = resized
+    return padded, scale, pad_x, pad_y
+
+
+# YOLO-NAS Pose outputs COCO-17 keypoints, in the standard order: 0 nose, 1 left_eye,
+# 2 right_eye, 3 left_ear, 4 right_ear, 5 left_shoulder, 6 right_shoulder, 7 left_elbow,
+# 8 right_elbow, 9 left_wrist, 10 right_wrist, 11 left_hip, 12 right_hip, 13 left_knee,
+# 14 right_knee, 15 left_ankle, 16 right_ankle.
+#
+# xinsir/controlnet-openpose-sdxl-1.0 was trained on OpenPose's COCO-18 body format, which
+# reorders these and inserts a synthetic "neck" (shoulder midpoint) at index 1. This table maps
+# OpenPose-18 slot -> COCO-17 index (None = no direct counterpart; synthesized separately in
+# show_predictions_from_batch_format).
+OPENPOSE18_FROM_COCO17 = [
+    0,  # 0  nose
+    None,  # 1  neck (synthetic: shoulder midpoint)
+    6,  # 2  right_shoulder
+    8,  # 3  right_elbow
+    10,  # 4  right_wrist
+    5,  # 5  left_shoulder
+    7,  # 6  left_elbow
+    9,  # 7  left_wrist
+    12,  # 8  right_hip
+    14,  # 9  right_knee
+    16,  # 10 right_ankle
+    11,  # 11 left_hip
+    13,  # 12 left_knee
+    15,  # 13 left_ankle
+    2,  # 14 right_eye
+    1,  # 15 left_eye
+    4,  # 16 right_ear
+    3,  # 17 left_ear
 ]
 
+# Skeleton limb topology in OpenPose-18 index space, ported verbatim (converted from 1-indexed
+# to 0-indexed) from controlnet_aux.open_pose.util.draw_bodypose's `limbSeq` -- the topology
+# xinsir/controlnet-openpose-sdxl-1.0 was trained against.
+edge_links = [
+    [1, 2],
+    [1, 5],
+    [2, 3],
+    [3, 4],
+    [5, 6],
+    [6, 7],
+    [1, 8],
+    [8, 9],
+    [9, 10],
+    [1, 11],
+    [11, 12],
+    [12, 13],
+    [1, 0],
+    [0, 14],
+    [14, 16],
+    [0, 15],
+    [15, 17],
+]
+
+# Per-limb/joint RGB colours, ported verbatim from the same source (its `colors`). The first 17
+# entries colour the limbs (zipped against edge_links above); all 18 colour the joints.
 edge_colors = [
     [255, 0, 0],
     [255, 85, 0],
+    [255, 170, 0],
+    [255, 255, 0],
     [170, 255, 0],
     [85, 255, 0],
-    [85, 255, 0],
+    [0, 255, 0],
+    [0, 255, 85],
+    [0, 255, 170],
+    [0, 255, 255],
+    [0, 170, 255],
+    [0, 85, 255],
+    [0, 0, 255],
     [85, 0, 255],
-    [255, 170, 0],
-    [0, 177, 58],
-    [0, 179, 119],
-    [179, 179, 0],
-    [0, 119, 179],
-    [0, 179, 179],
-    [119, 0, 179],
-    [179, 0, 179],
-    [178, 0, 118],
-    [178, 0, 118],
+    [170, 0, 255],
+    [255, 0, 255],
+    [255, 0, 170],
+    [255, 0, 85],
 ]
 
 
 def show_predictions_from_batch_format(
     predictions,
     keypoint_threshold: float = 0.5,
-    joint_thickness: int = 10,
-    keypoint_radius: int = 10,
+    joint_thickness: int = 4,
+    keypoint_radius: int = 4,
+    canvas_width: int = 640,
+    canvas_height: int = 640,
+    letterbox_scale: float = 1.0,
+    letterbox_pad_x: int = 0,
+    letterbox_pad_y: int = 0,
 ):
-    """Convert predictions to pose visualization format.
+    """Convert predictions to an OpenPose-COCO18-format pose visualization.
 
     Args:
         predictions:         Raw TRT engine output list (num_dets, boxes, scores, joints).
         keypoint_threshold:  Confidence cutoff for drawing joints (category-standard param).
-        joint_thickness:     Skeleton limb line thickness in pixels.
+        joint_thickness:     Skeleton limb ellipse half-width, in pixels.
         keypoint_radius:     Keypoint dot radius in pixels.
+        canvas_width:        Output canvas width, in pixels. Should match the caller's
+                              get_target_dimensions() so no further resize is needed -- a
+                              mismatch crops/misplaces the skeleton silently (no exception).
+        canvas_height:       Output canvas height, in pixels. See canvas_width.
+        letterbox_scale:     Scale factor from `_letterbox_resize` that produced the
+                              detection-space image. Joints from iterate_over_batch_predictions
+                              are in that padded square's pixel space, not the original frame's;
+                              this (with the pad offsets below) maps them back.
+        letterbox_pad_x:     Horizontal letterbox padding (pixels) to undo.
+        letterbox_pad_y:     Vertical letterbox padding (pixels) to undo.
+
+    The canvas is allocated uint8, not the numpy float64 default: cv2.LINE_AA (used by
+    PoseVisualization.draw_skeleton) is silently a no-op on float64 images -- measured 2 unique pixel
+    values (hard edges) vs 30 on uint8 (real antialiasing) for the same drawing call. float64 also
+    makes every image.copy()/cv2.fillConvexPoly in draw_poses/draw_skeleton move 8x the memory
+    traffic per pose than necessary (9.8 MB vs 1.2 MB at 640x640).
     """
     try:
         image_index, pred_boxes, pred_scores, pred_joints = next(iter(iterate_over_batch_predictions(predictions, 1)))
@@ -156,24 +263,40 @@ def show_predictions_from_batch_format(
 
     # Handle case where no poses are detected
     if pred_joints.shape[0] == 0:
-        return np.zeros((640, 640, 3))
+        return np.zeros((canvas_height, canvas_width, 3), dtype=np.uint8)
 
-    # Add middle joint between shoulders (keypoints 5 and 6)
     try:
-        # Calculate middle joints for all poses at once
-        middle_joints = (pred_joints[:, 5] + pred_joints[:, 6]) / 2
-        # Add middle joint as keypoint 17 to all poses
-        new_pred_joints = np.concatenate([pred_joints, middle_joints[:, np.newaxis]], axis=1)
+        pred_joints = pred_joints.astype(np.float32, copy=True)
+
+        # Undo the letterbox: joints are in the padded detect_resolution-square's pixel space,
+        # not the original frame's -- see _letterbox_resize.
+        if letterbox_scale != 1.0 or letterbox_pad_x or letterbox_pad_y:
+            pred_joints[..., 0] = (pred_joints[..., 0] - letterbox_pad_x) / letterbox_scale
+            pred_joints[..., 1] = (pred_joints[..., 1] - letterbox_pad_y) / letterbox_scale
+
+        # Remap COCO-17 -> OpenPose-18 (see OPENPOSE18_FROM_COCO17). "neck" (index 1) is
+        # synthesized as the shoulder midpoint, gated on the *lower* of the two shoulder
+        # confidences -- not the average, which let a partially-visible pair falsely pass
+        # keypoint_threshold and draw a false limb toward absent hips (plan Finding 3d).
+        num_poses = pred_joints.shape[0]
+        op_joints = np.zeros((num_poses, 18, 3), dtype=np.float32)
+        for op_idx, coco_idx in enumerate(OPENPOSE18_FROM_COCO17):
+            if coco_idx is not None:
+                op_joints[:, op_idx] = pred_joints[:, coco_idx]
+        left_shoulder, right_shoulder = pred_joints[:, 5], pred_joints[:, 6]
+        op_joints[:, 1, 0] = (left_shoulder[:, 0] + right_shoulder[:, 0]) / 2.0
+        op_joints[:, 1, 1] = (left_shoulder[:, 1] + right_shoulder[:, 1]) / 2.0
+        op_joints[:, 1, 2] = np.minimum(left_shoulder[:, 2], right_shoulder[:, 2])
     except Exception as e:
         raise RuntimeError(f"show_predictions_from_batch_format: Error processing poses: {e}") from e
 
     # Create black background for pose visualization
-    black_image = np.zeros((640, 640, 3))
+    black_image = np.zeros((canvas_height, canvas_width, 3), dtype=np.uint8)
 
     try:
         image = PoseVisualization.draw_poses(
             image=black_image,
-            poses=new_pred_joints,
+            poses=op_joints,
             edge_links=edge_links,
             edge_colors=edge_colors,
             joint_thickness=joint_thickness,
@@ -262,13 +385,12 @@ class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
         Apply TensorRT pose estimation to the input image
         """
         detect_resolution = self.params.get("detect_resolution", 640)
+        target_width, target_height = self.get_target_dimensions()
 
         image_tensor = torch.from_numpy(np.array(image)).float() / 255.0
         image_tensor = image_tensor.permute(2, 0, 1).unsqueeze(0)
 
-        image_resized = F.interpolate(
-            image_tensor, size=(detect_resolution, detect_resolution), mode="bilinear", align_corners=False
-        )
+        image_resized, letterbox_scale, pad_x, pad_y = _letterbox_resize(image_tensor, detect_resolution)
 
         image_resized_uint8 = (image_resized * 255.0).type(torch.uint8)
 
@@ -281,8 +403,8 @@ class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
         predictions = [result[key].cpu().numpy() for key in result.keys() if key != "input"]
 
         keypoint_threshold = float(self.params.get("keypoint_threshold", 0.5))
-        joint_thickness = int(self.params.get("joint_thickness", 10))
-        keypoint_radius = int(self.params.get("keypoint_radius", 10))
+        joint_thickness = int(self.params.get("joint_thickness", 4))
+        keypoint_radius = int(self.params.get("keypoint_radius", 4))
 
         try:
             pose_image = show_predictions_from_batch_format(
@@ -290,14 +412,25 @@ class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
                 keypoint_threshold=keypoint_threshold,
                 joint_thickness=joint_thickness,
                 keypoint_radius=keypoint_radius,
+                canvas_width=target_width,
+                canvas_height=target_height,
+                letterbox_scale=letterbox_scale,
+                letterbox_pad_x=pad_x,
+                letterbox_pad_y=pad_y,
             )
         except Exception:
             # Fallback to black image on error
-            pose_image = np.zeros((detect_resolution, detect_resolution, 3))
+            pose_image = np.zeros((target_height, target_width, 3), dtype=np.uint8)
 
-        pose_image = pose_image.clip(0, 255).astype(np.uint8)
-        pose_image = cv2.cvtColor(pose_image, cv2.COLOR_BGR2RGB)
+        # show_predictions_from_batch_format and the fallback above are both already uint8 -- this
+        # guard is defensive, not the hot path (it used to be an unconditional clip/astype on a
+        # float64 canvas, which cost ~2.9ms/frame; see the docstring above).
+        if pose_image.dtype != np.uint8:
+            pose_image = pose_image.clip(0, 255).astype(np.uint8)
 
+        # NOTE: no cv2.cvtColor(BGR2RGB) here -- the canvas is authored (edge_colors) and
+        # consumed (Image.fromarray) as RGB throughout; the previous swap inverted every limb's
+        # colour identity (plan Finding 3a).
         result = Image.fromarray(pose_image)
 
         return result
@@ -312,10 +445,9 @@ class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
             image_tensor = image_tensor.cuda()
 
         detect_resolution = self.params.get("detect_resolution", 640)
+        target_width, target_height = self.get_target_dimensions()
 
-        image_resized = torch.nn.functional.interpolate(
-            image_tensor, size=(detect_resolution, detect_resolution), mode="bilinear", align_corners=False
-        )
+        image_resized, letterbox_scale, pad_x, pad_y = _letterbox_resize(image_tensor, detect_resolution)
 
         image_resized_uint8 = (image_resized * 255.0).type(torch.uint8)
 
@@ -325,8 +457,8 @@ class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
         predictions = [result[key].cpu().numpy() for key in result.keys() if key != "input"]
 
         keypoint_threshold = float(self.params.get("keypoint_threshold", 0.5))
-        joint_thickness = int(self.params.get("joint_thickness", 10))
-        keypoint_radius = int(self.params.get("keypoint_radius", 10))
+        joint_thickness = int(self.params.get("joint_thickness", 4))
+        keypoint_radius = int(self.params.get("keypoint_radius", 4))
 
         try:
             pose_image = show_predictions_from_batch_format(
@@ -334,15 +466,22 @@ class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
                 keypoint_threshold=keypoint_threshold,
                 joint_thickness=joint_thickness,
                 keypoint_radius=keypoint_radius,
+                canvas_width=target_width,
+                canvas_height=target_height,
+                letterbox_scale=letterbox_scale,
+                letterbox_pad_x=pad_x,
+                letterbox_pad_y=pad_y,
             )
-            pose_image = pose_image.clip(0, 255).astype(np.uint8)
-            pose_image = cv2.cvtColor(pose_image, cv2.COLOR_BGR2RGB)
+            # Defensive guard, not the hot path -- see the CPU path's comment above.
+            if pose_image.dtype != np.uint8:
+                pose_image = pose_image.clip(0, 255).astype(np.uint8)
 
-            pose_tensor = torch.from_numpy(pose_image).float() / 255.0
+            # NOTE: no cv2.cvtColor(BGR2RGB) here -- see _process_core.
+            pose_tensor = torch.from_numpy(pose_image).to(dtype=torch.float16) / 255.0
             pose_tensor = pose_tensor.permute(2, 0, 1).unsqueeze(0).cuda()
 
         except Exception:
             # Fallback to black tensor on error
-            pose_tensor = torch.zeros(1, 3, detect_resolution, detect_resolution).cuda()
+            pose_tensor = torch.zeros(1, 3, target_height, target_width, dtype=torch.float16).cuda()
 
         return pose_tensor

--- a/src/streamdiffusion/preprocessing/processors/pose_tensorrt.py
+++ b/src/streamdiffusion/preprocessing/processors/pose_tensorrt.py
@@ -501,11 +501,11 @@ class YoloNasPoseTensorrtPreprocessor(BasePreprocessor):
                 pose_image = pose_image.clip(0, 255).astype(np.uint8)
 
             # NOTE: no cv2.cvtColor(BGR2RGB) here -- see _process_core.
-            pose_tensor = torch.from_numpy(pose_image).to(dtype=torch.float16) / 255.0
+            pose_tensor = torch.from_numpy(pose_image).to(dtype=self.dtype) / 255.0
             pose_tensor = pose_tensor.permute(2, 0, 1).unsqueeze(0).cuda()
 
         except Exception:
             # Fallback to black tensor on error
-            pose_tensor = torch.zeros(1, 3, target_height, target_width, dtype=torch.float16).cuda()
+            pose_tensor = torch.zeros(1, 3, target_height, target_width, dtype=self.dtype).cuda()
 
         return pose_tensor

--- a/src/streamdiffusion/tools/compile_yolo_nas_pose_tensorrt.py
+++ b/src/streamdiffusion/tools/compile_yolo_nas_pose_tensorrt.py
@@ -1,0 +1,284 @@
+"""
+YOLO-NAS Pose TensorRT Engine Builder
+
+Builds the TensorRT engine consumed by the `pose_tensorrt` preprocessor
+(streamdiffusion.preprocessing.processors.pose_tensorrt.YoloNasPoseTensorrtPreprocessor).
+Based on: https://github.com/yuvraj108c/ComfyUI-YoloNasPose-Tensorrt
+
+Unlike compile_depth_anything_tensorrt.py, this tool does not export a torch model to ONNX:
+the repo has no YOLO-NAS torch checkpoint, and neither `super-gradients` nor `ultralytics`
+(the libraries that could produce one) is installed. Instead it downloads the prebuilt,
+publicly available ONNX export that the ported ComfyUI-YoloNasPose-Tensorrt implementation
+was written against.
+
+Usage:
+    python -m streamdiffusion.tools.compile_yolo_nas_pose_tensorrt --output_dir ./engines/td/preprocessors
+    python -m streamdiffusion.tools.compile_yolo_nas_pose_tensorrt --model_size l --resolution 640
+"""
+
+import importlib.util
+import logging
+import shutil
+from pathlib import Path
+
+import fire
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+try:
+    import tensorrt as trt
+
+    from streamdiffusion.acceleration.tensorrt.utilities import BUILD_TRT_LOGGER
+
+    TENSORRT_AVAILABLE = True
+except ImportError:
+    TENSORRT_AVAILABLE = False
+    BUILD_TRT_LOGGER = None
+    logger.warning("TensorRT not available. Please install it first.")
+
+ONNX_AVAILABLE = importlib.util.find_spec("onnx") is not None
+
+# Public, ungated HF Hub repo publishing prebuilt YOLO-NAS Pose ONNX exports at several
+# score-threshold variants. Filenames encode {model_size}_{score_threshold}. Only the "l"
+# (large) / 0.8 variant has been verified downloadable and matches this repo's own example
+# engine basename (yolo_nas_pose_l_0.8-fp16.engine, see configs/*.yaml.example).
+YOLO_NAS_POSE_HF_REPO = "yuvraj108c/yolo-nas-pose-onnx"
+YOLO_NAS_POSE_VARIANTS = {
+    "l": "yolo_nas_pose_l_0.8.onnx",
+}
+
+
+def export_yolo_nas_pose_to_onnx(
+    onnx_path: Path, model_size: str = "l", resolution: int = 640, device: str = "cuda"
+) -> bool:
+    """
+    Stage a prebuilt YOLO-NAS Pose ONNX at `onnx_path` by downloading it from the HF Hub.
+
+    Named/shaped like the other tools' `export_*` functions (and called identically by
+    td_manager.py's `external` build_registry dispatch: `export_fn(onnx_path, model_size,
+    resolution, 'cuda')`) even though nothing is actually exported here — there is no local
+    torch model to export from.
+
+    `device` is accepted only for call-signature compatibility with that dispatch; a download
+    has no device to run on.
+    """
+    del device  # unused; kept for signature parity with the `external` build_registry dispatch
+
+    if model_size not in YOLO_NAS_POSE_VARIANTS:
+        logger.error(f"Unknown model_size: {model_size}. Choose from: {list(YOLO_NAS_POSE_VARIANTS.keys())}")
+        return False
+
+    if resolution != 640:
+        logger.warning(
+            f"resolution={resolution} was requested, but the published ONNX is a fixed 640x640 "
+            "export -- the downloaded model will still be 640x640 regardless of this argument."
+        )
+
+    filename = YOLO_NAS_POSE_VARIANTS[model_size]
+
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError:
+        logger.error(
+            "huggingface_hub is required to download the YOLO-NAS Pose ONNX. Install with: pip install huggingface_hub"
+        )
+        return False
+
+    try:
+        logger.info(
+            f"Downloading {filename} from {YOLO_NAS_POSE_HF_REPO} (reuses the shared HF cache on repeat calls)..."
+        )
+        downloaded_path = hf_hub_download(repo_id=YOLO_NAS_POSE_HF_REPO, filename=filename)
+    except Exception as e:
+        logger.error(f"Failed to download YOLO-NAS Pose ONNX from {YOLO_NAS_POSE_HF_REPO}: {e}")
+        return False
+
+    try:
+        onnx_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(downloaded_path, onnx_path)
+    except Exception as e:
+        logger.error(f"Failed to stage downloaded ONNX at {onnx_path}: {e}")
+        return False
+
+    logger.info(f"YOLO-NAS Pose ONNX staged at: {onnx_path}")
+    return True
+
+
+def build_tensorrt_engine(
+    onnx_path: Path,
+    engine_path: Path,
+    resolution: int = 640,
+    fp16: bool = True,
+) -> bool:
+    """
+    Build a TensorRT engine from the YOLO-NAS Pose ONNX model.
+
+    Deliberately deviates from compile_depth_anything_tensorrt.build_tensorrt_engine in two
+    ways (see plan i-ve-noticed-that-in-graceful-kettle.md, Change 1):
+
+    1. The optimization profile is added only if the parsed network's input is actually
+       dynamic (a dim == -1). The published ONNX is expected to be static (1,3,640,640), and
+       unconditionally calling profile.set_shape() for a fully-static input errors in TRT 10.x
+       the way compile_depth_anything_tensorrt.py does it (that tool's ONNX has dynamic axes,
+       so it never hits this).
+    2. The engine's I/O contract is asserted right after parsing, not left to fail on frame 1.
+       pose_tensorrt.py's _process_core/_process_tensor_core both call
+       `self.engine.infer({"input": image_resized_uint8}, cuda_stream)` with a hardcoded input
+       name "input" and a uint8 tensor -- if the downloaded ONNX doesn't match that contract,
+       failing here (at build time, with an explicit message) is the entire point of this
+       change: it converts "silent skip -> 17-minute-delayed per-frame crash" into "loud
+       failure at build time", which is the same fix this tool exists to make for pose_tensorrt
+       in the first place.
+    """
+    if not TENSORRT_AVAILABLE:
+        logger.error("TensorRT not available")
+        return False
+
+    logger.info(f"Building TensorRT engine: {engine_path}")
+
+    try:
+        builder = trt.Builder(BUILD_TRT_LOGGER)
+        network = builder.create_network()  # EXPLICIT_BATCH deprecated/ignored in TRT 10.x
+        parser = trt.OnnxParser(network, BUILD_TRT_LOGGER)
+
+        with open(onnx_path, "rb") as f:
+            if not parser.parse(f.read()):
+                for i in range(parser.num_errors):
+                    logger.error(f"ONNX parse error: {parser.get_error(i)}")
+                return False
+
+        if network.num_inputs == 0:
+            logger.error("Parsed network has no inputs -- cannot validate the I/O contract")
+            return False
+
+        input_tensor = network.get_input(0)
+        input_shape = tuple(input_tensor.shape)
+        expected_shape = (1, 3, resolution, resolution)
+
+        logger.info(f"Parsed input: name={input_tensor.name!r} dtype={input_tensor.dtype} shape={input_shape}")
+
+        if input_tensor.name != "input":
+            logger.error(
+                f"YOLO-NAS Pose ONNX input is named {input_tensor.name!r}, but pose_tensorrt.py's "
+                "infer() call is hardcoded to the key 'input'. Either the published ONNX changed "
+                "or the wrong file was downloaded -- refusing to build a mismatched engine."
+            )
+            return False
+
+        if input_tensor.dtype != trt.DataType.UINT8:
+            logger.error(
+                f"YOLO-NAS Pose ONNX input dtype is {input_tensor.dtype}, but pose_tensorrt.py "
+                "always sends a uint8 tensor. Refusing to build an engine that would only move "
+                "today's frame-1 failure to a dtype mismatch instead of fixing it."
+            )
+            return False
+
+        is_dynamic = any(d == -1 for d in input_shape)
+
+        config = builder.create_builder_config()
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 4 << 30)  # 4GB
+
+        if fp16 and builder.platform_has_fast_fp16:
+            config.set_flag(trt.BuilderFlag.FP16)
+            logger.info("Using FP16 precision")
+
+        if is_dynamic:
+            logger.info(
+                f"Input has dynamic dims {input_shape} -- adding a fixed optimization profile at {expected_shape}"
+            )
+            profile = builder.create_optimization_profile()
+            profile.set_shape("input", expected_shape, expected_shape, expected_shape)
+            config.add_optimization_profile(profile)
+        else:
+            if input_shape != expected_shape:
+                logger.error(
+                    f"YOLO-NAS Pose ONNX has a static input shape {input_shape}, but "
+                    f"pose_tensorrt.py expects {expected_shape} (resolution={resolution}). Adjust "
+                    "the preprocessor's detect_resolution to match, or use a different export."
+                )
+                return False
+            logger.info(f"Input is static {input_shape} -- no optimization profile needed")
+
+        logger.info("Building engine (this may take a few minutes)...")
+        serialized_engine = builder.build_serialized_network(network, config)
+
+        if serialized_engine is None:
+            logger.error("Failed to build TensorRT engine")
+            return False
+
+        engine_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(engine_path, "wb") as f:
+            f.write(serialized_engine)
+
+        logger.info(f"TensorRT engine saved: {engine_path}")
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to build TensorRT engine: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def compile_yolo_nas_pose(
+    output_dir: str = "./engines/td/preprocessors",
+    model_size: str = "l",
+    resolution: int = 640,
+    fp16: bool = True,
+    keep_onnx: bool = False,
+    device: str = "cuda",
+):
+    """
+    Compile YOLO-NAS Pose to a TensorRT engine for the `pose_tensorrt` preprocessor.
+
+    Args:
+        output_dir: Directory to save the engine (should match the ControlNet config's
+                     preprocessor_params.engine_path parent, e.g. engines/td/preprocessors)
+        model_size: Published ONNX variant key -- see YOLO_NAS_POSE_VARIANTS
+        resolution: Expected square input resolution; must match pose_tensorrt.py's
+                    detect_resolution (default 640)
+        fp16: Use FP16 precision
+        keep_onnx: Keep the intermediate ONNX file
+        device: Unused, kept for CLI/signature parity with compile_depth_anything
+    """
+    if not TENSORRT_AVAILABLE:
+        logger.error("TensorRT is required. Install with: pip install tensorrt")
+        return
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    engine_path = output_path / "yolonas_pose.engine"
+    onnx_path = output_path / "yolonas_pose.onnx"
+
+    if engine_path.exists():
+        logger.info(f"Engine already exists: {engine_path}")
+        overwrite = input("Overwrite? (y/N): ").lower().strip() == "y"
+        if not overwrite:
+            return
+
+    logger.info("Step 1/2: Downloading YOLO-NAS Pose ONNX...")
+    if not export_yolo_nas_pose_to_onnx(onnx_path, model_size, resolution, device):
+        logger.error("ONNX download failed")
+        return
+
+    logger.info("Step 2/2: Building TensorRT engine...")
+    if not build_tensorrt_engine(onnx_path, engine_path, resolution, fp16):
+        logger.error("TensorRT build failed")
+        return
+
+    if not keep_onnx and onnx_path.exists():
+        onnx_path.unlink()
+        logger.info("Removed intermediate ONNX file")
+
+    logger.info(f"\nSuccess! Engine saved to: {engine_path}")
+    logger.info("\nTo use in config:")
+    logger.info('  preprocessor: "pose_tensorrt"')
+    logger.info("  preprocessor_params:")
+    logger.info(f'    engine_path: "{engine_path}"')
+
+
+if __name__ == "__main__":
+    fire.Fire(compile_yolo_nas_pose)

--- a/src/streamdiffusion/tools/compile_yolo_nas_pose_tensorrt.py
+++ b/src/streamdiffusion/tools/compile_yolo_nas_pose_tensorrt.py
@@ -250,8 +250,12 @@ def compile_yolo_nas_pose(
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
 
-    engine_path = output_path / "yolonas_pose.engine"
-    onnx_path = output_path / "yolonas_pose.onnx"
+    # Matches the example configs' engine_path (yolo_nas_pose_l_0.8-fp16.engine), not a
+    # generic "yolonas_pose.engine" -- see YOLO_NAS_POSE_HF_REPO comment above.
+    onnx_basename = YOLO_NAS_POSE_VARIANTS[model_size].removesuffix(".onnx")
+    engine_name = f"{onnx_basename}-fp16.engine" if fp16 else f"{onnx_basename}.engine"
+    engine_path = output_path / engine_name
+    onnx_path = output_path / f"{onnx_basename}.onnx"
 
     if engine_path.exists():
         logger.info(f"Engine already exists: {engine_path}")

--- a/tests/unit/test_pose_tensorrt_canvas.py
+++ b/tests/unit/test_pose_tensorrt_canvas.py
@@ -1,0 +1,184 @@
+"""
+Regression test for the pose_tensorrt canvas dtype/size fix (plan
+i-ve-noticed-that-in-graceful-kettle.md, "postprocess waste" changes), updated for the
+OpenPose-COCO18 rendering + letterbox fix (plan in-the-previous-session-lively-snail.md).
+
+Context: show_predictions_from_batch_format
+(streamdiffusion.preprocessing.processors.pose_tensorrt) allocated its rasterization canvas with
+np.zeros((640, 640, 3)) -- no dtype, so numpy defaults to float64. Two costs followed:
+
+  1. cv2.LINE_AA (used by PoseVisualization.draw_skeleton for both the skeleton limbs and the
+     keypoint circles) is silently a no-op on float64 images -- measured 2 unique pixel values
+     (hard edges) on a single antialiased shape, vs 30 unique values (a real antialiased
+     gradient) on the equivalent uint8 canvas.
+  2. Every image.copy() / cv2.fillConvexPoly call in draw_poses/draw_skeleton moved 8x the
+     memory traffic it needed to (9.8 MB float64 vs 1.2 MB uint8 at 640x640), measured at
+     7.8-17.4 ms/frame wasted depending on pose count -- the actual perf motivation for this fix.
+
+The canvas was also hardcoded to a square 640x640 regardless of the caller's target dimensions,
+and previously to the *detect* resolution rather than the pipeline's output resolution -- both
+silently corruptible: iterate_over_batch_predictions returns joints in detection-space pixel
+coordinates, so a mismatched canvas size, or skipping the letterbox-undo, crops/misplaces the
+skeleton without raising. The rendering was also switched from raw COCO-17 stick lines (wrong
+topology, hard-coded green joints, inverted BGR/RGB colours, 75%-alpha-dimmed) to the OpenPose
+COCO-18 filled-ellipse convention xinsir/controlnet-openpose-sdxl-1.0 was trained on -- see
+show_predictions_from_batch_format's docstring and OPENPOSE18_FROM_COCO17.
+
+This test exercises show_predictions_from_batch_format directly -- pure numpy/cv2, no TensorRT, no
+GPU, no engine file -- so it runs in milliseconds and works on any machine.
+
+Run with: pytest tests/unit/test_pose_tensorrt_canvas.py -v
+"""
+
+import numpy as np
+import pytest
+
+from streamdiffusion.preprocessing.processors.pose_tensorrt import show_predictions_from_batch_format
+
+
+def _predictions_no_detections():
+    """[num_detections, boxes, scores, joints] batch-format predictions with zero detections."""
+    num_detections = np.array([[0]])
+    batch_boxes = np.zeros((1, 1, 4))
+    batch_scores = np.zeros((1, 1))
+    batch_joints = np.zeros((1, 1, 51))  # 17 keypoints * 3 (x, y, conf)
+    return [num_detections, batch_boxes, batch_scores, batch_joints]
+
+
+def _predictions_one_pose(kp5=(100.0, 100.0, 0.9), kp6=(400.0, 300.0, 0.9)):
+    """One detected pose with only COCO-17 keypoints 5 and 6 (left/right shoulder) confidently set.
+
+    show_predictions_from_batch_format synthesizes OpenPose-18 "neck" (index 1) as the midpoint
+    of the two shoulders, gated on min(conf5, conf6) -- and edge_links includes [1, 2]
+    (neck->right_shoulder) and [1, 5] (neck->left_shoulder) directly -- so this is the minimal
+    input that reaches PoseVisualization.draw_skeleton's cv2.fillConvexPoly/cv2.circle calls
+    without needing a full 17-point pose.
+    """
+    num_detections = np.array([[1]])
+    batch_boxes = np.zeros((1, 1, 4))
+    batch_scores = np.array([[0.9]])
+
+    joints = np.zeros((17, 3))
+    joints[5] = kp5
+    joints[6] = kp6
+    batch_joints = joints.reshape(1, 1, 51)
+
+    return [num_detections, batch_boxes, batch_scores, batch_joints]
+
+
+class TestNoDetectionCanvas:
+    """The early-return path at pose_tensorrt.py's `if pred_joints.shape[0] == 0` guard."""
+
+    def test_dtype_is_uint8(self):
+        image = show_predictions_from_batch_format(_predictions_no_detections())
+        assert image.dtype == np.uint8
+
+    def test_default_canvas_size_is_640(self):
+        image = show_predictions_from_batch_format(_predictions_no_detections())
+        assert image.shape == (640, 640, 3)
+
+    def test_canvas_size_is_honoured(self):
+        image = show_predictions_from_batch_format(_predictions_no_detections(), canvas_width=512, canvas_height=384)
+        assert image.shape == (384, 512, 3)
+        assert image.dtype == np.uint8
+
+
+class TestWithDetectionCanvas:
+    """The main drawing path -- the actual perf regression guard."""
+
+    def test_dtype_is_uint8(self):
+        image = show_predictions_from_batch_format(_predictions_one_pose())
+        assert image.dtype == np.uint8
+
+    def test_default_canvas_size_is_640(self):
+        image = show_predictions_from_batch_format(_predictions_one_pose())
+        assert image.shape == (640, 640, 3)
+
+    def test_canvas_size_is_honoured(self):
+        image = show_predictions_from_batch_format(_predictions_one_pose(), canvas_width=512, canvas_height=384)
+        assert image.shape == (384, 512, 3)
+        assert image.dtype == np.uint8
+
+    def test_antialiasing_is_not_defeated_by_canvas_dtype(self):
+        """cv2.LINE_AA is a no-op on float64 -- this is the signal that distinguishes the two
+        dtypes. A regression back to a dtype-less np.zeros() canvas would collapse this to <=2
+        unique nonzero pixel values (hard edges only)."""
+        image = show_predictions_from_batch_format(_predictions_one_pose())
+        nonzero = image[image.sum(axis=-1) > 0]
+        assert nonzero.size > 0, "expected the skeleton limb/keypoints to draw something"
+        unique_values = np.unique(nonzero)
+        assert len(unique_values) > 2, (
+            f"only {len(unique_values)} unique pixel value(s) in drawn region -- antialiasing "
+            "looks defeated (a float64 canvas silently disables cv2.LINE_AA)"
+        )
+
+    def test_colours_are_not_bgr_swapped(self):
+        """Regression guard for plan Finding 3a: a stray cv2.cvtColor(..., COLOR_BGR2RGB) used
+        to invert every limb's authored colour. edge_colors[0] (nose->neck, RGB (255,0,0)) is
+        drawn at 60% intensity as a filled ellipse -- the red channel must dominate, not blue."""
+        image = show_predictions_from_batch_format(
+            _predictions_one_pose(kp5=(100.0, 100.0, 0.9), kp6=(100.0, 100.0, 0.9))
+        )
+        # Set nose too, so edge_links[12] == [1, 0] (neck->nose, colour index 12, [0,0,255] blue)
+        # is NOT what's tested here; instead confirm the neck->right_shoulder limb (edge_links[0]
+        # == [1, 2], colour index 0, RGB (255,0,0) red) dominates red over blue somewhere on canvas.
+        red_channel_max = int(image[..., 0].max())
+        blue_channel_max = int(image[..., 2].max())
+        assert red_channel_max > blue_channel_max, (
+            f"red max {red_channel_max} <= blue max {blue_channel_max} -- looks BGR/RGB swapped"
+        )
+
+    def test_full_intensity_not_75_percent_dimmed(self):
+        """Regression guard for plan Finding 3b: cv2.addWeighted(overlay, 0.75, image, 0.25, 0)
+        used to cap every stroke's brightest channel at 255*0.75=192. Keypoint dots are drawn at
+        full intensity (limb fills are intentionally 60% per the OpenPose convention -- see
+        draw_skeleton -- so this checks a keypoint circle's peak, not a limb's)."""
+        image = show_predictions_from_batch_format(_predictions_one_pose())
+        assert image.max() == 255, f"brightest channel is {image.max()}, expected 255 (not 192)"
+
+
+class TestSuccessFallbackReconciliation:
+    """The success path (show_predictions_from_batch_format) and the CPU fallback
+    (np.zeros((target_height, target_width, 3), dtype=np.uint8) in _process_core/
+    _process_tensor_core) must agree on shape/dtype for the same target dimensions."""
+
+    @pytest.mark.parametrize("canvas_width,canvas_height", [(384, 384), (512, 512), (640, 384)])
+    def test_success_and_fallback_shapes_match(self, canvas_width, canvas_height):
+        success_image = show_predictions_from_batch_format(
+            _predictions_one_pose(), canvas_width=canvas_width, canvas_height=canvas_height
+        )
+        fallback_image = np.zeros((canvas_height, canvas_width, 3), dtype=np.uint8)
+
+        assert success_image.shape == fallback_image.shape
+        assert success_image.dtype == fallback_image.dtype
+
+
+class TestLetterboxUndo:
+    """Regression guard for plan Finding 3e: joints returned by the TRT engine are in the
+    padded detect-resolution-square's pixel space, not the original frame's -- the
+    letterbox_scale/pad_x/pad_y params must be applied before drawing."""
+
+    def test_pad_offset_shifts_the_drawn_pose(self):
+        image_no_pad = show_predictions_from_batch_format(_predictions_one_pose(), canvas_width=640, canvas_height=640)
+        image_with_pad = show_predictions_from_batch_format(
+            _predictions_one_pose(),
+            canvas_width=640,
+            canvas_height=640,
+            letterbox_scale=1.0,
+            letterbox_pad_x=50,
+            letterbox_pad_y=0,
+        )
+        assert not np.array_equal(image_no_pad, image_with_pad), (
+            "letterbox_pad_x had no effect -- pad undo looks unapplied"
+        )
+
+    def test_scale_factor_rescales_the_drawn_pose(self):
+        image_no_scale = show_predictions_from_batch_format(
+            _predictions_one_pose(), canvas_width=640, canvas_height=640
+        )
+        image_scaled = show_predictions_from_batch_format(
+            _predictions_one_pose(), canvas_width=640, canvas_height=640, letterbox_scale=2.0
+        )
+        assert not np.array_equal(image_no_scale, image_scaled), (
+            "letterbox_scale had no effect -- scale undo looks unapplied"
+        )

--- a/tests/unit/test_pose_tensorrt_canvas.py
+++ b/tests/unit/test_pose_tensorrt_canvas.py
@@ -156,7 +156,7 @@ class TestSuccessFallbackReconciliation:
 class TestLetterboxUndo:
     """Regression guard for plan Finding 3e: joints returned by the TRT engine are in the
     padded detect-resolution-square's pixel space, not the original frame's -- the
-    letterbox_scale/pad_x/pad_y params must be applied before drawing."""
+    letterbox_scale_x/y/pad_x/pad_y params must be applied before drawing."""
 
     def test_pad_offset_shifts_the_drawn_pose(self):
         image_no_pad = show_predictions_from_batch_format(_predictions_one_pose(), canvas_width=640, canvas_height=640)
@@ -164,7 +164,8 @@ class TestLetterboxUndo:
             _predictions_one_pose(),
             canvas_width=640,
             canvas_height=640,
-            letterbox_scale=1.0,
+            letterbox_scale_x=1.0,
+            letterbox_scale_y=1.0,
             letterbox_pad_x=50,
             letterbox_pad_y=0,
         )
@@ -177,8 +178,45 @@ class TestLetterboxUndo:
             _predictions_one_pose(), canvas_width=640, canvas_height=640
         )
         image_scaled = show_predictions_from_batch_format(
-            _predictions_one_pose(), canvas_width=640, canvas_height=640, letterbox_scale=2.0
+            _predictions_one_pose(),
+            canvas_width=640,
+            canvas_height=640,
+            letterbox_scale_x=2.0,
+            letterbox_scale_y=2.0,
         )
         assert not np.array_equal(image_no_scale, image_scaled), (
-            "letterbox_scale had no effect -- scale undo looks unapplied"
+            "letterbox_scale_x/y had no effect -- scale undo looks unapplied"
+        )
+
+    def test_per_axis_scale_is_independent(self):
+        """The letterbox undo and the raw-input-to-canvas squash are composed into a single
+        per-axis factor precisely because they can differ per axis (e.g. a 1280x720 source
+        frame rendered onto a 512x512 canvas). Scaling only one axis must only move the pose
+        along that axis, proving x and y aren't coupled through a single scalar anymore."""
+        baseline = show_predictions_from_batch_format(
+            _predictions_one_pose(),
+            canvas_width=640,
+            canvas_height=640,
+            letterbox_scale_x=1.0,
+            letterbox_scale_y=1.0,
+        )
+        x_only = show_predictions_from_batch_format(
+            _predictions_one_pose(),
+            canvas_width=640,
+            canvas_height=640,
+            letterbox_scale_x=1.5,
+            letterbox_scale_y=1.0,
+        )
+        y_only = show_predictions_from_batch_format(
+            _predictions_one_pose(),
+            canvas_width=640,
+            canvas_height=640,
+            letterbox_scale_x=1.0,
+            letterbox_scale_y=1.5,
+        )
+        assert not np.array_equal(baseline, x_only), "letterbox_scale_x alone had no effect"
+        assert not np.array_equal(baseline, y_only), "letterbox_scale_y alone had no effect"
+        assert not np.array_equal(x_only, y_only), (
+            "scaling x-only and y-only produced the same image -- axes look coupled, "
+            "defeating the point of separate letterbox_scale_x/y factors"
         )


### PR DESCRIPTION
## Summary

- Adds a `compile_yolo_nas_pose_tensorrt` tool that downloads the published YOLO-NAS Pose ONNX
  export and builds the TensorRT engine consumed by `pose_tensorrt.py`, validating the model's
  I/O contract (input name/dtype/shape) at build time instead of failing on frame 1.
- Rewrites `pose_tensorrt.py`'s skeleton rendering from raw COCO-17 stick lines (wrong topology,
  hard-coded green joints, inverted BGR/RGB, 75%-alpha-dimmed) to the OpenPose-18 filled-ellipse
  convention `xinsir/controlnet-openpose-sdxl-1.0` was trained on, and switches the rasterization
  canvas from a dtype-less (float64) `np.zeros` array to `uint8`, restoring `cv2.LINE_AA`
  antialiasing and cutting per-frame draw cost.
- Fixes a coordinate-space bug in the letterbox undo: keypoints returned by the TRT engine are in
  the padded detect-resolution-square's pixel space. The undo previously mapped them back into the
  *raw input frame's* pixel space, but the drawing canvas is sized to the pipeline's independently
  configured output resolution (`get_target_dimensions()`) — a different rectangle whenever the
  source frame resolution and the configured output resolution don't match. Both call sites now
  compute a combined per-axis scale (`letterbox_scale_x`/`letterbox_scale_y`) that composes the
  letterbox undo with the anisotropic squash into canvas space, matching the squash-to-target-dims
  convention every other preprocessor already uses via `BasePreprocessor._ensure_target_size(_tensor)`.
- Fixes `_process_tensor_core` hardcoding `torch.float16` on its output tensor instead of
  `self.dtype`, so the preprocessor now respects a non-default `dtype` passed via constructor
  kwargs, consistent with sibling TRT preprocessors (e.g. `realesrgan_trt.py`).

## Branch note

Squashed from 5 commits on the fork; no unrelated fork-only paths included. Diff is exactly 4
files: `category_params.py` (bodypose param contract), `pose_tensorrt.py`, the new
`tools/compile_yolo_nas_pose_tensorrt.py`, and `tests/unit/test_pose_tensorrt_canvas.py`.

**Caveat (intentionally not fixed, out of scope):** `pose_tensorrt.py`'s `.cuda()` calls in
`_process_tensor_core` are hardcoded rather than routed through `self.device`. This predates this
PR and is shared with sibling `depth_tensorrt.py` — left as-is to avoid an unrelated drive-by
change; flagging here in case you'd like it addressed as a follow-up across both files.

Went through this fork's two-stage review gate (`claude-code-review.yml` on a fork-only
`fork-review/SDTD_040_beta_release` base) across several rounds; findings from that review
(engine/onnx filename mismatch, the coordinate-space bug, the `self.dtype` fix) are folded into
the commits above.
