### PR TITLE
fix(hed): full 5-scale export, GPU scribble nms, tuned knobs

### DIFF
--- a/src/streamdiffusion/preprocessing/processors/hed_tensorrt.py
+++ b/src/streamdiffusion/preprocessing/processors/hed_tensorrt.py
@@ -1,19 +1,32 @@
 """
 HED TensorRT preprocessor — GPU-native edge detection via TRT engine.
 
-The HED network (ControlNetHED_Apache2) is wrapped in HEDExportWrapper so
-that ONNX export sees a single output tensor (full-resolution edge map) rather
-than the native 5-output multi-scale tuple.  The wrapper input/output contract:
+The HED network (ControlNetHED_Apache2) is wrapped in HEDExportWrapper so that
+ONNX export sees a single output tensor (full-resolution edge map) rather than
+the native 5-output multi-scale tuple.  The wrapper reproduces exactly what
+``controlnet_aux.HEDdetector.__call__`` does on the CPU:
 
-    input  : float32 (B, 3, H, W) in [0, 1]   ← same as validate_tensor_input output
-    output : float32 (B, 1, H, W) in [0, 1]   ← sigmoid edge map at full resolution
+    1. feed the network 0-255 pixels (its learned ``norm`` parameter is a
+       per-channel mean of ~[122, 117, 104] and expects that range),
+    2. bilinearly upsample the five side outputs to the input resolution,
+    3. average them and apply a sigmoid.
+
+Wrapper input/output contract:
+
+    input  : float32 (B, 3, H, W) in [0, 1]   <- same as validate_tensor_input output
+    output : float32 (B, 1, H, W) in [0, 1]   <- fused sigmoid edge map ("edge_map")
+
+Engines built by the previous wrapper (block-1 side output only, 0-1 input) are
+detected by their output tensor name and rebuilt automatically on load.
 """
 
 import logging
 from pathlib import Path
 
 import torch
+import torch.nn.functional as F
 
+from .category_params import EDGE_SMOOTHNESS_PARAM, apply_edge_smoothness
 from .trt_base import SelfBuildingTRTPreprocessor, _first_output
 
 logger = logging.getLogger(__name__)
@@ -25,9 +38,16 @@ try:
 except ImportError:
     CONTROLNET_AUX_AVAILABLE = False
 
+#: Default post-process knobs, tuned on images/inputs/input.png at 640x384 against
+#: SargeZT/controlnet-sd-xl-1.0-softedge-dexined: 0.3 drops the low-probability
+#: texture haze (hair/cloth interiors) while keeping the soft outline values; a
+#: light post-blur matches the DexiNed-style soft edges the ControlNet was trained on.
+DEFAULT_EDGE_THRESHOLD = 0.3
+DEFAULT_HED_SMOOTHNESS = 0.15
+
 
 # ---------------------------------------------------------------------------
-# ONNX export wrapper — returns only the full-resolution output
+# ONNX export wrapper — fused multi-scale sigmoid edge map
 # ---------------------------------------------------------------------------
 
 
@@ -35,21 +55,32 @@ class HEDExportWrapper(torch.nn.Module):
     """
     Thin wrapper around ControlNetHED_Apache2 for ONNX export.
 
-    The native forward returns a 5-element tuple of tensors at decreasing
-    resolutions.  ONNX export requires a single output of consistent shape.
-    This wrapper returns only output[0] (the full-resolution sigmoid map).
+    The native forward returns five side-output logit maps at (H, H/2, H/4,
+    H/8, H/16).  Following ``HEDdetector.__call__`` the maps are upsampled to
+    (H, W), averaged, and passed through a sigmoid, giving one (B, 1, H, W)
+    edge-probability map.  Returning only ``outputs[0]`` (as an earlier version
+    did) makes the exporter drop four of the five VGG blocks and yields a
+    texture-sensitive first-layer response instead of HED.
     """
+
+    #: Scale applied to the [0, 1] pipeline tensor before the network.
+    INPUT_SCALE = 255.0
 
     def __init__(self, netNetwork: torch.nn.Module):
         super().__init__()
         self.netNetwork = netNetwork
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # x: (B, 3, H, W) in [0, 1]
-        outputs = self.netNetwork(x)
-        # outputs is a list/tuple of 5 tensors at (H, H/2, H/4, H/8, H/16);
-        # take the first = full-resolution edge map  shape (B, 1, H, W)
-        return outputs[0] if isinstance(outputs, (list, tuple)) else outputs
+        # x: (B, 3, H, W) in [0, 1]  ->  network expects 0-255 (mean-subtracted inside)
+        outputs = self.netNetwork(x * self.INPUT_SCALE)
+        if not isinstance(outputs, (list, tuple)):
+            return torch.sigmoid(outputs)
+        full = outputs[0]
+        size = full.shape[-2:]
+        acc = full
+        for side in outputs[1:]:
+            acc = acc + F.interpolate(side, size=size, mode="bilinear", align_corners=False)
+        return torch.sigmoid(acc / float(len(outputs)))
 
 
 # ---------------------------------------------------------------------------
@@ -69,17 +100,39 @@ class HEDTensorrtPreprocessor(SelfBuildingTRTPreprocessor):
     engine_filename = "hed.engine"
     onnx_filename = "hed.onnx"
     default_detect_resolution = 512
+    #: Output tensor name of the current export format.  Engines whose output is
+    #: still called ``output`` were built by the block-1-only wrapper and are stale.
+    ENGINE_OUTPUT_NAME = "edge_map"
 
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
-            "display_name": "HED Edge Detection (TensorRT)",
+            "display_name": "HED Soft Edges (TensorRT)",
             "description": (
-                "GPU-native HED (Holistically-Nested Edge Detection) via TensorRT. "
-                "Self-builds its engine from the controlnet_aux model on first run. "
-                "No CPU/PIL round-trips — satisfies the GPU-residency constraint."
+                "GPU-native HED (Holistically-Nested Edge Detection) via TensorRT: the soft "
+                "white-on-black edge map expected by HED ControlNets. Self-builds hed.engine "
+                "from the controlnet_aux model on first run; the Scribble preprocessor runs "
+                "the same engine and only differs in post-processing. No CPU/PIL round-trips."
             ),
