### PR TITLE
fix(wrapper): align skip-diffusion hook range

### DIFF
--- a/src/streamdiffusion/wrapper.py
+++ b/src/streamdiffusion/wrapper.py
@@ -1228,20 +1228,21 @@ class StreamDiffusionWrapper:
         if image is None:
             raise ValueError("_process_skip_diffusion: image required for skip diffusion mode")
 
-        # Handle input tensor normalization to [-1,1] pipeline range
+        # Image preprocessing hooks ("image_pre") receive and return [-1,1] pipeline
+        # range (same contract StreamDiffusion.__call__ uses for its main txt2img/img2img
+        # path: image_processor.preprocess(..., do_normalize=True) -> hooks -> encode_image,
+        # with no conversion at either boundary). Any [0,1]<->[-1,1] round trip a processor
+        # needs internally is its own responsibility per custom_processors/sdtd_fx/README.md.
         if isinstance(image, str) or isinstance(image, Image.Image):
-            processed_tensor = self.preprocess_image(image)
-            preprocessor_input = self._denormalize_on_gpu(processed_tensor)
+            preprocessor_input = self.preprocess_image(image)
         elif isinstance(image, torch.Tensor):
-            # Ensure tensor is on correct device and dtype first
+            # Ensure tensor is on correct device and dtype first. Assumed already in
+            # [-1,1] pipeline range, matching the PIL/str branch above.
             preprocessor_input = image.to(device=self.device, dtype=self.dtype)
         else:
             preprocessor_input = image
 
-        preprocessor_output = self.stream._apply_image_preprocessing_hooks(preprocessor_input)
-
-        # Convert [0,1] -> [-1,1] back to pipeline range for postprocessing hooks
-        processed_tensor = self._normalize_on_gpu(preprocessor_output)
+        processed_tensor = self.stream._apply_image_preprocessing_hooks(preprocessor_input)
 
         # Apply image postprocessing hooks (expect [-1,1] range - post-VAE decoding)
         processed_tensor = self.stream._apply_image_postprocessing_hooks(processed_tensor)

