### PR TITLE
fix: NaN guards for model_pred, CN residuals and image-filter skip prob (black-frame latch recovery)

### DIFF
--- a/src/streamdiffusion/image_filter.py
+++ b/src/streamdiffusion/image_filter.py
@@ -4,6 +4,8 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 
+from streamdiffusion.utils.nan_guard import NanGuard
+
 
 class SimilarImageFilter:
     """Stochastic frame-skip filter (StreamDiffusion §3.3).
@@ -25,6 +27,10 @@ class SimilarImageFilter:
         self._skip_prob_pin: Optional[torch.Tensor] = None  # pinned CPU scalar (lazy init)
         self._skip_evt: Optional[torch.cuda.Event] = None  # marks when the copy_ below has landed
         self._last_skip_prob: float = 0.0  # fallback while that copy is still in flight
+        # NaN guard 8: clamp() below does not filter NaN (NaN < x is always False), so a
+        # NaN mse used to survive into skip_prob and latch the always-skip branch forever
+        # (comment here previously claimed "never garbage" -- see nan_guard.py docstring).
+        self._nan_guard_skip_prob = NanGuard("image_filter.skip_prob")
 
     def __call__(self, x: torch.Tensor) -> Optional[torch.Tensor]:
         # First frame: allocate buffers, always pass through
@@ -44,9 +50,10 @@ class SimilarImageFilter:
         # completion is checked explicitly instead, via _skip_evt (recorded on the
         # producing stream right after the copy_() below) -- .query() is non-blocking, so
         # this adds no host stall. If the copy hasn't landed yet, fall back to the last
-        # value that did; _skip_prob_pin is zero-initialised above and only ever
-        # overwritten with a value clamped to [0, 1] (Step 2 below), so a fallback read is
-        # always a valid, merely stale, probability -- never garbage.
+        # value that did; _skip_prob_pin is zero-initialised above and only ever overwritten
+        # with a value clamped to [0, 1] AND NaN-sanitized (Step 2's NaN guard 8 below) --
+        # clamp() alone does not filter NaN, so a fallback read is always a valid, merely
+        # stale, probability -- never garbage.
         if self._skip_evt is not None and self._skip_evt.query():
             self._last_skip_prob = self._skip_prob_pin.item()
         skip_prob = self._last_skip_prob
@@ -58,6 +65,11 @@ class SimilarImageFilter:
             gpu_skip = torch.zeros(1, device=x.device, dtype=torch.float32)
         else:
             gpu_skip = torch.clamp(1.0 - mse / self._mse_threshold, min=0.0, max=1.0)
+        # NaN guard 8: sanitize in place before the async copy below -- NaN -> 0.0 means
+        # "never skip" (self-healing: keeps processing frames) rather than latching into
+        # the always-skip branch (Step 3's `skip_prob < random.random()` is always False
+        # for NaN). Unconditional, branch-free, no extra sync (mirrors nan_guard.py).
+        self._nan_guard_skip_prob.sanitize_(gpu_skip)
         # Async copy result to pinned CPU buffer for NEXT frame to read
         self._skip_prob_pin.copy_(gpu_skip.view(1), non_blocking=True)
         self._skip_evt.record()  # marks when the copy above has actually landed

--- a/src/streamdiffusion/modules/controlnet_module.py
+++ b/src/streamdiffusion/modules/controlnet_module.py
@@ -14,6 +14,7 @@ from streamdiffusion.preprocessing.preprocessing_orchestrator import (
     PreprocessingOrchestrator,
 )
 from streamdiffusion.tools.gpu_profiler import profiler
+from streamdiffusion.utils.nan_guard import NanGuard
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +97,11 @@ class ControlNetModule(OrchestratorUser):
         self._cn_ema_down: Optional[List[torch.Tensor]] = None
         self._cn_ema_mid: Optional[torch.Tensor] = None
         self._cn_ema_shape_key: Optional[tuple] = None
+        # NaN guard 5 (see utils/nan_guard.py): decay < 1.0 makes lerp_ a PERMANENT latch
+        # for a poisoned target -- applied.lerp_(nan_target, decay) is NaN forever after,
+        # never flushed by subsequent good frames. Sanitize the incoming target in place
+        # before it reaches the EMA buffers or the cache. One guard per residual group.
+        self._nan_guard_cn_residuals = NanGuard("controlnet.residuals")
 
         # Persistent multi-ControlNet residual merge buffers (Phase-2 prep). The naive
         # `merged_down[j] = merged_down[j] + ds[j]` allocates a fresh tensor every frame,
@@ -709,6 +715,13 @@ class ControlNetModule(OrchestratorUser):
                     down_block_additional_residuals=self._cn_merged_down,
                     mid_block_additional_residual=self._cn_merged_mid,
                 )
+
+            # NaN guard 5: sanitize the freshly computed residuals in place before they can
+            # reach the persistent cache (below) or the EMA buffers (_apply_residual_decay).
+            # Single choke point for both the single-CN and merged-CN paths above.
+            for _t in _result.down_block_additional_residuals:
+                self._nan_guard_cn_residuals.sanitize_(_t)
+            self._nan_guard_cn_residuals.sanitize_(_result.mid_block_additional_residual)
 
             # Residual cache write: store result for reuse on upcoming intermediate
             # frames. With decay > 0 the EMA needs a target even at interval == 1.

--- a/src/streamdiffusion/pipeline.py
+++ b/src/streamdiffusion/pipeline.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import time
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
@@ -34,6 +35,7 @@ from streamdiffusion.param_schema import (
 )
 from streamdiffusion.stream_parameter_updater import StreamParameterUpdater
 from streamdiffusion.tools.gpu_profiler import profiler
+from streamdiffusion.utils.nan_guard import NanGuard
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -174,6 +176,20 @@ class StreamDiffusion:
         self._sync_counter = 0  # counts __call__ invocations for timing-sync cadence (P2)
         self.similar_filter_sleep_fraction = 0.025
         self.last_frame_was_skipped = False  # True when similar filter skipped inference this frame
+
+        # NaN/Inf guards on the hot path — see utils/nan_guard.py docstring. One
+        # instance per guarded buffer so each keeps its own warn-once state and
+        # names itself in the WARNING. Sanitizing is unconditional every call
+        # (branch-free); only the recovery ACTION below (stock_noise reseed) is
+        # gated on a 1-frame-delayed, non-blocking verdict.
+        self._nan_guard_model_pred = NanGuard("unet_step.model_pred")
+        self._nan_guard_image_input = NanGuard("__call__.image_input")
+        self._nan_guard_prev_image = NanGuard("_prev_image_buf")
+        self._nan_guard_latent_cache = NanGuard("_latent_cache")
+        # Guard 7 (_fi_warp_attenuation) already forces a host sync via float() every call,
+        # so it checks isfinite() inline rather than through NanGuard -- but still needs its
+        # own warn-once flag to avoid flooding if fx_frame_transform stays NaN.
+        self._warned_fi_warp_attenuation: bool = False
 
         # Initialize SDXL-specific attributes
         if self.is_sdxl:
@@ -444,6 +460,22 @@ class StreamDiffusion:
 
     def disable_similar_image_filter(self) -> None:
         self.similar_image_filter = False
+
+    def _nan_guard(self, attr: str, name: str) -> NanGuard:
+        """Lazily fetch/create a NanGuard stored at `attr`.
+
+        __init__ already sets the standard guards up front (self-documenting,
+        the normal path), but some tests construct StreamDiffusion via
+        object.__new__ to drive predict_x0_batch/unet_step directly without a
+        real model (test_rcfg_self_single_step_reseed.py, test_derived_tensor_sync.py),
+        bypassing __init__ entirely. Falling back to lazy creation here keeps
+        the guards resilient to that construction path too.
+        """
+        guard = getattr(self, attr, None)
+        if guard is None:
+            guard = NanGuard(name)
+            setattr(self, attr, guard)
+        return guard
 
     @torch.inference_mode()
     def prepare(
@@ -1070,7 +1102,25 @@ class StreamDiffusion:
         linear_dev = (theta[:, :, :2] - identity).flatten(1).norm(dim=1)
         translation_dev = theta[:, :, 2].norm(dim=1)
         warp_mag = (linear_dev + translation_dev).max()
-        return float(torch.exp(-self._FI_WARP_ATTENUATION_K * warp_mag).clamp(0.0, 1.0))
+        attenuation = float(torch.exp(-self._FI_WARP_ATTENUATION_K * warp_mag).clamp(0.0, 1.0))
+        # NaN guard 7: this already forces a host read via float() above (no extra sync
+        # cost), so check inline rather than through NanGuard. A non-finite fx_frame_transform
+        # (e.g. a NaN FX zoom/rotation) would otherwise become a NaN FI strength at the call
+        # site below and NaN the entire UNet -- fall back to no attenuation instead.
+        if not math.isfinite(attenuation):
+            # getattr fallback: tests construct StreamDiffusion via object.__new__,
+            # bypassing __init__ (see pipeline._nan_guard docstring for the same concern).
+            if not getattr(self, "_warned_fi_warp_attenuation", False):
+                logger.warning(
+                    "pipeline._fi_warp_attenuation: non-finite result (fx_frame_transform has "
+                    "NaN/Inf) -- falling back to 1.0 (no attenuation); further occurrences "
+                    "logged at DEBUG"
+                )
+                self._warned_fi_warp_attenuation = True
+            else:
+                logger.debug("pipeline._fi_warp_attenuation: non-finite result -- falling back to 1.0")
+            return 1.0
+        return attenuation
 
     def unet_step(
         self,
@@ -1175,6 +1225,9 @@ class StreamDiffusion:
 
         # Extract potential ControlNet residual kwargs / extra kwargs (e.g., ipadapter_scale), then call UNet
         with profiler.region("unet_step.engine"):
+            # Guard 1's verdict is read unconditionally in unet_step.post (:1375), so it must be
+            # bound on EVERY branch below -- the two SDXL branches previously left it unbound.
+            nan_guard_bad_last_frame = False
             hook_down_res = unet_kwargs.get("down_block_additional_residuals", None)
             hook_mid_res = unet_kwargs.get("mid_block_additional_residual", None)
             hook_extra_kwargs = (
@@ -1217,7 +1270,14 @@ class StreamDiffusion:
                         model_pred = _unet_result[0]
                         kvo_cache_out = _unet_result[1] if len(_unet_result) > 1 else []
                         fio_cache_out = _unet_result[2] if len(_unet_result) > 2 else []
-                        self.update_kvo_cache(kvo_cache_out, fio_cache_out)
+                        # NaN guard 1: mirrors the SD1.5/2.1 branch below -- sanitize model_pred
+                        # unconditionally, and skip this frame's K/V-O/FI cache write on a
+                        # poisoned frame so garbage doesn't enter the long-lived attention cache.
+                        nan_guard_bad_last_frame = self._nan_guard(
+                            "_nan_guard_model_pred", "unet_step.model_pred"
+                        ).sanitize_(model_pred)
+                        if not nan_guard_bad_last_frame:
+                            self.update_kvo_cache(kvo_cache_out, fio_cache_out)
                     else:
                         # PyTorch UNet expects diffusers-style named arguments. Any processor scaling is handled by IP-Adapter hook
 
@@ -1235,6 +1295,11 @@ class StreamDiffusion:
                             call_kwargs["mid_block_additional_residual"] = hook_mid_res
                         model_pred = self.unet(**call_kwargs)[0]
                         # No restoration for per-layer scale; next step will set again via updater/time factor
+
+                        # NaN guard 1: this branch never calls update_kvo_cache, so sanitize only.
+                        nan_guard_bad_last_frame = self._nan_guard(
+                            "_nan_guard_model_pred", "unet_step.model_pred"
+                        ).sanitize_(model_pred)
 
                 except Exception as e:
                     logger.error(f"[PIPELINE] unet_step: *** ERROR: SDXL UNet call failed: {e} ***")
@@ -1281,7 +1346,19 @@ class StreamDiffusion:
                 model_pred = _unet_result[0]
                 kvo_cache_out = _unet_result[1] if len(_unet_result) > 1 else []
                 fio_cache_out = _unet_result[2] if len(_unet_result) > 2 else []
-                self.update_kvo_cache(kvo_cache_out, fio_cache_out)
+
+                # NaN guard 1 (highest value): sanitizes model_pred unconditionally so a
+                # poisoned UNet output can't propagate into the CFG combine, the scheduler
+                # step, or the self/initialize stock_noise recurrence below. The returned
+                # verdict is the PREVIOUS call's (1-frame-delayed on CUDA, see nan_guard.py)
+                # -- used here to also skip this frame's K/V-O/FI cache writes (don't let a
+                # garbage-recovery frame poison the long-lived attention cache) and, below,
+                # to reseed stock_noise from the clean init_noise.
+                nan_guard_bad_last_frame = self._nan_guard("_nan_guard_model_pred", "unet_step.model_pred").sanitize_(
+                    model_pred
+                )
+                if not nan_guard_bad_last_frame:
+                    self.update_kvo_cache(kvo_cache_out, fio_cache_out)
 
         with profiler.region("unet_step.post"):
             if self.guidance_scale > 1.0 and (self.cfg_type == "initialize"):
@@ -1309,6 +1386,13 @@ class StreamDiffusion:
             # treats as a throwaway (_alpha_next/_beta_next degenerate to 1.0), and
             # predict_x0_batch reseeds stock_noise from init_noise every frame anyway.
             if (self.cfg_type == "self" or self.cfg_type == "initialize") and self.denoising_steps_num > 1:
+                if nan_guard_bad_last_frame:
+                    # NaN guard 1 recovery: the previous frame poisoned model_pred, which
+                    # (pre-guard) would have poisoned self.stock_noise via this same
+                    # recurrence -- reseed from the clean init_noise before continuing it,
+                    # reusing predict_x0_batch's n==1 recovery (pipeline.py's per-frame
+                    # reseed comment above `self.stock_noise.copy_(self.init_noise)`).
+                    self.stock_noise.copy_(self.init_noise)
                 scaled_noise = self.beta_prod_t_sqrt * self.stock_noise
                 delta_x = self.scheduler_step_batch(model_pred, scaled_noise, idx)
                 delta_x = self._alpha_next * delta_x
@@ -1511,6 +1595,13 @@ class StreamDiffusion:
             # IMAGE PREPROCESSING HOOKS: After built-in preprocessing, before filtering
             x = self._apply_image_preprocessing_hooks(x)
 
+            # NaN guard 2: single choke point for all image input, including anything an
+            # image-preprocessing hook (FX chain) may have injected. Sanitizes in place,
+            # unconditionally -- see utils/nan_guard.py. No recovery action needed here
+            # (unlike guard 1's stock_noise reseed): cutting off propagation into
+            # encode_image is the whole job.
+            self._nan_guard("_nan_guard_image_input", "__call__.image_input").sanitize_(x)
+
             if self.similar_image_filter:
                 x = self.similar_filter(x)
                 if x is None:
@@ -1558,6 +1649,12 @@ class StreamDiffusion:
         # LATENT POSTPROCESSING HOOKS: After diffusion, before VAE decoding
         x_0_pred_out = self._apply_latent_postprocessing_hooks(x_0_pred_out)
 
+        # NaN guard 4: sanitizes in place before both consumers below -- the persistent
+        # _latent_cache (read by latent-feedback processors on the NEXT frame) and
+        # decode_image just below it. Covers anything a latent-postprocessing hook (e.g.
+        # latent_feedback.py) may have injected, in addition to guard 1's UNet coverage.
+        self._nan_guard("_nan_guard_latent_cache", "_latent_cache").sanitize_(x_0_pred_out)
+
         # Store latent result for latent feedback processors (reuse pre-allocated buffer)
         if self._latent_cache is None:
             self._latent_cache = torch.empty_like(x_0_pred_out)
@@ -1572,6 +1669,12 @@ class StreamDiffusion:
 
         # IMAGE POSTPROCESSING HOOKS: After VAE decoding, before final output
         x_output = self._apply_image_postprocessing_hooks(x_output)
+
+        # NaN guard 3: sanitizes in place before the persistent _prev_image_buf (read by
+        # image-feedback processors, e.g. feedback_loop.py, on the NEXT frame) and before
+        # this frame's returned output -- covers anything an image-postprocessing hook may
+        # have injected, in addition to guards 1/2/4's upstream coverage.
+        self._nan_guard("_nan_guard_prev_image", "_prev_image_buf").sanitize_(x_output)
 
         # Copy into pre-allocated skip-frame cache — TRT VAE buffer is reused on next decode call
         if self._prev_image_buf is None:
@@ -1673,6 +1776,9 @@ class StreamDiffusion:
         # LATENT POSTPROCESSING HOOKS: After diffusion, before VAE decoding
         x_0_pred_out = self._apply_latent_postprocessing_hooks(x_0_pred_out)
 
+        # NaN guard 4 (see __call__ for full rationale): same persistent _latent_cache.
+        self._nan_guard("_nan_guard_latent_cache", "_latent_cache").sanitize_(x_0_pred_out)
+
         # Store latent result for latent feedback processors (reuse pre-allocated buffer)
         if self._latent_cache is None:
             self._latent_cache = torch.empty_like(x_0_pred_out)
@@ -1687,6 +1793,9 @@ class StreamDiffusion:
 
         # IMAGE POSTPROCESSING HOOKS: After VAE decoding, before final output
         x_output = self._apply_image_postprocessing_hooks(x_output)
+
+        # NaN guard 3 (see __call__ for full rationale): sanitize final output in place.
+        self._nan_guard("_nan_guard_prev_image", "_prev_image_buf").sanitize_(x_output)
 
         # NOTE: x_output aliases self._image_decode_buf, a persistent buffer reused every
         # call to avoid a per-frame .clone() (see buffer init above). Intentional: callers
@@ -1739,12 +1848,19 @@ class StreamDiffusion:
                 return_dict=False,
             )[0]
 
+        # NaN guard (mirrors guard 1 -- this path doesn't go through unet_step, so
+        # model_pred isn't covered there): sanitize before it feeds the x_0 formula below.
+        self._nan_guard("_nan_guard_model_pred", "unet_step.model_pred").sanitize_(model_pred)
+
         x_0_pred_out = ((x_t_latent - self.beta_prod_t_sqrt * model_pred).float() / self.alpha_prod_t_sqrt.float()).to(
             x_t_latent.dtype
         )
 
         # LATENT POSTPROCESSING HOOKS: After diffusion, before VAE decoding
         x_0_pred_out = self._apply_latent_postprocessing_hooks(x_0_pred_out)
+
+        # NaN guard 4 (see __call__ for full rationale): same persistent _latent_cache.
+        self._nan_guard("_nan_guard_latent_cache", "_latent_cache").sanitize_(x_0_pred_out)
 
         # Store latent result for latent feedback processors (reuse pre-allocated buffer)
         if self._latent_cache is None:
@@ -1756,5 +1872,8 @@ class StreamDiffusion:
 
         # IMAGE POSTPROCESSING HOOKS: After VAE decoding, before final output
         x_output = self._apply_image_postprocessing_hooks(x_output)
+
+        # NaN guard 3 (see __call__ for full rationale): sanitize final output in place.
+        self._nan_guard("_nan_guard_prev_image", "_prev_image_buf").sanitize_(x_output)
 
         return x_output

--- a/src/streamdiffusion/utils/__init__.py
+++ b/src/streamdiffusion/utils/__init__.py
@@ -1,7 +1,9 @@
 from .diagnostics import collect_diagnostics, format_report_text, write_error_report
+from .nan_guard import NanGuard
 from .reporting import report_error
 
 __all__ = [
+    "NanGuard",
     "collect_diagnostics",
     "format_report_text",
     "report_error",

--- a/src/streamdiffusion/utils/nan_guard.py
+++ b/src/streamdiffusion/utils/nan_guard.py
@@ -1,0 +1,101 @@
+"""NaN/Inf detection and sanitization for hot-path GPU buffers.
+
+Context: nothing on the streaming hot path ever checked for non-finite values.
+A single degenerate input (e.g. all prompt weights summing to zero -- see
+_normalize_weights in stream_parameter_updater.py) could turn a tensor NaN,
+and several cross-frame recurrences (stock_noise, x_t_latent_buffer, the
+ControlNet residual EMA, the FX feedback canvas) then latch that NaN forever:
+torch.clamp does not filter NaN, and every comparison against NaN is False, so
+existing ".clamp(...)" callers that read as "safety" did not actually guard
+anything. The stream kept running with no exception (the only try/except on
+this path catches OOM and shape-mismatch RuntimeErrors) and rendered solid
+black until a full re-prepare.
+
+Mechanism (mirrors SimilarImageFilter in image_filter.py -- see its docstring
+for the full rationale): a per-frame host-side branch/sync on freshly computed
+GPU state is a documented anti-pattern in this codebase (see
+docs/PMPP_deep_dive_verification_2026-07-29.md and
+docs/perf_bestpractices_audit_2026-07-10.md). So:
+
+  1. Sanitize unconditionally -- one `torch.nan_to_num_` elementwise kernel,
+     every call, no branch, no readback needed for this part.
+  2. Detect on-device (`~isfinite(...).any()`), async-copy the verdict into a
+     pinned CPU scalar, and mark completion with a `torch.cuda.Event`.
+  3. The NEXT call reads that scalar via a non-blocking `.query()` -- so the
+     "was last frame bad" signal used to gate any recovery action (e.g.
+     resetting stock_noise from init_noise) is always one frame stale, never
+     a host stall.
+  4. Log first occurrence at WARNING (loud -- this is exactly the silent
+     failure mode that made the bug hard to find), subsequent occurrences at
+     DEBUG, mirroring wrapper.py's `_cn_ipc_export_warned` idiom.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class NanGuard:
+    """One instance per guarded buffer/site -- state (pinned scalar, event,
+    warn-once flag) is not shared across sites, and the constructor's `name`
+    is what shows up in the WARNING so the specific poisoned buffer is named.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._bad_pin: Optional[torch.Tensor] = None  # pinned CPU scalar (lazy init)
+        self._evt: Optional[torch.cuda.Event] = None
+        self._last_bad: bool = False
+        self._warned: bool = False
+
+    def sanitize_(self, tensor: torch.Tensor) -> bool:
+        """Sanitize `tensor` in place (NaN/+-Inf -> 0.0), unconditionally.
+
+        Returns whether the PREVIOUS call's tensor was non-finite (1-frame
+        delayed on CUDA tensors, exactly like SimilarImageFilter.skip_prob) --
+        callers use this to gate a cross-frame recovery action without ever
+        forcing a fresh sync to know THIS frame's verdict early.
+        """
+        if not tensor.is_cuda:
+            # CPU tensors (unit tests, CPU-only fallback configs): no async
+            # plumbing needed or possible (no CUDA events) -- check inline.
+            bad = bool((~torch.isfinite(tensor)).any())
+            tensor.nan_to_num_(nan=0.0, posinf=0.0, neginf=0.0)
+            if bad:
+                self._warn()
+            self._last_bad = bad
+            return self._last_bad
+
+        bad_pin = self._bad_pin
+        evt = self._evt
+        if bad_pin is None or evt is None:
+            bad_pin = torch.zeros(1, dtype=torch.float32, device="cpu").pin_memory()
+            evt = torch.cuda.Event()
+            self._bad_pin, self._evt = bad_pin, evt
+        elif evt.query():
+            self._last_bad = bool(bad_pin.item())
+            if self._last_bad:
+                self._warn()
+
+        bad_this_frame = (~torch.isfinite(tensor)).any()
+        tensor.nan_to_num_(nan=0.0, posinf=0.0, neginf=0.0)
+        bad_pin.copy_(bad_this_frame.view(1).float(), non_blocking=True)
+        evt.record()
+
+        return self._last_bad
+
+    def _warn(self) -> None:
+        if not self._warned:
+            logger.warning(
+                "NanGuard(%s): non-finite values detected and sanitized (NaN/Inf -> 0.0); "
+                "further occurrences on this buffer are logged at DEBUG",
+                self.name,
+            )
+            self._warned = True
+        else:
+            logger.debug("NanGuard(%s): non-finite values detected and sanitized", self.name)

--- a/tests/unit/test_nan_guard.py
+++ b/tests/unit/test_nan_guard.py
@@ -1,0 +1,103 @@
+"""Unit tests for streamdiffusion.utils.nan_guard.NanGuard.
+
+CPU-only: NanGuard's CPU branch checks-and-sanitizes inline (no CUDA event
+plumbing needed or possible), so these tests exercise the sanitize semantics
+and warn-once logging directly and deterministically. A separate CUDA-path
+smoke test below (skipped if no GPU) exercises the pinned-scalar +
+Event.query() deferred-readback branch.
+"""
+
+import logging
+
+import pytest
+import torch
+
+from streamdiffusion.utils.nan_guard import NanGuard
+
+
+class TestNanGuardCPU:
+    def test_clean_tensor_untouched_and_reports_not_bad(self):
+        guard = NanGuard("test.clean")
+        t = torch.tensor([1.0, -2.0, 3.5])
+        was_bad = guard.sanitize_(t)
+        assert not was_bad
+        assert torch.equal(t, torch.tensor([1.0, -2.0, 3.5]))
+
+    def test_nan_replaced_with_zero_in_place(self):
+        guard = NanGuard("test.nan")
+        t = torch.tensor([1.0, float("nan"), 3.0])
+        data_ptr_before = t.data_ptr()
+        was_bad = guard.sanitize_(t)
+        assert was_bad
+        assert t.data_ptr() == data_ptr_before, "sanitize_ must mutate in place, not reallocate"
+        assert torch.equal(t, torch.tensor([1.0, 0.0, 3.0]))
+
+    def test_inf_and_neg_inf_replaced_with_zero(self):
+        guard = NanGuard("test.inf")
+        t = torch.tensor([float("inf"), float("-inf"), 2.0])
+        was_bad = guard.sanitize_(t)
+        assert was_bad
+        assert torch.equal(t, torch.tensor([0.0, 0.0, 2.0]))
+        assert torch.isfinite(t).all()
+
+    def test_all_zero_division_nan_is_caught(self):
+        """Directly mirrors the reported bug's failure mode: 0/0 -> NaN."""
+        guard = NanGuard("test.zero_div")
+        w = torch.tensor([0.0, 0.0])
+        poisoned = w / w.sum()
+        assert not torch.isfinite(poisoned).all()
+        was_bad = guard.sanitize_(poisoned)
+        assert was_bad
+        assert torch.isfinite(poisoned).all()
+
+    def test_warns_once_then_debug(self, caplog):
+        guard = NanGuard("test.warn_once")
+        with caplog.at_level(logging.DEBUG, logger="streamdiffusion.utils.nan_guard"):
+            guard.sanitize_(torch.tensor([float("nan")]))
+            guard.sanitize_(torch.tensor([float("nan")]))
+            guard.sanitize_(torch.tensor([float("nan")]))
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        debugs = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert len(warnings) == 1, "exactly one WARNING across repeated bad frames"
+        assert len(debugs) == 2, "subsequent bad frames log at DEBUG, not WARNING"
+        assert "test.warn_once" in warnings[0].message, "warning must name the guarded buffer"
+
+    def test_no_log_when_never_bad(self, caplog):
+        guard = NanGuard("test.silent")
+        with caplog.at_level(logging.DEBUG, logger="streamdiffusion.utils.nan_guard"):
+            for _ in range(5):
+                guard.sanitize_(torch.tensor([1.0, 2.0]))
+        assert not caplog.records
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA for the deferred-readback path")
+class TestNanGuardCUDA:
+    def test_deferred_detection_across_frames(self):
+        """The bad verdict for a CUDA tensor lags by one call, exactly like
+        SimilarImageFilter.skip_prob -- verify it eventually reflects a bad
+        frame without ever requiring a blocking sync from the caller."""
+        guard = NanGuard("test.cuda")
+        clean = torch.tensor([1.0, 2.0], device="cuda")
+        poisoned = torch.tensor([float("nan"), 1.0], device="cuda")
+
+        # First call: always sanitizes; nothing to report yet (no prior frame).
+        first_bad = guard.sanitize_(clean.clone())
+        assert not first_bad
+
+        # Second call is poisoned; sanitized immediately regardless of the
+        # returned (still-previous-frame) verdict.
+        t = poisoned.clone()
+        guard.sanitize_(t)
+        torch.cuda.synchronize()  # test-only: force the async copy to land before we poll it
+        assert torch.isfinite(t).all()
+
+        # Poll subsequent clean calls until the event has landed and the bad
+        # verdict surfaces -- bounded loop, no fixed sleep.
+        saw_bad = False
+        for _ in range(50):
+            bad = guard.sanitize_(clean.clone())
+            if bad:
+                saw_bad = True
+                break
+        assert saw_bad, "the poisoned frame's verdict never surfaced on a later call"