-            "parameters": {},
+            "parameters": {
+                "edge_threshold": {
+                    "type": "float",
+                    "default": DEFAULT_EDGE_THRESHOLD,
+                    "range": [0.0, 1.0],
+                    "description": (
+                        "Zero out edge probabilities below this value (thins the map, keeps the "
+                        "surviving values soft). 0 = raw HED output."
+                    ),
+                },
+                "smoothness": {
+                    **EDGE_SMOOTHNESS_PARAM["smoothness"],
+                    "default": DEFAULT_HED_SMOOTHNESS,
+                    "description": (
+                        "Gaussian post-blur of the edge map, applied after the threshold "
+                        "(0 = sharp; 1 = σ≈2, ~13×13 kernel)."
+                    ),
+                },
+            },
             "use_cases": [
                 "HED ControlNet conditioning",
                 "Structured edge maps (real-time)",
@@ -92,6 +145,24 @@ class HEDTensorrtPreprocessor(SelfBuildingTRTPreprocessor):
                 "controlnet_aux is required for HEDTensorrtPreprocessor. Install with: pip install controlnet_aux"
             )
         super().__init__(**kwargs)
+
+    # ------------------------------------------------------------------
+    # Stale-engine detection
+    # ------------------------------------------------------------------
+
+    def _engine_is_current(self, trt_engine) -> bool:
+        """True when the loaded engine exposes the fused ``edge_map`` output."""
+        eng = trt_engine.engine
+        names = [eng.get_tensor_name(i) for i in range(eng.num_io_tensors)]
+        if self.ENGINE_OUTPUT_NAME in names:
+            return True
+        logger.warning(
+            "%s: engine outputs %s lack '%s' — built by the pre-fix wrapper (block-1 only, 0-1 input); rebuilding.",
+            self.__class__.__name__,
+            names,
+            self.ENGINE_OUTPUT_NAME,
+        )
+        return False
 
     # ------------------------------------------------------------------
     # ONNX export
@@ -119,10 +190,10 @@ class HEDTensorrtPreprocessor(SelfBuildingTRTPreprocessor):
                 str(onnx_path),
                 opset_version=17,
                 input_names=["input"],
-                output_names=["output"],
+                output_names=[self.ENGINE_OUTPUT_NAME],
                 dynamic_axes={
                     "input": {0: "batch", 2: "height", 3: "width"},
-                    "output": {0: "batch", 2: "height", 3: "width"},
+                    self.ENGINE_OUTPUT_NAME: {0: "batch", 2: "height", 3: "width"},
                 },
                 dynamo=False,
             )
@@ -140,8 +211,17 @@ class HEDTensorrtPreprocessor(SelfBuildingTRTPreprocessor):
         """
         Convert TRT output to a 3-channel [0, 1] edge map GPU tensor (CHW).
 
-        Input  : engine_outputs["output"]  shape (B, 1, H, W)  or (B, H, W)
+        Input  : engine_outputs["edge_map"]  shape (B, 1, H, W)  or (B, H, W)
         Output : (3, H, W) in [0, 1]
+
+        The engine output is already a sigmoid probability, so no min/max
+        normalisation is applied (it would amplify noise on flat frames and
+        break the absolute threshold semantics of the scribble post-process).
+
+        Optional knobs (``self.params``, live-updatable from TD):
+          * ``edge_threshold`` — probabilities below it become 0, the rest keep
+            their value (thins the map without binarising it).
+          * ``smoothness``     — Gaussian post-blur of the result.
         """
         out = _first_output(engine_outputs).float()
 
@@ -151,11 +231,15 @@ class HEDTensorrtPreprocessor(SelfBuildingTRTPreprocessor):
         if out.dim() == 3:
             out = out.squeeze(0)  # (H, W)
 
-        # Normalize to [0, 1]  (edge map may already be in this range)
-        v_min, v_max = out.min(), out.max()
-        if v_max > v_min:
-            out = (out - v_min) / (v_max - v_min)
         out = out.clamp(0.0, 1.0)
+
+        threshold = float(self.params.get("edge_threshold", DEFAULT_EDGE_THRESHOLD))
+        if threshold > 0.0:
+            out = torch.where(out >= threshold, out, torch.zeros_like(out))
+
+        smoothness = float(self.params.get("smoothness", DEFAULT_HED_SMOOTHNESS))
+        if smoothness > 0.0:
+            out = apply_edge_smoothness(out, smoothness)  # (H, W) in, (H, W) out
 
         # Expand to 3-channel RGB  →  (3, H, W)
         return out.unsqueeze(0).repeat(3, 1, 1)

--- a/src/streamdiffusion/preprocessing/processors/scribble_tensorrt.py
+++ b/src/streamdiffusion/preprocessing/processors/scribble_tensorrt.py
@@ -2,15 +2,18 @@
 Scribble TensorRT preprocessor — GPU-native scribble edge maps via TRT.
 
 Reuses the HED TRT engine (no second build needed).  Overrides _postprocess
-to apply a GPU-native NMS + binarization that replicates the scribble=True
-post-processing from controlnet_aux HEDdetector.__call__:
+with a GPU port of the ``scribble=True`` branch of
+``controlnet_aux.HEDdetector.__call__``:
 