--- a/tests/unit/test_skip_diffusion_range.py
+++ b/tests/unit/test_skip_diffusion_range.py
@@ -1,0 +1,81 @@
+"""
+Regression coverage for `_process_skip_diffusion`'s image-preprocessing-hook range.
+
+Image preprocessing hooks ("image_pre") are a documented [-1,1]-in/[-1,1]-out contract
+(custom_processors/sdtd_fx/README.md: "Receives [-1, 1] tensors. Convert to [0, 1]
+internally, convert back to [-1, 1] before returning."). StreamDiffusion.__call__'s main
+txt2img/img2img path honours this: image_processor.preprocess(..., do_normalize=True)
+yields [-1,1], which is fed straight into _apply_image_preprocessing_hooks and then
+straight into encode_image with no conversion at either boundary (pipeline.py:1504-1512).
+
+_process_skip_diffusion previously disagreed with itself: the PIL/str branch called
+_denormalize_on_gpu before the hook (handing it [0,1]) while the torch.Tensor branch
+passed its input straight through (handing it [-1,1] as-is) — so the *same logical input*
+produced different values at the hook depending on whether it arrived as a PIL.Image or a
+pre-normalized tensor. A second bug compounded it: the code then always ran
+_normalize_on_gpu on the hook's output before the postprocessing hooks, which is only
+correct if the hook received [0,1] — for the (correct) tensor-branch case this silently
+double-transformed an already-[-1,1] result.
+
+Both tests are CPU-only and model-free, using the object.__new__ shell pattern from
+test_safety_checker.py / test_wrapper_exception_hygiene.py — no diffusers model is loaded.
+"""
+
+import torch
+
+from streamdiffusion.wrapper import StreamDiffusionWrapper
+
+
+def _make_wrapper(recorded_pre_hook_input, recorded_post_hook_input):
+    w = object.__new__(StreamDiffusionWrapper)
+    w.mode = "img2img"
+    w.device = "cpu"
+    w.dtype = torch.float32
+    w.output_type = "pt"
+
+    class _StreamStub:
+        def _apply_image_preprocessing_hooks(self, x):
+            recorded_pre_hook_input.append(x.clone())
+            return x  # identity: whatever range comes in, comes back out
+
+        def _apply_image_postprocessing_hooks(self, x):
+            recorded_post_hook_input.append(x.clone())
+            return x
+
+    w.stream = _StreamStub()
+    w._apply_safety_checker = lambda t: t
+    w.postprocess_image = lambda t, output_type=None: t
+    return w
+
+
+def test_pil_and_tensor_inputs_reach_preprocessing_hook_with_same_range():
+    """A PIL-derived [-1,1] tensor and an equivalent pre-normalized tensor input
+    must hit _apply_image_preprocessing_hooks with the SAME values."""
+    known = torch.tensor([[[[-1.0, -0.5, 0.0, 0.5, 1.0]]]], dtype=torch.float32)
+
+    pre_pil, post_pil = [], []
+    w_pil = _make_wrapper(pre_pil, post_pil)
+    w_pil.preprocess_image = lambda image: known.clone()
+    w_pil._process_skip_diffusion(image="fake_path.png")
+
+    pre_tensor, post_tensor = [], []
+    w_tensor = _make_wrapper(pre_tensor, post_tensor)
+    w_tensor._process_skip_diffusion(image=known.clone())
+
+    assert torch.allclose(pre_pil[0], known)
+    assert torch.allclose(pre_tensor[0], known)
+    assert torch.allclose(pre_pil[0], pre_tensor[0])
+
+
+def test_hook_output_reaches_postprocessing_hook_unmodified():
+    """The [-1,1] hook contract means _process_skip_diffusion must NOT rescale the
+    preprocessing hook's output before handing it to the postprocessing hooks."""
+    known = torch.tensor([[[[-1.0, -0.5, 0.0, 0.5, 1.0]]]], dtype=torch.float32)
+
+    pre, post = [], []
+    w = _make_wrapper(pre, post)
+    w._process_skip_diffusion(image=known.clone())
+
+    # Hook is identity, so whatever it received is what it returned. If a stray
+    # normalize/denormalize crept back in, this would no longer match `known`.
+    assert torch.allclose(post[0], known)


### PR DESCRIPTION
## Summary

`_process_skip_diffusion` disagreed with itself about what range reaches
`_apply_image_preprocessing_hooks`: the PIL/str branch called `_denormalize_on_gpu` first
(handing the hook `[0,1]`), the `torch.Tensor` branch passed its input straight through
(`[-1,1]`). The main `txt2img`/`img2img` path confirms `[-1,1]` is correct:
`pipeline.py:1504-1512` runs `image_processor.preprocess(..., do_normalize=True)` (which
yields `[-1,1]`) straight into the preprocessing hook, then straight into `encode_image`,
with no conversion at either boundary — so the PIL branch here was the outlier.

A second bug compounded it: the code always ran `_normalize_on_gpu` on the hook's output
before the postprocessing hooks. That's only correct if the hook received `[0,1]`; for the
(correct) tensor-branch case it silently double-transformed an already-`[-1,1]` result.

## Fix

- PIL/str branch: drop the `_denormalize_on_gpu` call, passing the already-`[-1,1]` tensor
  from `preprocess_image` straight through — matching the tensor branch and the mainline
  path.
- Drop the post-hook `_normalize_on_gpu` call — the hook already returns `[-1,1]`.
- New `tests/unit/test_skip_diffusion_range.py`: asserts a PIL-derived tensor and an
  equivalent pre-normalized tensor input reach the preprocessing hook with identical
  values, and that the hook's output reaches the postprocessing hook unmodified. Both
  tests fail against the unpatched code.

## Test plan

```
pytest tests/unit/test_skip_diffusion_range.py -q
2 passed
```

Reviewed on fork PR forkni/StreamDiffusion#30 (claude-code-review.yml, clean — reviewer
independently traced the same `pipeline.py` mainline path cited above).