--- a/tests/unit/test_nan_guard_latch_recovery.py
+++ b/tests/unit/test_nan_guard_latch_recovery.py
@@ -1,0 +1,341 @@
+"""Regression test for the permanent-black-output latch this whole guard pass
+exists to fix: with cfg_type="self"/"initialize" and denoising_steps_num > 1
+(the user's live regime: t_index_list=[22, 36] -> n=2), a single NaN UNet
+output used to poison self.stock_noise via the recurrence in unet_step
+
+    scaled_noise = self.beta_prod_t_sqrt * self.stock_noise
+    delta_x = self.scheduler_step_batch(model_pred, scaled_noise, idx)
+    ...
+    self.stock_noise = self._init_noise_rotated + delta_x
+
+forever -- there was no isfinite/nan_to_num anywhere on this path, so once
+stock_noise went NaN it stayed NaN every subsequent frame, with no exception
+(the only try/except on this path catches OOM/shape RuntimeErrors) and no way
+to recover short of a full re-prepare.
+
+This test injects exactly one NaN model_pred mid-stream via a fake UNet and
+asserts the NaN guard (pipeline.py `unet_step`, `self._nan_guard_model_pred`)
+sanitizes it immediately and stock_noise recovers within one extra frame,
+instead of staying poisoned forever.
+
+CPU-only, model-free -- same object.__new__ / fake-UNet idiom as
+test_rcfg_self_single_step_reseed.py and test_derived_tensor_sync.py.
+"""
+
+import pytest
+import torch
+from diffusers import LCMScheduler
+
+from streamdiffusion.pipeline import StreamDiffusion
+
+# ---------------------------------------------------------------------------
+# helpers (deliberately duplicated from test_rcfg_self_single_step_reseed.py
+# rather than imported -- each test file is a self-contained fixture per this
+# suite's existing convention)
+# ---------------------------------------------------------------------------
+
+
+class _NanInjectingUnet:
+    """Deterministic stand-in for the UNet that returns NaN on one chosen call."""
+
+    def __init__(self, nan_on_call: int):
+        self.nan_on_call = nan_on_call
+        self.calls = 0
+
+    def __call__(self, sample, timestep, encoder_hidden_states=None, kvo_cache=None, return_dict=False, **kwargs):
+        self.calls += 1
+        if self.calls == self.nan_on_call:
+            return (torch.full_like(sample, float("nan")),)
+        return (0.05 * sample,)
+
+
+def _make_stream(t_index_list, unet, cfg_type="self", guidance_scale=1.0, dtype=torch.float32, latent_hw=8, seed=1234):
+    stream = object.__new__(StreamDiffusion)
+    n = len(t_index_list)
+    frame_bff_size = 1
+    batch_size = n * frame_bff_size
+    h = w = latent_hw
+
+    stream.device = "cpu"
+    stream.dtype = dtype
+    stream.latent_height = h
+    stream.latent_width = w
+    stream.frame_bff_size = frame_bff_size
+    stream.denoising_steps_num = n
+    stream.batch_size = batch_size
+    stream.cfg_type = cfg_type
+    stream.use_denoising_batch = True
+    stream.trt_unet_batch_size = n * frame_bff_size
+    stream.guidance_scale = guidance_scale
+    stream.delta = 1.0
+    stream.do_add_noise = True
+    stream.generator = torch.Generator(device="cpu").manual_seed(seed)
+
+    stream.is_sdxl = False
+    stream.unet_hooks = []
+    stream.kvo_cache = []
+    stream.fio_cache = []
+    stream.use_feature_injection = False
+    stream._fi_strength_tensor = None
+    stream._fi_threshold_tensor = None
+    stream._is_unet_tensorrt = None
+    stream._unet_kwargs = {"return_dict": False}
+    stream._sdxl_conditioning_cache = {}
+    stream._cached_batch_size = None
+    stream._cached_cfg_type = None
+    stream._cached_guidance_scale = None
+    stream.unet = unet
+    stream.prompt_embeds = torch.zeros(batch_size, 77, 8, dtype=dtype)
+
+    sched = object.__new__(LCMScheduler)
+    betas = torch.linspace(0.0001, 0.02, 1000)
+    alphas_cumprod = torch.cumprod(1.0 - betas, dim=0)
+    sched.alphas_cumprod = alphas_cumprod
+    stream.scheduler = sched
+
+    timesteps_raw = torch.linspace(999, 19, 50).long()
+    sub_timesteps = [int(timesteps_raw[i]) for i in t_index_list]
+    stream.sub_timesteps_tensor = torch.tensor(sub_timesteps, dtype=torch.long)
+
+    stream.alpha_prod_t_sqrt = (
+        torch.stack([alphas_cumprod[t].sqrt() for t in sub_timesteps]).view(n, 1, 1, 1).to(dtype)
+    )
+    stream.beta_prod_t_sqrt = (
+        torch.stack([(1 - alphas_cumprod[t]).sqrt() for t in sub_timesteps]).view(n, 1, 1, 1).to(dtype)
+    )
+
+    c_skip_l, c_out_l = [], []
+    for t in sub_timesteps:
+        st = 10.0 * t
+        c_skip_l.append(0.25 / (st**2 + 0.25))
+        c_out_l.append(st / (st**2 + 0.25) ** 0.5)
+    stream.c_skip = torch.tensor(c_skip_l, dtype=dtype).view(n, 1, 1, 1)
+    stream.c_out = torch.tensor(c_out_l, dtype=dtype).view(n, 1, 1, 1)
+
+    stream.init_noise = torch.randn((batch_size, 4, h, w), dtype=dtype, generator=stream.generator)
+    stream.stock_noise = stream.init_noise.clone()
+    stream._stock_noise_bufs = [stream.stock_noise.clone(), torch.empty_like(stream.stock_noise)]
+    stream._stock_noise_pong = 0
+
+    stream._alpha_next = torch.cat(
+        [stream.alpha_prod_t_sqrt[1:], torch.ones_like(stream.alpha_prod_t_sqrt[0:1])], dim=0
+    )
+    stream._beta_next = torch.cat([stream.beta_prod_t_sqrt[1:], torch.ones_like(stream.beta_prod_t_sqrt[0:1])], dim=0)
+    stream._init_noise_rotated = torch.cat([stream.init_noise[1:], stream.init_noise[0:1]], dim=0)
+
+    stream.x_t_latent_buffer = None if n == 1 else torch.zeros((n - 1) * frame_bff_size, 4, h, w, dtype=dtype)
+    stream._combined_latent_buf = None if n == 1 else torch.empty(batch_size, 4, h, w, dtype=dtype)
+    stream._cfg_latent_buf = None
+    stream._cfg_t_buf = None
+
+    return stream
+
+
+def _zero_input(stream):
+    return torch.zeros(stream.frame_bff_size, 4, stream.latent_height, stream.latent_width, dtype=stream.dtype)
+
+
+class TestNanGuardBreaksPermanentLatch:
+    """Live regime from td_config.yaml: t_index_list=[22, 36] (n=2), cfg_type='self',
+    guidance_scale=1.0 -- exactly the configuration in which the reported bug
+    (Normpweights off + both prompts at 0 -> permanently black) went unrecoverable."""
+
+    def test_single_nan_frame_self_heals(self):
+        unet = _NanInjectingUnet(nan_on_call=3)
+        stream = _make_stream([22, 36], unet, cfg_type="self", guidance_scale=1.0)
+        x_in = _zero_input(stream)
+
+        results = []
+        for _ in range(8):
+            x0 = StreamDiffusion.predict_x0_batch(stream, x_in)
+            results.append(
+                {
+                    "x0_finite": torch.isfinite(x0).all().item(),
+                    "stock_noise_finite": torch.isfinite(stream.stock_noise).all().item(),
+                    "x_t_latent_buffer_finite": (
+                        stream.x_t_latent_buffer is None or torch.isfinite(stream.x_t_latent_buffer).all().item()
+                    ),
+                }
+            )
+
+        # The guard sanitizes model_pred THE SAME frame it goes bad -- there must
+        # be no frame, including the injected one, with a non-finite output.
+        bad_frames = [i for i, r in enumerate(results) if not r["x0_finite"]]
+        assert not bad_frames, f"non-finite x0 at frame(s) {bad_frames} -- pre-fix this would latch forever"
+
+        bad_stock = [i for i, r in enumerate(results) if not r["stock_noise_finite"]]
+        assert not bad_stock, f"non-finite stock_noise at frame(s) {bad_stock}"
+
+        bad_buf = [i for i, r in enumerate(results) if not r["x_t_latent_buffer_finite"]]
+        assert not bad_buf, f"non-finite x_t_latent_buffer at frame(s) {bad_buf}"
+
+        # And the stream must still be producing real (non-degenerate-zero) output
+        # a few frames after the injected NaN -- i.e. actually recovered, not just
+        # zeroed out permanently.
+        assert results[-1]["x0_finite"]
+
+    def test_unguarded_reference_would_have_latched(self):
+        """Sanity check that the injected NaN is actually load-bearing: with the
+        guard's sanitize_ call short-circuited, the same scenario latches NaN into
+        stock_noise from the injected frame onward (proves this test can go red)."""
+        unet = _NanInjectingUnet(nan_on_call=3)
+        stream = _make_stream([22, 36], unet, cfg_type="self", guidance_scale=1.0)
+        x_in = _zero_input(stream)
+
+        # Force the guard to report "not bad" and skip sanitizing, reproducing the
+        # pre-fix unguarded path exactly.
+        stream._nan_guard_model_pred = _NoOpGuard()
+
+        saw_nan = False
+        for _ in range(5):
+            StreamDiffusion.predict_x0_batch(stream, x_in)
+            if not torch.isfinite(stream.stock_noise).all():
+                saw_nan = True
+        assert saw_nan, "expected the unguarded path to latch NaN into stock_noise"
+
+
+class _NoOpGuard:
+    """Stand-in for NanGuard that never sanitizes and never flags -- used only to
+    prove the injected-NaN scenario is load-bearing without the real guard."""
+
+    def sanitize_(self, tensor):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Regression for the UnboundLocalError this guard shipped, and the missing
+# SDXL coverage that caused it: `nan_guard_bad_last_frame` was assigned only in
+# unet_step's SD1.5/2.1 branch but read unconditionally in the shared
+# post-branch code (the self/initialize stock_noise recurrence), so every SDXL
+# model with cfg_type self/initialize and denoising_steps_num > 1 crashed on
+# frame 1 -- exactly the user's sdxl-turbo + tensorrt + cfg_type=self +
+# t_index_list=[22, 36] configuration. Neither existing fixture in this suite
+# nor test_unet_call_backend_gate.py exercises is_sdxl=True through unet_step,
+# which is why 705 passing tests missed a 100%-reproducible crash.
+# ---------------------------------------------------------------------------
+
+_SDXL_BACKEND_PARAMS = [
+    pytest.param(False, False, id="sd15"),
+    pytest.param(True, False, id="sdxl-pytorch"),
+    pytest.param(True, True, id="sdxl-trt"),
+]
+
+
+class TestUnetStepDoesNotRaiseAcrossBackends:
+    @pytest.mark.parametrize("is_sdxl, is_trt", _SDXL_BACKEND_PARAMS)
+    def test_predict_x0_batch_does_not_raise(self, is_sdxl, is_trt):
+        """nan_on_call=99 never fires -- proves the crash is unconditional, not
+        NaN-dependent (matches the minimised repro used to find this bug)."""
+        unet = _NanInjectingUnet(nan_on_call=99)
+        stream = _make_stream([22, 36], unet, cfg_type="self", guidance_scale=1.0)
+        stream.is_sdxl = is_sdxl
+        stream._is_unet_tensorrt = is_trt
+        stream._lora_scale_tensor = None  # read only by the SDXL+TensorRT sub-branch
+        x_in = _zero_input(stream)
+
+        for _ in range(3):
+            StreamDiffusion.predict_x0_batch(stream, x_in)  # must not raise
+
+
+class TestNanGuardHealsAcrossBackends:
+    """Extends TestNanGuardBreaksPermanentLatch.test_single_nan_frame_self_heals to
+    both SDXL sub-branches -- proves guard 1 actually protects sdxl-turbo (the
+    user's model), not merely that unet_step no longer crashes."""
+
+    @pytest.mark.parametrize(
+        "is_sdxl, is_trt",
+        [p for p in _SDXL_BACKEND_PARAMS if p.id != "sd15"],
+    )
+    def test_single_nan_frame_self_heals(self, is_sdxl, is_trt):
+        unet = _NanInjectingUnet(nan_on_call=3)
+        stream = _make_stream([22, 36], unet, cfg_type="self", guidance_scale=1.0)
+        stream.is_sdxl = is_sdxl
+        stream._is_unet_tensorrt = is_trt
+        stream._lora_scale_tensor = None
+        x_in = _zero_input(stream)
+
+        results = []
+        for _ in range(8):
+            x0 = StreamDiffusion.predict_x0_batch(stream, x_in)
+            results.append(
+                {
+                    "x0_finite": torch.isfinite(x0).all().item(),
+                    "stock_noise_finite": torch.isfinite(stream.stock_noise).all().item(),
+                    "x_t_latent_buffer_finite": (
+                        stream.x_t_latent_buffer is None or torch.isfinite(stream.x_t_latent_buffer).all().item()
+                    ),
+                }
+            )
+
+        bad_frames = [i for i, r in enumerate(results) if not r["x0_finite"]]
+        assert not bad_frames, f"non-finite x0 at frame(s) {bad_frames} -- pre-fix this would latch forever"
+
+        bad_stock = [i for i, r in enumerate(results) if not r["stock_noise_finite"]]
+        assert not bad_stock, f"non-finite stock_noise at frame(s) {bad_stock}"
+
+        bad_buf = [i for i, r in enumerate(results) if not r["x_t_latent_buffer_finite"]]
+        assert not bad_buf, f"non-finite x_t_latent_buffer at frame(s) {bad_buf}"
+
+        assert results[-1]["x0_finite"]
+
+
+# ---------------------------------------------------------------------------
+# Second defect found while verifying the crash fix: unet_step's NaN-recovery
+# path used to pass kvo_cache_out=[] to update_kvo_cache on a bad frame, but
+# that function gates on self.kvo_cache (the stream's cache), not the passed
+# list, so empty lists still entered the bucketed write path
+# (update_kvo_cache, pipeline.py) and raised IndexError indexing an empty
+# list. The fix skips the update_kvo_cache call entirely on a bad frame.
+# ---------------------------------------------------------------------------
+
+
+class _NanInjectingKvoUnet:
+    """Like _NanInjectingUnet, but also returns per-layer kvo cache outputs so the
+    call exercises update_kvo_cache's bucketed write path."""
+
+    def __init__(self, nan_on_call: int, n_layers=2, batch=2, seq=4, hidden=8):
+        self.nan_on_call = nan_on_call
+        self.calls = 0
+        self.n_layers = n_layers
+        self.batch = batch
+        self.seq = seq
+        self.hidden = hidden
+
+    def __call__(self, sample, timestep, encoder_hidden_states=None, kvo_cache=None, return_dict=False, **kwargs):
+        self.calls += 1
+        pred = torch.full_like(sample, float("nan")) if self.calls == self.nan_on_call else 0.05 * sample
+        kvo_out = [torch.zeros(2, 1, self.batch, self.seq, self.hidden) for _ in range(self.n_layers)]
+        return (pred, kvo_out, [])
+
+
+def _wire_bucketed_kvo_cache(stream, n_layers=2, batch=2, seq=4, hidden=8, cache_maxframes=4):
+    """Minimal single-bucket scaffolding matching create_kvo_cache's real layout
+    (acceleration/tensorrt/models/utils.py): all n_layers share one bucket."""
+    bucket = torch.zeros(n_layers, 2, cache_maxframes, batch, seq, hidden)
+    stream._kvo_buckets = [bucket]
+    stream._kvo_outputs_by_bucket = [list(range(n_layers))]
+    stream.kvo_cache = [bucket[i] for i in range(n_layers)]  # per-layer views, like create_kvo_cache returns
+    stream.fio_cache = []
+    stream.cache_interval = 1
+    stream.cache_maxframes = cache_maxframes
+    stream.frame_idx = 0
+
+
+class TestKvoCacheBucketedRecoveryDoesNotRaise:
+    def test_direct_empty_list_call_raises_documenting_the_defect(self):
+        """Red-capability proof: the bucketed write path really does crash on
+        empty lists, so this test class isn't vacuously passing."""
+        stream = StreamDiffusion.__new__(StreamDiffusion)
+        _wire_bucketed_kvo_cache(stream)
+
+        with pytest.raises(IndexError):
+            stream.update_kvo_cache([], [])
+
+    def test_nan_frame_with_bucketed_cache_does_not_raise(self):
+        unet = _NanInjectingKvoUnet(nan_on_call=3)
+        stream = _make_stream([22, 36], unet, cfg_type="self", guidance_scale=1.0)
+        _wire_bucketed_kvo_cache(stream)
+        x_in = _zero_input(stream)
+
+        for _ in range(8):
+            StreamDiffusion.predict_x0_batch(stream, x_in)  # must not raise, incl. on the frame-3 NaN