-    1. Gaussian-blur the sigmoid edge map (smooth noise)
-    2. Directional NMS — keep only local maxima  (thin lines)
-    3. Threshold at 0.5 → binary edge mask
+    1. nms(edge, 127, 3.0):  Gaussian blur (sigma 3) -> keep pixels that are a
+       local maximum along any of the 4 scan lines (h / v / two diagonals)
+       -> threshold at 127/255
+    2. Gaussian blur (sigma 3) of the binary map, re-threshold at 4/255
+       (thickens the thin ridges into scribble strokes)
 """
 
 import logging
+import math
 
 import torch
 import torch.nn.functional as F
@@ -21,44 +24,86 @@ from .trt_base import _first_output
 
 logger = logging.getLogger(__name__)
 
+#: controlnet_aux ``nms(x, t=127, s=3.0)`` threshold expressed on a [0, 1] map.
+DEFAULT_SCRIBBLE_THRESHOLD = 127.0 / 255.0
+#: Gaussian sigma used by both the NMS pre-blur and the stroke-thickening blur.
+SCRIBBLE_SIGMA = 3.0
+#: ``detected_map[detected_map > 4] = 255`` on a [0, 1] map.
+THICKEN_THRESHOLD = 4.0 / 255.0
+
 
 # ---------------------------------------------------------------------------
-# GPU scribble NMS helper
+# GPU scribble NMS helpers
 # ---------------------------------------------------------------------------
 
 
-def _scribble_nms_gpu(edge_map: torch.Tensor, threshold: float = 0.5) -> torch.Tensor:
+def _gaussian_blur(x: torch.Tensor, sigma: float) -> torch.Tensor:
+    """Separable Gaussian blur of a (1, 1, H, W) tensor (cv2.GaussianBlur((0, 0), sigma) equivalent)."""
+    radius = max(1, int(math.ceil(4.0 * sigma)))
+    t = torch.arange(-radius, radius + 1, device=x.device, dtype=x.dtype)
+    k = torch.exp(-(t * t) / (2.0 * sigma * sigma))
+    k = k / k.sum()
+    h, w = x.shape[-2:]
+    # cv2 default border is BORDER_REFLECT_101 (= torch "reflect"); it needs pad < dim.
+    mode = "reflect" if radius < min(h, w) else "replicate"
+    x = F.pad(x, (radius, radius, 0, 0), mode=mode)
+    x = F.conv2d(x, k.view(1, 1, 1, -1))
+    x = F.pad(x, (0, 0, radius, radius), mode=mode)
+    x = F.conv2d(x, k.view(1, 1, -1, 1))
+    return x
+
+
+def _directional_nms(x: torch.Tensor) -> torch.Tensor:
+    """Keep pixels of a (1, 1, H, W) map that are a local max along any of the 4 scan lines.
+
+    Mirrors the ``cv2.dilate(x, kernel=f) == x`` loop in controlnet_aux ``nms``
+    with the four 3-pixel line kernels (horizontal, vertical, both diagonals).
+    Replicate padding leaves border pixels unaffected, like cv2's default
+    morphology border.
     """
-    Approximate GPU version of controlnet_aux nms() used by scribble=True mode.
+    xp = F.pad(x, (1, 1, 1, 1), mode="replicate")
+    c = xp[..., 1:-1, 1:-1]
 
-    Performs:
-      1. Light Gaussian blur  (3×3 average pool — avoids kornia dependency)
-      2. 4-directional local-max suppression  (keep only ridge pixels)
-      3. Threshold at `threshold`
+    def _dil(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return torch.maximum(torch.maximum(a, c), b)
+
+    horiz = _dil(xp[..., 1:-1, :-2], xp[..., 1:-1, 2:])
+    vert = _dil(xp[..., :-2, 1:-1], xp[..., 2:, 1:-1])
+    diag1 = _dil(xp[..., :-2, :-2], xp[..., 2:, 2:])
+    diag2 = _dil(xp[..., :-2, 2:], xp[..., 2:, :-2])
+    keep = (horiz == c) | (vert == c) | (diag1 == c) | (diag2 == c)
+    return torch.where(keep, c, torch.zeros_like(c))
+
+
+def _scribble_nms_gpu(
+    edge_map: torch.Tensor,
+    threshold: float = DEFAULT_SCRIBBLE_THRESHOLD,
+    sigma: float = SCRIBBLE_SIGMA,
+    thicken: bool = True,
+) -> torch.Tensor:
+    """
+    GPU port of the controlnet_aux scribble post-process.
 
     Args:
-        edge_map: (H, W) float32 tensor in [0, 1] on GPU
-        threshold: binarization threshold (default 0.5)
+        edge_map:  (H, W) float tensor in [0, 1] (HED sigmoid probabilities)
+        threshold: ridge threshold on the blurred map (controlnet_aux: 127/255)
+        sigma:     Gaussian sigma for the pre-blur and the thickening blur
+        thicken:   apply the blur + 4/255 re-threshold that widens ridges into strokes
 
     Returns:
-        (H, W) float32 binary tensor on GPU
+        (H, W) float tensor in {0.0, 1.0}
     """
-    x = edge_map.unsqueeze(0).unsqueeze(0)  # (1, 1, H, W)
+    h, w = edge_map.shape[-2:]
+    x = edge_map.reshape(1, 1, h, w).float()
 
-    # Step 1: smooth
-    x = F.avg_pool2d(x, kernel_size=3, stride=1, padding=1)
+    x = _gaussian_blur(x, sigma)
+    ridges = _directional_nms(x)
+    binary = (ridges > threshold).to(x.dtype)
 
-    # Step 2: directional NMS — keep pixel if it is the local max along
-    #         each of the 4 scanning directions (horizontal, vertical, two diagonals).
-    #         We approximate with isotropic max-pool (good enough for thin-line extraction).
-    x_max = F.max_pool2d(x, kernel_size=3, stride=1, padding=1)
-    is_max = (x == x_max).float()
-    thinned = x * is_max
+    if thicken:
+        binary = (_gaussian_blur(binary, sigma) > THICKEN_THRESHOLD).to(x.dtype)
 
-    # Step 3: binarize
-    binary = (thinned.squeeze() > threshold).float()
-
-    return binary
+    return binary.reshape(h, w)
 
 
 # ---------------------------------------------------------------------------
@@ -85,20 +130,21 @@ class ScribbleTensorrtPreprocessor(HEDTensorrtPreprocessor):
     @classmethod
     def get_preprocessor_metadata(cls):
         return {
-            "display_name": "Scribble Edge Detection (TensorRT)",
+            "display_name": "Scribble Strokes (HED + NMS, TensorRT)",
             "description": (
-                "GPU-native scribble-style edge maps. Uses the HED TRT engine with "
-                "GPU NMS + binarization post-processing (no CPU round-trips). "
-                "Compatible with scribble ControlNets."
+                "GPU-native scribble strokes for scribble ControlNets. Runs the same "
+                "hed.engine as the HED preprocessor and applies the controlnet_aux "
+                "scribble=True post-process on the GPU: NMS thinning, binarisation at "
+                "scribble_threshold, then stroke thickening (no CPU round-trips)."
             ),
             "parameters": {
                 "scribble_threshold": {
                     "type": "float",
-                    "default": 0.01,  # was 0.5 — post-NMS ridge values live near zero (~0.005–0.05)
-                    "range": [0.0, 0.05],  # was [0.0, 1.0] — spreads useful control across full travel
+                    "default": round(DEFAULT_SCRIBBLE_THRESHOLD, 3),
+                    "range": [0.0, 1.0],
                     "description": (
-                        "Binarization threshold for scribble edge NMS. Operates on the post-NMS ridge map "
-                        "whose values are small (~0.005–0.05); lower keeps more edges."
+                        "Ridge threshold applied after the Gaussian-blurred directional NMS, on the "
+                        "HED edge probability in [0, 1] (controlnet_aux uses 127/255). Lower keeps more edges."
                     ),
                 },
                 **EDGE_SMOOTHNESS_PARAM,
@@ -113,7 +159,7 @@ class ScribbleTensorrtPreprocessor(HEDTensorrtPreprocessor):
         """
         Apply scribble NMS + threshold to the HED output, return 3-channel CHW.
 
-        Input  : engine_outputs["output"]  shape (B, 1, H, W)  or (B, H, W)
+        Input  : engine_outputs["edge_map"]  shape (B, 1, H, W)  or (B, H, W)
         Output : (3, H, W) in {0.0, 1.0}   (binary scribble map)
         """
         out = _first_output(engine_outputs).float()
@@ -123,10 +169,8 @@ class ScribbleTensorrtPreprocessor(HEDTensorrtPreprocessor):
         if out.dim() == 3:
             out = out.squeeze(0)  # (H, W)
 
-        # Normalize to [0, 1] before NMS
-        v_min, v_max = out.min(), out.max()
-        if v_max > v_min:
-            out = (out - v_min) / (v_max - v_min)
+        # Engine output is a sigmoid probability map; keep absolute values so the
+        # threshold matches controlnet_aux (no min/max normalisation).
         out = out.clamp(0.0, 1.0)
 
         # Optional smoothness pre-blur (category-standard edge param) applied before
@@ -136,7 +180,7 @@ class ScribbleTensorrtPreprocessor(HEDTensorrtPreprocessor):
         if smoothness > 0.0:
             out = apply_edge_smoothness(out, smoothness)  # (H, W) in, (H, W) out
 
-        threshold = float(self.params.get("scribble_threshold", 0.5))
+        threshold = float(self.params.get("scribble_threshold", DEFAULT_SCRIBBLE_THRESHOLD))
         scribble = _scribble_nms_gpu(out, threshold=threshold)  # (H, W)
 
         # Expand to 3-channel RGB

--- a/src/streamdiffusion/preprocessing/processors/trt_base.py
+++ b/src/streamdiffusion/preprocessing/processors/trt_base.py
@@ -411,6 +411,14 @@ class SelfBuildingTRTPreprocessor(BasePreprocessor):
                     try:
                         trt_engine = TensorRTEngine(str(engine_path))
                         trt_engine.load()
+                        if not self._engine_is_current(trt_engine):
+                            # Stale export format on disk (see subclass hook): rebuild in place.
+                            logger.warning("%s: rebuilding stale engine %s", cls_name, engine_path)
+                            del trt_engine
+                            engine_path.unlink()
+                            self._ensure_engine()
+                            trt_engine = TensorRTEngine(str(engine_path))
+                            trt_engine.load()
                         trt_engine.activate()
                         trt_engine.allocate_buffers(
                             device=self.device,
@@ -427,6 +435,12 @@ class SelfBuildingTRTPreprocessor(BasePreprocessor):
                             f"{cls_name}: engine load/activate/allocate failed for {engine_path}: {exc}"
                         ) from exc
         return self._engine
+
+    def _engine_is_current(self, trt_engine: TensorRTEngine) -> bool:
+        """Hook: return False when the engine on disk was built by an older export
+        format and must be rebuilt.  Called once, right after deserialisation and
+        before activation.  Default: every engine is accepted."""
+        return True
 
     def _ensure_engine(self) -> None:
         """Build the TRT engine from scratch if it doesn't exist yet."""

--- a/src/streamdiffusion/preprocessing/processors/trt_base.py
+++ b/src/streamdiffusion/preprocessing/processors/trt_base.py
@@ -313,6 +313,33 @@ def _first_output(engine_outputs: dict) -> torch.Tensor:
 
 
 # ---------------------------------------------------------------------------
