### PR TITLE
fix(trt): MHA fusion ratio regression, probe update

### DIFF
--- a/src/streamdiffusion/acceleration/tensorrt/builder.py
+++ b/src/streamdiffusion/acceleration/tensorrt/builder.py
@@ -349,17 +349,37 @@ def _count_attn_bmm_dq_fed(onnx_path: str) -> Optional[Tuple[int, int]]:
         return None
 
 
-def _find_best_sibling_mha_ratio(engine_dir: str, precision: str) -> Optional[float]:
-    """Best (highest) mha_kernels_per_attn_block seen among sibling engine dirs'
-    build_stats.json files at the same precision -- the same-precision regression
-    baseline for the inspector block's warning gate (FP8 Round 11).
+def _find_best_sibling_mha_ratio(engine_dir: str, precision: str, window: int = 5) -> Optional[float]:
+    """Best (lowest) mha_kernels_per_attn_block seen among the `window` most recent
+    sibling engine dirs' build_stats.json files at the same precision -- the
+    same-precision regression baseline for the inspector block's warning gate
+    (FP8 Round 11; direction and windowing corrected by the 2026-09-06 MHA-fusion
+    investigation, see the comment at the gate's call site in `EngineBuilder.build`).
 
-    Replaces the old ``_mha_count == 0`` guard, which never caught the FP8-vs-FP16
-    fusion regression this round found because the inspector block used to be
-    FP8-gated and so only ever compared FP8 against FP8. Same-precision only here by
-    design: FP8 quantization is *expected* to change kernel fusion vs FP16, so
-    flagging that difference as a warning on every FP8 build would be noise, not
-    signal -- the cross-precision delta is reported separately as INFO.
+    Lower is better here. This ratio is *kernels needed per attention block*, not
+    "modules fused": SDXL's UNet has `kvo_cache_count` self-attention (attn1) blocks
+    and an equal number of cross-attention (attn2) blocks (`get_kvo_cache_info` in
+    `models/utils.py` counts attn1 only), so TRT's fusion ceiling is one kernel per
+    attention module, i.e. ratio == 2.0. A build needing *more* kernels per block than
+    history means some attention sites stopped fusing into a single kernel each --
+    worse fusion, not better. Originally this function returned the historical
+    *maximum* and the gate warned when a build fell *below* it, which flagged a fully
+    saturated 1-kernel-per-module build (ratio 2.0) as a regression against a
+    worse-fused historical outlier (ratio 3.0, one build on 2026-08-22) that needed
+    two kernels for some sites. Confirmed empirically via
+    scripts/fp8/probe_engine_evidence.py: every sibling engine's fused-MHA layer names
+    normalize (stripping the trailing `_myl<N>_<M>` suffix) to the single pattern
+    `_gemm_mha_v2` -- the 3.0-ratio build never fused a second *kind* of kernel, its
+    per-Myelin-partition kernel counts are uniformly 1.5x the 2.0-ratio builds', i.e.
+    the same sites needing more kernels each, not more sites being covered.
+
+    Restricted to the `window` most recent sibling builds (by `build_end`, falling
+    back to `build_start`, falling back to the stats file's mtime) rather than an
+    all-time extremum, so a single anomalous historical build cannot pin the gate
+    forever once enough newer builds age it out of the window -- a defect independent
+    of the polarity bug above: an unbounded, unfiltered all-time extremum over
+    incomparable graph revisions/resolutions/opt levels is fragile regardless of which
+    direction counts as "best".
 
     Skips sibling files with no ``precision`` key (e.g. VAE engine dirs, which never
     run this inspector) or no ``mha_kernels_per_attn_block`` key (e.g. builds from
@@ -369,7 +389,7 @@ def _find_best_sibling_mha_ratio(engine_dir: str, precision: str) -> Optional[fl
     """
     try:
         root = Path(engine_dir).parent
-        best = None
+        candidates = []  # (sort_key, ratio), sort_key is an ISO-8601 string
         for sibling in root.iterdir():
             if not sibling.is_dir():
                 continue
@@ -386,9 +406,18 @@ def _find_best_sibling_mha_ratio(engine_dir: str, precision: str) -> Optional[fl
             ratio = sibling_stats.get("mha_kernels_per_attn_block")
             if ratio is None:
                 continue
-            if best is None or ratio > best:
-                best = ratio
-        return best
+            sort_key = sibling_stats.get("build_end") or sibling_stats.get("build_start")
+            if sort_key is None:
+                try:
+                    sort_key = datetime.fromtimestamp(stats_path.stat().st_mtime, tz=timezone.utc).isoformat()
+                except OSError:
+                    sort_key = ""
+            candidates.append((sort_key, ratio))
+        if not candidates:
+            return None
+        candidates.sort(key=lambda c: c[0])
+        recent_ratios = [ratio for _, ratio in candidates[-window:]]
+        return min(recent_ratios)
     except Exception:
         return None
 
@@ -496,6 +525,7 @@ class EngineBuilder:
                 )
                 os.remove(onnx_path)
             print(f"Exporting model: {onnx_path}")
+            _build_logger.info(f"Exporting model: {onnx_path}")
             t0 = time.perf_counter()
             _export_kwargs = {
                 "onnx_path": onnx_path,
@@ -520,6 +550,7 @@ class EngineBuilder:
             stats["stages"]["onnx_optimize"] = {"status": "cached"}
         else:
             print(f"Generating optimizing model: {onnx_opt_path}")
+            _build_logger.info(f"Generating optimizing model: {onnx_opt_path}")
             t0 = time.perf_counter()
             optimize_onnx(
                 onnx_path=onnx_path,
@@ -765,6 +796,7 @@ class EngineBuilder:
             _engine = None
             if not force_engine_build and os.path.exists(engine_path):
                 print(f"Found cached engine: {engine_path}")
+                _build_logger.info(f"Found cached engine: {engine_path}")
                 stats["stages"]["trt_build"] = {"status": "cached"}
             else:
                 t0 = time.perf_counter()
@@ -793,6 +825,14 @@ class EngineBuilder:
                     stats["dynamic_shapes"] = _tiling_info.get("dynamic_shapes")
                     stats["tiling_optimization_level"] = _tiling_info.get("tiling_optimization_level")
                     stats["l2_limit_for_tiling_mib"] = _tiling_info.get("l2_limit_for_tiling_mib")
+                    # Effective builder_optimization_level (2026-09-06 MHA-fusion
+                    # investigation) -- previously a build parameter that was forwarded
+                    # all the way to build_engine() but never persisted anywhere, which
+                    # made it impossible to tell whether a historical build's fusion
+                    # outcome was influenced by a different optimization level without a
+                    # full rebuild. Sourced from _apply_gpu_profile_to_config's return
+                    # value, which already reflects the requested override (if any).
+                    stats["builder_optimization_level"] = _tiling_info.get("builder_optimization_level")
 
             # --- Engine inspector: Q/DQ + fused-MHA + attn-BMM evidence record (FP8 Round 11) ---
             # Was `if fp8 and os.path.exists(engine_path)` -- FP16 builds never ran this, so
@@ -888,15 +928,26 @@ class EngineBuilder:
                     # different kvo_cache_count remain comparable. kvo_cache_count only
                     # exists on the model when use_cached_attn is set (models.py), hence
                     # getattr with a 0 default -- 0 skips the normalized metric entirely.
+                    #
+                    # Direction (corrected 2026-09-06 MHA-fusion investigation): LOWER is
+                    # better. mha_kernels_per_attn_block is kernels needed per block, and
+                    # SDXL's fusion ceiling is exactly 2.0 (one kernel per attn1 + one per
+                    # attn2, per kvo_cache_count blocks) -- a build needing *more* kernels
+                    # per block than its best-known sibling means some attention sites
+                    # stopped fusing into a single kernel each. The original comparison
+                    # (`ratio < best`, where `best` was the historical *maximum*) flagged
+                    # full 1-kernel-per-module fusion as a regression against a worse-fused
+                    # historical outlier that needed two kernels for some sites -- see
+                    # `_find_best_sibling_mha_ratio`'s docstring for the empirical evidence.
                     _kvo_count = getattr(self.model, "kvo_cache_count", 0)
                     if _kvo_count > 0:
                         _ratio = _mha_count / _kvo_count
                         stats["mha_kernels_per_attn_block"] = _ratio
                         _best_same = _find_best_sibling_mha_ratio(engine_dir_early, stats["precision"])
-                        if _best_same is not None and _ratio < _best_same:
+                        if _best_same is not None and _ratio > _best_same:
                             _build_logger.warning(
-                                f"[BUILD] MHA fusion regression vs best same-precision sibling: "
-                                f"{_ratio:.3f} kernels/block (this build) < {_best_same:.3f} (best sibling)."
+                                f"[BUILD] MHA fusion regression vs best (lowest) same-precision sibling: "
+                                f"{_ratio:.3f} kernels/block (this build) > {_best_same:.3f} (best sibling)."
                             )
                         _other_precision = "fp16" if fp8 else "fp8"
                         _best_other = _find_best_sibling_mha_ratio(engine_dir_early, _other_precision)

--- a/src/streamdiffusion/acceleration/tensorrt/utilities.py
+++ b/src/streamdiffusion/acceleration/tensorrt/utilities.py
@@ -309,21 +309,33 @@ def _apply_gpu_profile_to_config(
         dict with the tiling decision actually applied (FP8 Round 11 evidence record —
         callers persist this in build_stats.json rather than it existing only as an
         INFO log line): {"dynamic_shapes": bool, "tiling_optimization_level": str or
-        None, "l2_limit_for_tiling_mib": int or None}. `tiling_optimization_level` is
-        the applied level name, or one of "skipped (no gpu_profile)", "skipped
-        (dynamic_shapes)", "disabled (NONE)", "unsupported" when nothing was applied.
+        None, "l2_limit_for_tiling_mib": int or None, "builder_optimization_level": int
+        or str or None}. `tiling_optimization_level` is the applied level name, or one
+        of "skipped (no gpu_profile)", "skipped (dynamic_shapes)", "disabled (NONE)",
+        "unsupported" when nothing was applied. `builder_optimization_level` is the
+        effective level actually assigned to `config` — already reflects the caller's
+        override, if any (`build_engine` replaces `gpu_profile` with an overridden copy
+        before this function ever sees it) — or "unsupported"/"skipped (no gpu_profile)"
+        when it could not be applied. Added by the 2026-09-06 MHA-fusion-regression
+        investigation: this was a build parameter forwarded all the way from
+        `EngineBuilder.build`'s `builder_optimization_level` kwarg but never persisted
+        anywhere, which made it impossible to tell whether a historical build's fusion
+        outcome (see builder.py's `_find_best_sibling_mha_ratio`) was influenced by a
+        different optimization level without a full rebuild.
     """
     if gpu_profile is None:
         return {
             "dynamic_shapes": dynamic_shapes,
             "tiling_optimization_level": "skipped (no gpu_profile)",
             "l2_limit_for_tiling_mib": None,
+            "builder_optimization_level": "skipped (no gpu_profile)",
         }
 
     applied = {
         "dynamic_shapes": dynamic_shapes,
         "tiling_optimization_level": None,
         "l2_limit_for_tiling_mib": None,
+        "builder_optimization_level": None,
     }
 
     # builder_optimization_level (0–5):
@@ -335,8 +347,10 @@ def _apply_gpu_profile_to_config(
     try:
         config.builder_optimization_level = gpu_profile.builder_optimization_level
         logger.info(f"[TRT Config] builder_optimization_level={gpu_profile.builder_optimization_level}")
+        applied["builder_optimization_level"] = gpu_profile.builder_optimization_level
     except AttributeError:
         logger.debug("[TRT Config] builder_optimization_level not supported — skipping")
+        applied["builder_optimization_level"] = "unsupported"
 
     # tiling_optimization_level + l2_limit_for_tiling:
     # TRT's L2 tiling cache optimization requires static/concrete shapes to work.

--- a/tests/unit/test_fp8_calib_provenance.py
+++ b/tests/unit/test_fp8_calib_provenance.py
@@ -24,6 +24,11 @@ import json
 
 import numpy as np
 
+from streamdiffusion.acceleration.tensorrt.builder import (
+    _cleanup_intermediates,
+    _find_best_sibling_mha_ratio,
+    _write_build_stats,
+)
 from streamdiffusion.acceleration.tensorrt.fp8_quantize import (
     _build_calib_provenance,
     _write_calib_provenance_sidecar,
@@ -226,8 +231,197 @@ class TestWriteCalibProvenanceSidecar:
         assert not (tmp_path / "does_not_exist").exists()
 
 
-# `TestCleanupIntermediatesPreservesSidecar` / `TestWriteBuildStatsAppendGlobal`
-# (builder.py's `_cleanup_intermediates` / `_write_build_stats(..., append_global=...)`)
-# intentionally live in pr/trt-build-telemetry instead of here: this PR's cherry-pick
-# does not touch builder.py, so those tests would fail against a builder.py that
-# predates that PR's changes.
+class TestCleanupIntermediatesPreservesSidecar:
+    """The regression that would silently gut this feature: `_cleanup_intermediates`
+    runs from a `finally` block at the end of every build and deletes everything not
+    on its `_keep_exact`/`_keep_suffixes` allowlist -- a sidecar not on that list
+    would be destroyed at the end of the very build that wrote it."""
+
+    def test_calib_data_meta_json_survives_cleanup(self, tmp_path):
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        (engine_dir / "calib_data.meta.json").write_text("{}")
+        (engine_dir / "calib_data.npz").write_bytes(b"")
+        (engine_dir / "build_stats.json").write_text("{}")
+        (engine_dir / "unet.engine.onnx").write_bytes(b"")  # intermediate, must be deleted
+        (engine_dir / "unet.engine.opt.onnx").write_bytes(b"")  # intermediate, must be deleted
+
+        _cleanup_intermediates(str(engine_dir), fp8_ok=False)
+
+        assert (engine_dir / "calib_data.meta.json").exists()
+        assert (engine_dir / "calib_data.npz").exists()
+        assert (engine_dir / "build_stats.json").exists()
+        assert not (engine_dir / "unet.engine.onnx").exists()
+        assert not (engine_dir / "unet.engine.opt.onnx").exists()
+
+
+class TestWriteBuildStatsAppendGlobal:
+    """fp8-round-13's mid-build flush (builder.py, right after the capture stage
+    resolves) must not duplicate the build_log.jsonl line every successful build
+    already gets from the end-of-build _write_build_stats call."""
+
+    def _make_engine_path(self, tmp_path):
+        engines_root = tmp_path / "engines" / "td" / "stabilityai"
+        engine_dir = engines_root / "sdxl-turbo--fp8v4-mhaq--htest--res-384x640"
+        engine_dir.mkdir(parents=True)
+        return str(engine_dir / "unet.engine"), engines_root
+
+    def test_append_global_false_writes_stats_but_not_jsonl(self, tmp_path):
+        engine_path, engines_root = self._make_engine_path(tmp_path)
+        stats = {"engine_dir": "test", "stages": {"fp8_calib_capture": {"status": "built"}}}
+
+        _write_build_stats(engine_path, stats, append_global=False)
+
+        stats_file = engines_root / "sdxl-turbo--fp8v4-mhaq--htest--res-384x640" / "build_stats.json"
+        assert stats_file.exists()
+        assert json.loads(stats_file.read_text()) == stats
+        assert not (engines_root / "build_log.jsonl").exists()
+
+    def test_append_global_true_still_writes_jsonl(self, tmp_path):
+        """Default behavior (the pre-fp8-round-13 signature) is unchanged -- the
+        end-of-build call relies on this."""
+        engine_path, engines_root = self._make_engine_path(tmp_path)
+        stats = {"engine_dir": "test", "stages": {}}
+
+        _write_build_stats(engine_path, stats)
+
+        jsonl_path = engines_root / "build_log.jsonl"
+        assert jsonl_path.exists()
+        lines = jsonl_path.read_text().strip().splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0]) == stats
+
+    def test_mid_build_flush_then_final_write_appends_exactly_once(self, tmp_path):
+        """Simulates the real sequence: a mid-build flush (append_global=False)
+        followed by the end-of-build write (append_global=True, the default) --
+        build_log.jsonl must gain exactly one line, not two."""
+        engine_path, engines_root = self._make_engine_path(tmp_path)
+        stats = {"engine_dir": "test", "stages": {"fp8_calib_capture": {"status": "built"}}}
+
+        _write_build_stats(engine_path, stats, append_global=False)
+        stats["total_elapsed_s"] = 123.4
+        _write_build_stats(engine_path, stats)
+
+        jsonl_path = engines_root / "build_log.jsonl"
+        lines = jsonl_path.read_text().strip().splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["total_elapsed_s"] == 123.4
+
+
+class TestFindBestSiblingMhaRatio:
+    """Regression tests for the 2026-09-06 MHA-fusion-regression investigation.
+
+    The original `_find_best_sibling_mha_ratio` returned the historical *maximum*
+    ratio and the gate warned when a build fell *below* it -- backwards, since lower
+    mha_kernels_per_attn_block means more complete fusion (see the function's own
+    docstring for the full empirical argument: every sibling engine's fused-MHA layer
+    names normalize to the single kernel pattern `_gemm_mha_v2`, so a higher ratio
+    means the same attention sites needed *more* kernels each, not that more sites got
+    fused). `test_returns_lowest_ratio_not_highest` is the test that would have caught
+    that bug directly. The all-time-extremum baseline was also unbounded (`_ratio >
+    best` could never clear once a single anomalous build existed anywhere in
+    history), fixed here by the `window` parameter.
+    """
+
+    def _make_current_and_root(self, tmp_path):
+        """Mirrors the real call site: builder.py passes the *current* build's own
+        (not-yet-written) engine dir -- the function only ever reads `.parent`."""
+        engines_root = tmp_path / "engines" / "td" / "stabilityai"
+        engines_root.mkdir(parents=True)
+        current_engine_dir = engines_root / "sdxl-turbo--current--res-384x640"
+        return str(current_engine_dir), engines_root
+
+    def _write_sibling(self, engines_root, name, stats):
+        sibling_dir = engines_root / name
+        sibling_dir.mkdir(parents=True)
+        (sibling_dir / "build_stats.json").write_text(json.dumps(stats))
+
+    def test_none_when_no_sibling_dirs(self, tmp_path):
+        current_engine_dir, _engines_root = self._make_current_and_root(tmp_path)
+        assert _find_best_sibling_mha_ratio(current_engine_dir, "fp16") is None
+
+    def test_none_when_siblings_have_no_stats_file(self, tmp_path):
+        current_engine_dir, engines_root = self._make_current_and_root(tmp_path)
+        (engines_root / "sibling-no-stats").mkdir(parents=True)
+        assert _find_best_sibling_mha_ratio(current_engine_dir, "fp16") is None
+
+    def test_skips_sibling_missing_precision_key(self, tmp_path):
+        current_engine_dir, engines_root = self._make_current_and_root(tmp_path)
+        self._write_sibling(engines_root, "vae", {"mha_kernels_per_attn_block": 2.0})
+        assert _find_best_sibling_mha_ratio(current_engine_dir, "fp16") is None
+
+    def test_skips_sibling_with_different_precision(self, tmp_path):
+        current_engine_dir, engines_root = self._make_current_and_root(tmp_path)
+        self._write_sibling(engines_root, "fp8-sibling", {"precision": "fp8", "mha_kernels_per_attn_block": 1.0})
+        assert _find_best_sibling_mha_ratio(current_engine_dir, "fp16") is None
+
+    def test_skips_sibling_missing_ratio_key(self, tmp_path):
+        current_engine_dir, engines_root = self._make_current_and_root(tmp_path)
+        self._write_sibling(engines_root, "pre-round11", {"precision": "fp16"})
+        assert _find_best_sibling_mha_ratio(current_engine_dir, "fp16") is None
+
+    def test_returns_lowest_ratio_not_highest(self, tmp_path):
+        """The polarity regression test: a fully-fused sibling (2.0, one kernel per
+        attention module) and a worse-fused sibling (3.0, some modules needing two
+        kernels) coexist -- "best" must be the 2.0, not the 3.0."""
+        current_engine_dir, engines_root = self._make_current_and_root(tmp_path)
+        self._write_sibling(
+            engines_root,
+            "well-fused",
+            {"precision": "fp16", "mha_kernels_per_attn_block": 2.0, "build_end": "2026-08-16T00:00:00+00:00"},
+        )
+        self._write_sibling(
+            engines_root,
+            "worse-fused-outlier",
+            {"precision": "fp16", "mha_kernels_per_attn_block": 3.0, "build_end": "2026-08-22T00:00:00+00:00"},
+        )
+
+        best = _find_best_sibling_mha_ratio(current_engine_dir, "fp16")
+
+        assert best == 2.0
+
+    def test_window_ages_out_old_outlier(self, tmp_path):
+        """With window=2 and three siblings ordered oldest -> newest (outlier, then
+        two well-fused builds), only the two most recent are considered -- the
+        all-time-worst outlier must not pin the gate once enough newer builds exist."""
+        current_engine_dir, engines_root = self._make_current_and_root(tmp_path)
+        self._write_sibling(
+            engines_root,
+            "oldest-outlier",
+            {"precision": "fp16", "mha_kernels_per_attn_block": 3.0, "build_end": "2026-08-22T00:00:00+00:00"},
+        )
+        self._write_sibling(
+            engines_root,
+            "recent-a",
+            {"precision": "fp16", "mha_kernels_per_attn_block": 2.5, "build_end": "2026-09-04T00:00:00+00:00"},
+        )
+        self._write_sibling(
+            engines_root,
+            "recent-b",
+            {"precision": "fp16", "mha_kernels_per_attn_block": 2.0, "build_end": "2026-09-06T00:00:00+00:00"},
+        )
+
+        best_windowed = _find_best_sibling_mha_ratio(current_engine_dir, "fp16", window=2)
+        best_unwindowed = _find_best_sibling_mha_ratio(current_engine_dir, "fp16", window=3)
+
+        assert best_windowed == 2.0  # min(2.5, 2.0) -- the 3.0 outlier aged out
+        assert best_unwindowed == 2.0  # min(3.0, 2.5, 2.0) -- still 2.0, but for a different reason
+
+    def test_falls_back_to_build_start_when_build_end_absent(self, tmp_path):
+        """A build that crashed before reaching the end-of-build write only has
+        `build_start` (fp8-round-13's mid-build flush) -- ordering must still work."""
+        current_engine_dir, engines_root = self._make_current_and_root(tmp_path)
+        self._write_sibling(
+            engines_root,
+            "crashed-mid-build",
+            {"precision": "fp16", "mha_kernels_per_attn_block": 3.0, "build_start": "2026-08-22T00:00:00+00:00"},
+        )
+        self._write_sibling(
+            engines_root,
+            "completed",
+            {"precision": "fp16", "mha_kernels_per_attn_block": 2.0, "build_start": "2026-09-06T00:00:00+00:00"},
+        )
+
+        best = _find_best_sibling_mha_ratio(current_engine_dir, "fp16", window=1)
+
+        assert best == 2.0  # only "completed" (the newer build_start) is in the window


### PR DESCRIPTION
## Summary

- Fixes a polarity bug in `_find_best_sibling_mha_ratio` (`builder.py`): the function returned the
  **historical maximum** `mha_kernels_per_attn_block` across sibling engine builds, and the
  regression gate warned whenever the current build's ratio fell **below** that value. Since a
  lower ratio means better MHA fusion (fewer kernels per attention block), this was inverted -- a
  fully-fused build (ratio 2.0) would get flagged as a "regression" against a worse-fused
  historical outlier (ratio 3.0) that should never have been the baseline.
- The fix now takes the **minimum** ratio over a recency `window` (default 5) of prior builds,
  sorted by `build_end` -> `build_start` -> file-mtime fallback, so a single old, worse-fused
  outlier can no longer pin the gate forever, and the comparison at the call site is flipped to
  warn only when the current build needs *more* kernels than the best-known sibling.
- `_apply_gpu_profile_to_config` (`utilities.py`) now also returns/persists
  `builder_optimization_level` into `build_stats.json`, additive to the existing return dict, so
  the optimization level used for a given engine build is recorded for future investigations.
- Adds/restores test coverage in `test_fp8_calib_provenance.py`, including
  `test_returns_lowest_ratio_not_highest` (the direct regression guard for the polarity bug) and
  `test_window_ages_out_old_outlier` (recency-window behavior).

## Branch note

This branch materializes the fork's HEAD state directly for its 3 files rather than a clean
cherry-pick, because `test_fp8_calib_provenance.py` and `builder.py` have pre-existing drift
against this base unrelated to this fix (upstream separately stubbed two test classes with a
"lives in a follow-up PR instead" comment, and has additional `_build_logger.info` call sites).
A straight cherry-pick of the fork's fix commit would conflict on both files; this PR instead
lands the fork's current file state for exactly these 3 files, which is a superset that includes
this fix plus those already-diverged-but-compatible pieces.

Went through this fork's two-stage review gate (`claude-code-review.yml` on a fork-only
`fork-review/SDTD_040_beta_release` base); review came back clean with only two non-blocking
observations (an unreachable `window=0` edge case, and stylistic build-time-only logging
duplication), neither of which warranted a follow-up commit.