### PR DESCRIPTION
## Summary

Nothing on the streaming hot path checked for non-finite values. A single NaN/Inf produced anywhere (degenerate prompt weights, an overflowing UNet step, a bad ControlNet residual) latched into the buffers that are fed back on the next frame (`stock_noise`, the ControlNet residual cache / EMA, the image-filter skip probability) and the stream rendered solid black until re-prepare. `torch.clamp` does not filter NaN and every comparison against NaN is False, so the existing `.clamp(...)` calls that read as safety did not guard anything.

Companion to the zero-prompt-weight fix (dotsimulate/StreamDiffusion PR "fix(prompt): black output when all prompt weights are 0"); that one removes the most common *source*, this one makes the pipeline *recover* from any source.

## Fix

Two commits:

**`feat(utils): NanGuard + guards on CN residuals and image-filter skip prob`**

- `src/streamdiffusion/utils/nan_guard.py` (new): `NanGuard.sanitize_(tensor)` runs an unconditional in-place `nan_to_num_` so the tensor is always healed. On CUDA the verdict is read through a pinned host scalar + `torch.cuda.Event` and reported one frame late, so the guard never forces a host sync (same pattern as `SimilarImageFilter.skip_prob`); on CPU it is inline. First hit logs at WARNING, repeats at DEBUG.
- `modules/controlnet_module.py`: sanitize every down/mid residual before it is written into the residual cache or blended by the EMA.
- `image_filter.py`: sanitize the GPU skip probability before the async pinned copy. The previous `clamp()` was documented as filtering NaN; comment corrected.
- `utils/__init__.py`: export `NanGuard`.

**`feat(pipeline): NaN guard 1 on unet_step model_pred (SDXL-safe)`**

- `pipeline.py`: sanitize `unet_step`'s `model_pred` before it enters the `stock_noise` recurrence, wired in all three UNet-call branches (SD1.5/2.1 and both SDXL branches). On a bad frame the recovery path skips `update_kvo_cache` entirely rather than passing empty lists (that function gates on `self.kvo_cache`, so empty lists raise IndexError in the bucketed write path).

Cost: one elementwise kernel per guarded tensor per frame, no host syncs.

## Test plan

- `tests/unit/test_nan_guard.py`: CPU path (heals NaN/Inf in place, verdict, warn-once) and the deferred CUDA verdict when a GPU is present.
- `tests/unit/test_nan_guard_latch_recovery.py`: SD1.5 path plus both SDXL branches (crash regression + NaN-heals-in-place) and the bucketed cache recovery path.

```
venv/Scripts/python.exe -m pytest tests/unit -q
587 passed, 1 skipped
```

(On this branch, cherry-picked onto `SDTD_040_beta_release` @ f2588a9.)

Reviewed on fork PR forkni/StreamDiffusion#32 (claude-code-review.yml, clean).