+# Cross-instance engine locks
+# ---------------------------------------------------------------------------
+#
+# Subclasses can share an engine_filename (e.g. ScribbleTensorrtPreprocessor reuses
+# HEDTensorrtPreprocessor's "hed.engine") while still being distinct instances with
+# distinct per-instance state. get_preprocessor() never caches instances, and the
+# ControlNet orchestrator runs each preprocessor group on its own ThreadPoolExecutor
+# worker, so two such instances can race on the SAME engine file: both take the
+# stale-engine branch below on the same frame, and one's engine_path.unlink() /
+# rebuild collides with the other's in-flight load. A lock keyed by the resolved
+# engine path (rather than one lock per instance) is required to serialize them.
+_ENGINE_LOCKS: Dict[str, threading.Lock] = {}
+_ENGINE_LOCKS_GUARD = threading.Lock()
+
+
+def _engine_lock_for(path: Path) -> threading.Lock:
+    """Process-wide lock shared by every preprocessor resolving to the same engine file."""
+    key = str(path.resolve())
+    with _ENGINE_LOCKS_GUARD:
+        lock = _ENGINE_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _ENGINE_LOCKS[key] = lock
+        return lock
+
+
+# ---------------------------------------------------------------------------
 # Self-building TRT preprocessor base
 # ---------------------------------------------------------------------------
 
@@ -364,7 +391,6 @@ class SelfBuildingTRTPreprocessor(BasePreprocessor):
             )
         super().__init__(**kwargs)
         self._engine: Optional[TensorRTEngine] = None
-        self._engine_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # PIL fallback path — goes through tensor for GPU residency
@@ -396,9 +422,15 @@ class SelfBuildingTRTPreprocessor(BasePreprocessor):
 
     @property
     def engine(self) -> TensorRTEngine:
-        """Lazy-load the TRT engine (double-checked locking)."""
+        """Lazy-load the TRT engine (double-checked locking).
+
+        Locks on the resolved engine path, not on ``self`` — subclasses that share an
+        engine_filename (HED/Scribble both build "hed.engine") are otherwise distinct
+        instances with independent locks and can race on the same file. See
+        ``_engine_lock_for``.
+        """
         if self._engine is None:
-            with self._engine_lock:
+            with _engine_lock_for(self._get_engine_path()):
                 if self._engine is None:
                     cls_name = self.__class__.__name__
                     engine_path = self._get_engine_path()

