### PR TITLE
feat(diag): ErrorReporter with dedup + log tail

### DIFF
--- a/src/streamdiffusion/utils/diagnostics.py
+++ b/src/streamdiffusion/utils/diagnostics.py
@@ -14,6 +14,7 @@ the two are deliberately not shared code since they live in separate git repos.
 from __future__ import annotations
 
 import collections
+import contextlib
 import importlib.metadata
 import logging
 import os
@@ -26,6 +27,14 @@ import traceback
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+# Hardened against branch drift, same rationale as td_manager.py's own guarded import of
+# this pair: reporting.py lives alongside this module but isn't guaranteed present on
+# every branch the deployed (gitignored) copy of this file gets checked out against.
+try:
+    from .reporting import report_error
+except ImportError:
+    report_error = None
 
 SCHEMA_VERSION = "v1"
 # Only these env-var prefixes are dumped -- never the full os.environ (avoids leaking secrets).
@@ -62,7 +71,6 @@ WRAPPER_CONFIG_ATTRS = (
 _LOG_TAIL_MAXLEN = 200
 _log_tail_buffer: collections.deque = collections.deque(maxlen=_LOG_TAIL_MAXLEN)
 _log_tail_lock = threading.Lock()
-_log_tail_installed = False
 
 
 class _TailBufferHandler(logging.Handler):
@@ -76,20 +84,26 @@ class _TailBufferHandler(logging.Handler):
 
 
 def _install_log_tail_handler() -> None:
-    """Attach the tail-buffer handler to the root logger, once per process. Best-effort."""
-    global _log_tail_installed
+    """Attach the tail-buffer handler to the root logger. Best-effort and idempotent --
+    safe to call repeatedly.
+
+    Re-attaches whenever no _TailBufferHandler instance is currently on the root
+    logger, rather than gating on a one-shot "already installed" flag. td_main.py
+    strips every non-OSCLoggingHandler handler from root during its startup
+    reconfiguration, which silently removes this handler too; a one-shot flag would
+    then block it from ever coming back, leaving LOG TAIL permanently empty.
+    """
     with _log_tail_lock:
-        if _log_tail_installed:
+        root = logging.getLogger()
+        if any(isinstance(h, _TailBufferHandler) for h in root.handlers):
             return
         try:
             handler = _TailBufferHandler()
             handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
             handler.setLevel(logging.INFO)
-            logging.getLogger().addHandler(handler)
+            root.addHandler(handler)
         except Exception:
             pass
-        finally:
-            _log_tail_installed = True
 
 
 def _get_log_tail(n: int = 50) -> list:
@@ -379,6 +393,99 @@ def write_error_report(
         except Exception:
             pass
         return None
+
+
+class ErrorReporter:
+    """
+    Shared, dedup-aware wrapper around write_error_report() + report_error().
+
+    Generalizes the debounce block that used to live inline in
+    TouchDesignerManager._streaming_loop (a single `_last_error_report_sig`
+    attribute, usable only from that one call site) so every call site --
+    the streaming thread, the OSC server thread, the main thread's model-load
+    and start() excepts, and the process-wide excepthooks -- shares one
+    signature cache and one report cap instead of each needing its own.
+
+    Best-effort by construction, like write_error_report() itself: report()
+    must never raise, so a bug in reporting can never mask the exception that
+    triggered it.
+    """
+
+    def __init__(self, *, max_reports: int = 20) -> None:
+        self._max_reports = max_reports
+        self._lock = threading.Lock()
+        self._seen_sigs: set = set()
+        self._report_count = 0
+
+    def report(
+        self,
+        exc: BaseException,
+        *,
+        stage: str,
+        where: str,
+        wrapper: Any = None,
+        config: Optional[Dict[str, Any]] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Path]:
+        """
+        Write a diagnostic report for `exc`, deduped by (where, exception type,
+        truncated message) and capped at `max_reports` writes per process.
+
+        Args:
+            exc: The caught exception.
+            stage: Report stage label, forwarded to write_error_report (e.g.
+                "inference", "model_load", "start", "main").
+            where: Call-site label. Folded into the dedup signature and also
+                surfaced as `context["where"]` (the SUMMARY "Context:" line),
+                same as the streaming-loop block it replaces.
+            wrapper, config: Forwarded to write_error_report unchanged.
+            context: Extra key/value pairs merged into CONFIG; `where` is
+                injected automatically and does not need to be repeated here.
+
+        Returns:
+            Path to the newly written report, or None when the signature was
+            already seen, the per-process cap was reached, or writing itself
+            failed. Never raises.
+        """
+        try:
+            sig = f"{where}|{type(exc).__name__}:{str(exc)[:200]}"
+            with self._lock:
+                if sig in self._seen_sigs or self._report_count >= self._max_reports:
+                    return None
+                self._seen_sigs.add(sig)
+                self._report_count += 1
+
+            merged_context: Dict[str, Any] = {"where": where}
+            if context:
+                merged_context.update(context)
+
+            report_path = (
+                write_error_report(exc, stage=stage, wrapper=wrapper, config=config, context=merged_context)
+                if write_error_report is not None
+                else None
+            )
+
+            msg = f"Error [{where}]: {exc}"
+            if report_path:
+                msg += f". Report written to {report_path}"
+                # Belt-and-braces: this is backend subprocess code (no TD debug()), and
+                # td_main.py briefly strips/reconfigures logging handlers at startup --
+                # a bare print() guarantees the path still reaches the console even in
+                # that window. The report file, not this line, is the persistent record.
+                with contextlib.suppress(Exception):
+                    print(f"[StreamDiffusionTD] Error report written to {report_path}")
+
+            if report_error is not None:
+                report_error(msg)
+            else:
+                logging.getLogger(__name__).error(msg)
+            return report_path
+        except Exception as report_exc:
+            with contextlib.suppress(Exception):
+                logging.getLogger(__name__).error(
+                    f"Error [{where}]: {exc} (error-reporting also failed: {report_exc})"
+                )
+            return None
 
 
 _install_log_tail_handler()

--- a/src/streamdiffusion/utils/diagnostics.py
+++ b/src/streamdiffusion/utils/diagnostics.py
@@ -459,11 +459,7 @@ class ErrorReporter:
             if context:
                 merged_context.update(context)
 
-            report_path = (
-                write_error_report(exc, stage=stage, wrapper=wrapper, config=config, context=merged_context)
-                if write_error_report is not None
-                else None
-            )
+            report_path = write_error_report(exc, stage=stage, wrapper=wrapper, config=config, context=merged_context)
 
             msg = f"Error [{where}]: {exc}"
             if report_path:

--- a/tests/unit/test_error_reporter.py
+++ b/tests/unit/test_error_reporter.py
@@ -1,0 +1,154 @@
+"""
+Unit tests for streamdiffusion.utils.diagnostics.ErrorReporter.
+
+Covers the dedup-aware `report()` wrapper around write_error_report() + report_error():
+writing/returning a path, same-signature dedup, different-`where` distinctness, the
+max_reports cap, the never-raises contract when write_error_report itself blows up, and
+thread-safety under concurrent calls from several threads. All tests are CPU-only, mirroring
+test_diagnostics.py's convention of monkeypatching torch.cuda directly rather than requiring
+real hardware, and use the same SDTD_BASE_FOLDER_PATH env-var pattern to redirect writes into
+tmp_path (ErrorReporter.report() does not accept its own out_dir -- it forwards straight to
+write_error_report()'s default resolution).
+"""
+
+import threading
+from pathlib import Path
+
+import torch
+
+from streamdiffusion.utils import diagnostics
+
+
+class TestErrorReporterReport:
+    def test_writes_report_and_returns_path(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+        monkeypatch.setenv("SDTD_BASE_FOLDER_PATH", str(tmp_path))
+        reporter = diagnostics.ErrorReporter()
+
+        report_path = reporter.report(RuntimeError("boom"), stage="inference", where="streaming_loop")
+
+        assert report_path is not None
+        assert report_path.exists()
+        assert report_path.parent == tmp_path / "error_reports"
+        assert report_path.name.startswith("inference_error_report_")
+        text = report_path.read_text(encoding="utf-8")
+        assert "where: streaming_loop" in text
+        assert "Context: streaming_loop" in text
+
+    def test_same_where_and_exception_deduped_to_one_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+        monkeypatch.setenv("SDTD_BASE_FOLDER_PATH", str(tmp_path))
+        reporter = diagnostics.ErrorReporter()
+
+        first = reporter.report(RuntimeError("boom"), stage="inference", where="streaming_loop")
+        second = reporter.report(RuntimeError("boom"), stage="inference", where="streaming_loop")
+
+        assert first is not None
+        assert second is None
+        assert len(list((tmp_path / "error_reports").glob("*.txt"))) == 1
+
+    def test_different_where_produces_two_files(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+        monkeypatch.setenv("SDTD_BASE_FOLDER_PATH", str(tmp_path))
+        reporter = diagnostics.ErrorReporter()
+
+        first = reporter.report(RuntimeError("boom"), stage="inference", where="streaming_loop")
+        second = reporter.report(RuntimeError("boom"), stage="inference", where="get_input_frame")
+
+        assert first is not None
+        assert second is not None
+        assert first != second
+        assert len(list((tmp_path / "error_reports").glob("*.txt"))) == 2
+
+    def test_different_message_same_where_not_deduped(self, tmp_path, monkeypatch):
+        """Signature is (where, exception type, truncated message) -- a differently-worded
+        exception at the same call site must still get its own report."""
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+        monkeypatch.setenv("SDTD_BASE_FOLDER_PATH", str(tmp_path))
+        reporter = diagnostics.ErrorReporter()
+
+        first = reporter.report(RuntimeError("boom"), stage="inference", where="streaming_loop")
+        second = reporter.report(RuntimeError("a different failure"), stage="inference", where="streaming_loop")
+
+        assert first is not None
+        assert second is not None
+        assert first != second
+
+    def test_max_reports_cap_honoured(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+        monkeypatch.setenv("SDTD_BASE_FOLDER_PATH", str(tmp_path))
+        reporter = diagnostics.ErrorReporter(max_reports=2)
+
+        results = [reporter.report(RuntimeError(f"boom {i}"), stage="inference", where=f"where_{i}") for i in range(5)]
+
+        assert all(r is not None for r in results[:2])
+        assert all(r is None for r in results[2:])
+        assert len(list((tmp_path / "error_reports").glob("*.txt"))) == 2
+
+    def test_returns_none_without_raising_when_write_error_report_fails(self, monkeypatch):
+        """Best-effort contract: report() must swallow a failure inside write_error_report
+        (already best-effort itself, but report() adds its own belt-and-braces try/except
+        around the whole dedup+write+log sequence) and return None rather than propagating."""
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("write failure")
+
+        monkeypatch.setattr(diagnostics, "write_error_report", _boom)
+        reporter = diagnostics.ErrorReporter()
+
+        result = reporter.report(RuntimeError("boom"), stage="inference", where="streaming_loop")
+
+        assert result is None
+
+    def test_forwards_wrapper_and_config_to_write_error_report(self, monkeypatch):
+        captured = {}
+
+        def _fake_write(exc, *, stage, wrapper=None, config=None, context=None, out_dir=None):
+            captured.update(exc=exc, stage=stage, wrapper=wrapper, config=config, context=context)
+            return Path("fake_report.txt")
+
+        monkeypatch.setattr(diagnostics, "write_error_report", _fake_write)
+        reporter = diagnostics.ErrorReporter()
+
+        fake_wrapper = object()
+        fake_config = {"width": 512}
+        result = reporter.report(
+            RuntimeError("boom"),
+            stage="inference",
+            where="streaming_loop",
+            wrapper=fake_wrapper,
+            config=fake_config,
+            context={"frame": 42},
+        )
+
+        assert result == Path("fake_report.txt")
+        assert captured["exc"] is not None
+        assert captured["stage"] == "inference"
+        assert captured["wrapper"] is fake_wrapper
+        assert captured["config"] is fake_config
+        assert captured["context"] == {"where": "streaming_loop", "frame": 42}
+
+    def test_concurrent_calls_from_several_threads_produce_no_duplicate(self, tmp_path, monkeypatch):
+        """The same (where, exc) signature fired from many threads at once must still write
+        exactly one report -- the seen-signature check-and-set happens under `self._lock` as
+        a single critical section, not as two separate unlocked steps that could race."""
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+        monkeypatch.setenv("SDTD_BASE_FOLDER_PATH", str(tmp_path))
+        reporter = diagnostics.ErrorReporter()
+        results: list = []
+        results_lock = threading.Lock()
+
+        def _worker():
+            result = reporter.report(RuntimeError("boom"), stage="inference", where="streaming_loop")
+            with results_lock:
+                results.append(result)
+
+        threads = [threading.Thread(target=_worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        successes = [r for r in results if r is not None]
+        assert len(successes) == 1
+        assert len(list((tmp_path / "error_reports").glob("*.txt"))) == 1


### PR DESCRIPTION
## Summary

- Adds `ErrorReporter` to `src/streamdiffusion/utils/diagnostics.py`: dedups repeated
  errors by `(where, exception type, truncated message)`, bounds memory via
  `max_reports`, and locks around the check-and-reserve step (not just the write) to
  avoid duplicate-report races.
- Fixes `_install_log_tail_handler` idempotency: re-checks by handler type instead of a
  one-shot flag, since `td_main.py` strips root logging handlers at startup and a
  one-shot flag would permanently block the tail handler from re-attaching.
- New unit coverage in `tests/unit/test_error_reporter.py` (8 tests): dedup, distinctness,
  cap enforcement, never-raises-on-failure, arg forwarding, and a 20-thread concurrency
  test asserting the lock prevents duplicate writes.

## Branch note

There is no in-repo consumer yet — `ErrorReporter` is only referenced by its own test
file here. The consumer is the downstream `StreamDiffusionTD` repo (PR `td-error-reporting`
imports this class and depends on this merging first).

## Test plan

```
pytest tests/unit/test_error_reporter.py -q
8 passed
```

Reviewed on fork PR forkni/StreamDiffusion#29 (claude-code-review.yml, clean).