--- a/tests/unit/test_hed_scribble_trt_parity.py
+++ b/tests/unit/test_hed_scribble_trt_parity.py
@@ -1,0 +1,292 @@
+"""CPU-only guards for the HED / scribble TensorRT preprocessors.
+
+Regression context: the original HEDExportWrapper fed the network [0, 1] pixels
+(it expects 0-255) and returned only the block-1 side output, so the exporter
+dropped four of the five VGG blocks and the scribble map looked like a
+texture/contour response.  These tests pin the export contract and the
+controlnet_aux-faithful scribble post-process without needing a GPU or TRT.
+
+Also covered: the HED post-process knobs (``edge_threshold`` keeps values soft,
+``smoothness`` post-blurs) and the cuDNN-benchmark guard in
+``apply_edge_smoothness`` (a strength-dependent kernel size must never trigger
+a per-size autotune while the pipeline runs with cudnn.benchmark=True).
+"""
+
+import types
+
+import pytest
+import torch
+
+torch.manual_seed(0)
+
+from streamdiffusion.preprocessing.processors.category_params import apply_edge_smoothness
+from streamdiffusion.preprocessing.processors.hed_tensorrt import (
+    DEFAULT_EDGE_THRESHOLD,
+    DEFAULT_HED_SMOOTHNESS,
+    HEDExportWrapper,
+    HEDTensorrtPreprocessor,
+)
+from streamdiffusion.preprocessing.processors.scribble_tensorrt import (
+    DEFAULT_SCRIBBLE_THRESHOLD,
+    ScribbleTensorrtPreprocessor,
+    _directional_nms,
+    _gaussian_blur,
+    _scribble_nms_gpu,
+)
+
+
+class _FakeHED(torch.nn.Module):
+    """Mimics ControlNetHED_Apache2's 5 side outputs at H, H/2, H/4, H/8, H/16.
+
+    Records the input it received so the test can check the 0-255 scaling.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.seen = None
+
+    def forward(self, x):
+        self.seen = x
+        b, _, h, w = x.shape
+        outs = []
+        for k in range(5):
+            s = 2**k
+            # Constant logit k at each scale, independent of x (shape checks only)
+            outs.append(torch.full((b, 1, h // s, w // s), float(k)))
+        return outs
+
+
+# ---------------------------------------------------------------------------
+# Export wrapper contract
+# ---------------------------------------------------------------------------
+
+
+def test_wrapper_scales_input_to_0_255():
+    net = _FakeHED()
+    x = torch.rand(1, 3, 64, 64)
+    HEDExportWrapper(net)(x)
+    assert torch.allclose(net.seen, x * 255.0)
+
+
+def test_wrapper_fuses_five_scales_with_sigmoid():
+    net = _FakeHED()
+    out = HEDExportWrapper(net)(torch.rand(2, 3, 96, 160))
+    assert out.shape == (2, 1, 96, 160)
+    # mean of logits 0..4 = 2.0 -> sigmoid(2.0); every scale must contribute
+    assert torch.allclose(out, torch.sigmoid(torch.tensor(2.0)).expand_as(out), atol=1e-6)
+    assert out.min() >= 0.0 and out.max() <= 1.0
+
+
+def test_wrapper_output_name_is_edge_map():
+    assert HEDTensorrtPreprocessor.ENGINE_OUTPUT_NAME == "edge_map"
+    assert ScribbleTensorrtPreprocessor.ENGINE_OUTPUT_NAME == "edge_map"
+
+
+# ---------------------------------------------------------------------------
+# Stale-engine detection
+# ---------------------------------------------------------------------------
+
+
+def _fake_trt_engine(names):
+    eng = types.SimpleNamespace(num_io_tensors=len(names), get_tensor_name=lambda i: names[i])
+    return types.SimpleNamespace(engine=eng)
+
+
+def test_stale_engine_detected_by_output_name():
+    proc = HEDTensorrtPreprocessor.__new__(HEDTensorrtPreprocessor)
+    assert proc._engine_is_current(_fake_trt_engine(["input", "edge_map"])) is True
+    assert proc._engine_is_current(_fake_trt_engine(["input", "output"])) is False
+
+
+# ---------------------------------------------------------------------------
+# Scribble post-process (controlnet_aux nms port)
+# ---------------------------------------------------------------------------
+
+
+def test_gaussian_blur_preserves_mass_and_shape():
+    x = torch.zeros(1, 1, 64, 64)
+    x[0, 0, 32, 32] = 1.0
+    y = _gaussian_blur(x, 3.0)
+    assert y.shape == x.shape
+    assert abs(y.sum().item() - 1.0) < 1e-4
+    assert y[0, 0, 32, 32] > y[0, 0, 32, 36] > y[0, 0, 32, 44]
+
+
+def test_directional_nms_keeps_ridge_and_drops_slope():
+    # Horizontal ridge: row 10 is the max of every column -> vertical scan keeps it.
+    x = torch.zeros(1, 1, 21, 21)
+    for r in range(21):
+        x[0, 0, r, :] = 1.0 - abs(r - 10) / 10.0
+    y = _directional_nms(x)
+    assert torch.all(y[0, 0, 10, :] == 1.0)
+
+    # Tilted plane r + 2c: strictly monotonic along all four scan lines, so no
+    # interior pixel is a local max -> everything except the replicate-padded
+    # border corner is suppressed.
+    rr, cc = torch.meshgrid(torch.arange(15.0), torch.arange(15.0), indexing="ij")
+    plane = (rr + 2.0 * cc).reshape(1, 1, 15, 15)
+    yp = _directional_nms(plane)
+    assert torch.all(yp[0, 0, 1:-1, 1:-1] == 0.0)
+    assert yp[0, 0, 14, 14] == plane[0, 0, 14, 14]  # global max survives
+
+
+def test_scribble_nms_line_survives_and_thickens():
+    h, w = 96, 96
+    edge = torch.zeros(h, w)
+    edge[48, 16:80] = 1.0  # one-pixel HED ridge at full confidence
+    thin = _scribble_nms_gpu(edge, threshold=0.05, thicken=False)
+    thick = _scribble_nms_gpu(edge, threshold=0.05, thicken=True)
+    assert thin.shape == (h, w)
+    assert set(thin.unique().tolist()) <= {0.0, 1.0}
+    assert thin[48, 40] == 1.0
+    assert thin.sum() < thick.sum()  # thickening widens the stroke
+    # The stroke stays localised: nothing far from the ridge
+    assert thick[10, 40] == 0.0 and thick[86, 40] == 0.0
+
+
+def test_scribble_nms_flat_frame_stays_black():
+    # Flat low-probability frame (no edges): the old min/max normalisation turned
+    # this into all-white; with absolute thresholds it must stay black.
+    edge = torch.full((64, 64), 0.05)
+    out = _scribble_nms_gpu(edge)
+    assert out.sum() == 0.0
+
+
+def test_scribble_default_threshold_matches_controlnet_aux():
+    assert pytest.approx(127 / 255) == DEFAULT_SCRIBBLE_THRESHOLD
+    meta = ScribbleTensorrtPreprocessor.get_preprocessor_metadata()["parameters"]["scribble_threshold"]
+    assert meta["range"] == [0.0, 1.0]
+    assert meta["default"] == pytest.approx(DEFAULT_SCRIBBLE_THRESHOLD, abs=1e-3)
+
+
+@pytest.mark.skipif(
+    pytest.importorskip("cv2", reason="cv2 needed for controlnet_aux nms parity") is None,
+    reason="cv2 missing",
+)
+def test_scribble_nms_matches_controlnet_aux_reference():
+    """Bit-for-bit-ish parity with controlnet_aux.util.nms + the thickening step."""
+    import cv2
+    import numpy as np
+    from controlnet_aux.util import nms as ref_nms
+
+    torch.manual_seed(1)
+    # Smooth random field with a few strong ridges
+    field = _gaussian_blur(torch.rand(1, 1, 128, 128), 2.0)[0, 0]
+    field = (field - field.min()) / (field.max() - field.min())
+    field[64, :] = 1.0
+    field[:, 40] = 0.9
+
+    # Reference (CPU, uint8 like HEDdetector.__call__)
+    ref_u8 = (field.numpy() * 255.0).clip(0, 255).astype(np.uint8)
+    ref = ref_nms(ref_u8, 127, 3.0)
+    ref = cv2.GaussianBlur(ref, (0, 0), 3.0)
+    ref = (ref > 4).astype(np.float32)
+
+    ours = _scribble_nms_gpu(field).numpy()
+    agree = (ours == ref).mean()
+    assert agree > 0.98, f"only {agree:.3%} pixel agreement with controlnet_aux"
+
+
+# ---------------------------------------------------------------------------
+# HED post-process knobs
+# ---------------------------------------------------------------------------
+
+
+def _hed_proc(**params):
+    proc = HEDTensorrtPreprocessor.__new__(HEDTensorrtPreprocessor)
+    proc.params = dict(params)
+    return proc
+
+
+def test_hed_postprocess_threshold_keeps_values_not_binary():
+    edge = torch.zeros(1, 1, 8, 8)
+    edge[0, 0, 1, 1] = 0.2
+    edge[0, 0, 3, 3] = 0.6
+    edge[0, 0, 5, 5] = 0.9
+    out = _hed_proc(edge_threshold=0.5, smoothness=0.0)._postprocess({"edge_map": edge})
+    assert out.shape == (3, 8, 8)
+    assert out[0, 1, 1] == 0.0  # below threshold -> dropped
+    assert out[0, 3, 3] == pytest.approx(0.6)  # survivors keep their soft value
+    assert out[0, 5, 5] == pytest.approx(0.9)
+    assert torch.equal(out[0], out[1]) and torch.equal(out[0], out[2])
+
+
+def test_hed_postprocess_zero_knobs_is_raw_map():
+    edge = torch.rand(1, 1, 8, 8)
+    out = _hed_proc(edge_threshold=0.0, smoothness=0.0)._postprocess({"edge_map": edge})
+    assert torch.allclose(out[0], edge[0, 0])
+
+
+def test_hed_postprocess_missing_params_use_metadata_defaults():
+    # A processor built without params must behave like one built with the advertised defaults.
+    edge = torch.rand(1, 1, 16, 16)
+    implicit = _hed_proc()._postprocess({"edge_map": edge})
+    explicit = _hed_proc(edge_threshold=DEFAULT_EDGE_THRESHOLD, smoothness=DEFAULT_HED_SMOOTHNESS)._postprocess(
+        {"edge_map": edge}
+    )
+    assert torch.equal(implicit, explicit)
+    assert not torch.allclose(implicit[0], edge[0, 0])  # defaults are not a no-op
+
+
+def test_hed_postprocess_smoothness_post_blurs():
+    edge = torch.zeros(1, 1, 16, 16)
+    edge[0, 0, 8, 8] = 1.0
+    sharp = _hed_proc(smoothness=0.0)._postprocess({"edge_map": edge})[0]
+    soft = _hed_proc(smoothness=0.5)._postprocess({"edge_map": edge})[0]
+    assert torch.equal(sharp, edge[0, 0])
+    assert soft[8, 8] < 1.0
+    assert soft[8, 9] > 0.0 and soft[9, 8] > 0.0 and soft[7, 8] > 0.0 and soft[8, 7] > 0.0
+    assert soft.min() >= 0.0 and soft.max() <= 1.0
+    assert abs(soft.sum().item() - 1.0) < 1e-4  # blur preserves mass away from the border
+
+
+def test_hed_metadata_exposes_threshold_and_smoothness():
+    hed_params = HEDTensorrtPreprocessor.get_preprocessor_metadata()["parameters"]
+    assert set(hed_params) == {"edge_threshold", "smoothness"}
+    for name in ("edge_threshold", "smoothness"):
+        assert hed_params[name]["type"] == "float"
+        assert hed_params[name]["range"] == [0.0, 1.0]
+    assert hed_params["edge_threshold"]["default"] == pytest.approx(DEFAULT_EDGE_THRESHOLD)
+    assert hed_params["smoothness"]["default"] == pytest.approx(DEFAULT_HED_SMOOTHNESS)
+    assert 0.0 < DEFAULT_EDGE_THRESHOLD < 1.0 and 0.0 < DEFAULT_HED_SMOOTHNESS < 1.0
+    scribble_params = ScribbleTensorrtPreprocessor.get_preprocessor_metadata()["parameters"]
+    assert "edge_threshold" not in scribble_params
+    assert set(scribble_params) == {"scribble_threshold", "smoothness"}
+
+
+# ---------------------------------------------------------------------------
+# apply_edge_smoothness: cuDNN benchmark guard
+# ---------------------------------------------------------------------------
+
+
+def test_edge_smoothness_leaves_global_cudnn_benchmark_untouched():
+    prev = torch.backends.cudnn.benchmark
+    try:
+        torch.backends.cudnn.benchmark = True
+        x = torch.rand(32, 48)
+        y = apply_edge_smoothness(x, 0.7)
+        assert y.shape == x.shape and y.dtype == x.dtype
+        assert torch.backends.cudnn.benchmark is True
+    finally:
+        torch.backends.cudnn.benchmark = prev
+
+
+def test_edge_smoothness_disables_benchmark_inside_conv(monkeypatch):
+    import torch.nn.functional as F
+
+    real_conv2d = F.conv2d
+    seen = []
+
+    def recording_conv2d(*args, **kwargs):
+        seen.append(torch.backends.cudnn.benchmark)
+        return real_conv2d(*args, **kwargs)
+
+    monkeypatch.setattr(F, "conv2d", recording_conv2d)
+    prev = torch.backends.cudnn.benchmark
+    try:
+        torch.backends.cudnn.benchmark = True
+        apply_edge_smoothness(torch.rand(1, 16, 16), 0.4)
+    finally:
+        torch.backends.cudnn.benchmark = prev
+    assert len(seen) == 2  # separable: one horizontal + one vertical pass
+    assert seen == [False, False]

--- a/tests/unit/test_hed_scribble_trt_parity.py
+++ b/tests/unit/test_hed_scribble_trt_parity.py
@@ -15,6 +15,7 @@ owning PR.
 """
 
 import types
+from pathlib import Path
 
 import pytest
 import torch
@@ -269,3 +270,28 @@ def test_edge_smoothness_leaves_global_cudnn_benchmark_untouched():
         assert torch.backends.cudnn.benchmark is True
     finally:
         torch.backends.cudnn.benchmark = prev
+
+
+# ---------------------------------------------------------------------------
+# Shared engine lock: HED and Scribble both build "hed.engine"
+# ---------------------------------------------------------------------------
+
+
+def test_hed_and_scribble_share_one_engine_lock():
+    """ScribbleTensorrtPreprocessor reuses HEDTensorrtPreprocessor's engine_filename
+    ("hed.engine"), so two concurrent instances (get_preprocessor() never caches —
+    each ControlNet unit gets its own, and the orchestrator runs them on separate
+    ThreadPoolExecutor workers) must serialize on the SAME lock. Per-instance locks
+    would let both take the stale-engine rebuild branch at once and race on
+    engine_path.unlink() / TensorRTEngine(...).load(). No TRT/GPU required."""
+    from streamdiffusion.preprocessing.processors.trt_base import _engine_lock_for
+
+    assert HEDTensorrtPreprocessor.engine_filename == ScribbleTensorrtPreprocessor.engine_filename
+
+    engine_dir = Path("engines/preprocessors")
+    hed_path = engine_dir / HEDTensorrtPreprocessor.engine_filename
+    scribble_path = engine_dir / ScribbleTensorrtPreprocessor.engine_filename
+    assert _engine_lock_for(hed_path) is _engine_lock_for(scribble_path)
+
+    other_path = engine_dir / "some_other.engine"
+    assert _engine_lock_for(other_path) is not _engine_lock_for(hed_path)

--- a/tests/unit/test_hed_scribble_trt_parity.py
+++ b/tests/unit/test_hed_scribble_trt_parity.py
@@ -7,9 +7,11 @@ texture/contour response.  These tests pin the export contract and the
 controlnet_aux-faithful scribble post-process without needing a GPU or TRT.
 
 Also covered: the HED post-process knobs (``edge_threshold`` keeps values soft,
-``smoothness`` post-blurs) and the cuDNN-benchmark guard in
-``apply_edge_smoothness`` (a strength-dependent kernel size must never trigger
-a per-size autotune while the pipeline runs with cudnn.benchmark=True).
+``smoothness`` post-blurs) and that ``apply_edge_smoothness`` restores the global
+cudnn.benchmark flag afterward. The guard's actual inner-call behavior (that the
+strength-dependent kernel size never triggers a per-size autotune) is covered in
+tests/unit/test_edge_smoothness_cudnn_guard.py, alongside apply_edge_smoothness's
+owning PR.
 """
 
 import types
@@ -267,24 +269,3 @@ def test_edge_smoothness_leaves_global_cudnn_benchmark_untouched():
         assert torch.backends.cudnn.benchmark is True
     finally:
         torch.backends.cudnn.benchmark = prev
-
-
-def test_edge_smoothness_disables_benchmark_inside_conv(monkeypatch):
-    import torch.nn.functional as F
-
-    real_conv2d = F.conv2d
-    seen = []
-
-    def recording_conv2d(*args, **kwargs):
-        seen.append(torch.backends.cudnn.benchmark)
-        return real_conv2d(*args, **kwargs)
-
-    monkeypatch.setattr(F, "conv2d", recording_conv2d)
-    prev = torch.backends.cudnn.benchmark
-    try:
-        torch.backends.cudnn.benchmark = True
-        apply_edge_smoothness(torch.rand(1, 16, 16), 0.4)
-    finally:
-        torch.backends.cudnn.benchmark = prev
-    assert len(seen) == 2  # separable: one horizontal + one vertical pass
-    assert seen == [False, False]

--- a/tests/unit/test_hed_scribble_trt_parity.py
+++ b/tests/unit/test_hed_scribble_trt_parity.py
@@ -159,12 +159,10 @@ def test_scribble_default_threshold_matches_controlnet_aux():
     assert meta["default"] == pytest.approx(DEFAULT_SCRIBBLE_THRESHOLD, abs=1e-3)
 
 
-@pytest.mark.skipif(
-    pytest.importorskip("cv2", reason="cv2 needed for controlnet_aux nms parity") is None,
-    reason="cv2 missing",
-)
 def test_scribble_nms_matches_controlnet_aux_reference():
     """Bit-for-bit-ish parity with controlnet_aux.util.nms + the thickening step."""
+    pytest.importorskip("cv2", reason="cv2 needed for controlnet_aux nms parity")
+    pytest.importorskip("controlnet_aux", reason="controlnet_aux needed for nms reference")
     import cv2
     import numpy as np
     from controlnet_aux.util import nms as ref_nms


### PR DESCRIPTION
## Summary

- Fixes `HEDExportWrapper` to export the full 5-scale fused-sigmoid edge map (matching `controlnet_aux.HEDdetector.__call__`) instead of only the block-1 side output (`outputs[0]`), which produced a texture-sensitive response instead of true HED edges.
- Adds stale-engine detection: engines built by the old block-1-only wrapper are identified by their output tensor name and automatically rebuilt.
- Moves Scribble's NMS post-process to the GPU (`_directional_nms`, `_gaussian_blur`), reproducing `cv2.dilate`-based directional NMS and separable Gaussian blur without a CPU/PIL round-trip.
- Tunes `edge_threshold` / `smoothness` defaults for HED against SargeZT/controlnet-sd-xl-1.0-softedge-dexined.
- Fixes a shared-engine-rebuild race: `ScribbleTensorrtPreprocessor` reuses `HEDTensorrtPreprocessor`'s `engine_filename` ("hed.engine"), but the per-instance engine lock let two concurrently-running instances (one per ControlNet unit, scheduled on separate worker threads) both take the stale-engine rebuild branch on the same file at once. Replaced with a process-wide lock keyed by the resolved engine path.

## Known adjacent issue (not fixed here)

`HEDExportWrapper.forward` assumes its input is in `[0, 1]` (as `validate_tensor_input` produces for the ControlNet conditioning path) and scales by 255 before the network. If HED/Scribble were instead wired up as a generic pipeline image-preprocessing step (`normalization_context="pipeline"`), the pipeline-hook path can deliver `[-1, 1]`-range tensors, which this wrapper does not detect or renormalize, producing garbage output. This is a pre-existing, cross-cutting gap already present in other TRT preprocessors (e.g. `standard_lineart.py`, `normal_bae_tensorrt.py`) — this PR changes how wrong the existing assumption is if that path is ever exercised, not whether it exists. The ControlNet conditioning path (the one this PR is used through) is unaffected. Worth a follow-up PR normalizing `pipeline_preprocessing_orchestrator._apply_single_processor` the same way `postprocessing_orchestrator._apply_single_postprocessor` already does, rather than folding a cross-cutting normalization fix into this focused PR.

## Branch note

Reviewed on fork PR forkni/StreamDiffusion#28 by both GitHub Copilot and the repo's `claude-code-review.yml` action; all actionable findings from that review are fixed in this branch (see commits `96dc33f`, `f2607a1`, `40960cf`).
