### PR TITLE
fix(prompt): black output when all prompt weights are 0

### DIFF
--- a/src/streamdiffusion/stream_parameter_updater.py
+++ b/src/streamdiffusion/stream_parameter_updater.py
@@ -914,8 +914,12 @@ class StreamParameterUpdater(OrchestratorUser):
         dot_product = torch.clamp(torch.dot(flat1_norm, flat2_norm), -1.0, 1.0)
         theta = torch.acos(dot_product)
 
-        # Handle parallel vectors (degenerate SLERP → LERP)
-        if theta.abs() < 1e-6:
+        # Handle parallel AND antiparallel vectors (degenerate SLERP -> LERP).
+        # sin(theta) is the divisor below and is ~0 at both theta~=0 and
+        # theta~=pi; dot_product is clamped to exactly -1.0 above, so theta==pi
+        # is reachable and would otherwise divide into NaN (same guard as
+        # _slerp_noise).
+        if theta.abs() < 1e-6 or (math.pi - theta.abs()) < 1e-6:
             result = (1 - t) * flat1 + t * flat2
         else:
             # SLERP on unit sphere, rescaled to linearly-interpolated magnitude.

--- a/src/streamdiffusion/stream_parameter_updater.py
+++ b/src/streamdiffusion/stream_parameter_updater.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import threading
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
@@ -94,6 +95,17 @@ class StreamParameterUpdater(OrchestratorUser):
         # ceiling. A set-time check only — a later live guidance change can move
         # the ceiling without re-triggering it.
         self._warned_delta_above_ceiling: bool = False
+        # Warn-once flag for a degenerate (all-zero-sum) weight list reaching
+        # _normalize_weights — e.g. every prompt/seed weight dragged to 0 with
+        # normalize_prompt_weights/normalize_seed_weights False (bypassing TD's
+        # own all-zero guard, which only fires when its normalize toggle is on).
+        # This path takes live per-frame weight updates, so warn once, not every frame.
+        self._warned_degenerate_weights: bool = False
+        # Warn-once flags for cold-path NaN guards (see utils/nan_guard.py docstring for
+        # the family of hot-path guards this mirrors) — these are param-update-only sites,
+        # not per-frame, so a plain validate-and-reject on the host is fine, no sync concern.
+        self._warned_nonfinite_prompt_embeds: bool = False
+        self._warned_nonfinite_init_noise: bool = False
 
     def get_cache_info(self) -> Dict:
         """Get cache statistics for monitoring performance."""
@@ -247,9 +259,29 @@ class StreamParameterUpdater(OrchestratorUser):
         (a 0-dim CPU operand is treated as a wrapped scalar there), so building on
         device was a pure creation-sync + readback with no benefit — and float32 is
         more precise than the model's fp16 for the normalization divide.
+
+        A degenerate (near-zero) weight sum has no useful interpretation under either
+        setting of `normalize` — with normalize=True it's an unguarded 0/0 -> NaN that
+        latches permanently into cross-frame pipeline buffers (x_t_latent_buffer,
+        stock_noise) with no recovery; with normalize=False the "average" caller would
+        silently emit an all-zero embedding while "slerp"/"cosine_weighted" fall back
+        to embeddings[0], i.e. the three methods would disagree. So this is handled
+        before the normalize branch, unconditionally: fall back to uniform weights
+        (sum == 1), matching TD's own all-zero guard (StreamDiffusionExt.py Promptblock).
         """
         weights_tensor = torch.tensor(weights, dtype=torch.float32)
-        if normalize:
+        if weights_tensor.numel() and float(weights_tensor.sum().abs()) <= 1e-8:
+            if not self._warned_degenerate_weights:
+                logger.warning(
+                    "_normalize_weights: all weights are ~0 (%r) - falling back to "
+                    "uniform weights (1/%d each) instead of dividing by zero "
+                    "(warning shown once)",
+                    weights,
+                    weights_tensor.numel(),
+                )
+                self._warned_degenerate_weights = True
+            weights_tensor = torch.full_like(weights_tensor, 1.0 / weights_tensor.numel())
+        elif normalize:
             weights_tensor = weights_tensor / weights_tensor.sum()
         return weights_tensor
 
@@ -477,9 +509,11 @@ class StreamParameterUpdater(OrchestratorUser):
                     negative_prompt=negative_prompt or self._current_negative_prompt,
                     prompt_interpolation_method=self._last_prompt_interpolation_method,
                 )
-            elif prompt_interpolation_method is not None:
-                # Method-only change: re-blend the already-cached embeddings so the
-                # switch lands on the next frame instead of waiting for a prompt edit.
+            elif prompt_interpolation_method is not None or normalize_prompt_weights is not None:
+                # Method-only or normalize-flag-only change: re-blend the already-cached
+                # embeddings so the switch lands on the next frame instead of waiting for a
+                # prompt edit (Part 3 — previously toggling Normpweights with no prompt edit
+                # had no effect until the next prompt_list update).
                 self._apply_prompt_blending(self._last_prompt_interpolation_method)
 
             # Handle seed blending if seed_list is provided
@@ -487,8 +521,9 @@ class StreamParameterUpdater(OrchestratorUser):
                 self._update_blended_seeds(
                     seed_list=seed_list, interpolation_method=self._last_seed_interpolation_method
                 )
-            elif seed_interpolation_method is not None:
-                # Method-only change: re-blend the already-cached seed noise immediately.
+            elif seed_interpolation_method is not None or normalize_seed_weights is not None:
+                # Method-only or normalize-flag-only change: re-blend the already-cached seed
+                # noise immediately (mirrors the prompt-side trigger above).
                 self._apply_seed_blending(self._last_seed_interpolation_method)
 
             # Handle ControlNet configuration updates
@@ -827,6 +862,25 @@ class StreamParameterUpdater(OrchestratorUser):
 
             logging.getLogger(__name__).error(f"_apply_prompt_blending: embedding hook failed: {e}")
 
+        # Cold-path NaN guard: validate after the embedding hooks (any of which could
+        # inject non-finite values, e.g. an IP-Adapter or LoRA bug) and before assignment.
+        # This is a param-update, not a per-frame call, so a plain host isfinite() check is
+        # fine -- no hot-path sync concern. On failure, keep whatever embeddings the stream
+        # already had rather than handing the UNet a poisoned prompt_embeds.
+        embeds_finite = torch.isfinite(final_prompt_embeds).all() and (
+            final_negative_embeds is None or torch.isfinite(final_negative_embeds).all()
+        )
+        if not embeds_finite:
+            if not self._warned_nonfinite_prompt_embeds:
+                logger.error(
+                    "_apply_prompt_blending: computed prompt embeddings contain NaN/Inf -- "
+                    "keeping previous embeddings; further occurrences logged at DEBUG"
+                )
+                self._warned_nonfinite_prompt_embeds = True
+            else:
+                logger.debug("_apply_prompt_blending: computed prompt embeddings contain NaN/Inf -- keeping previous")
+            return
+
         # Set final embeddings on stream
         self.stream.prompt_embeds = final_prompt_embeds
         if final_negative_embeds is not None:
@@ -1063,6 +1117,22 @@ class StreamParameterUpdater(OrchestratorUser):
                 )
             combined_noise = self._linear_blend_noise(noise_tensors, weights)
 
+        # Cold-path NaN guard: init_noise is the pipeline's only clean recovery source (see
+        # guard 1's stock_noise reseed in pipeline.py) -- poisoning it here would remove that
+        # recovery path entirely. Single choke point for all four blend paths above (slerp,
+        # multi_slerp, cosine_weighted, linear). Param-update-only call, not per-frame, so a
+        # plain host isfinite() check is fine.
+        if not torch.isfinite(combined_noise).all():
+            if not self._warned_nonfinite_init_noise:
+                logger.error(
+                    "_apply_seed_blending: computed init_noise contains NaN/Inf -- "
+                    "keeping previous init_noise; further occurrences logged at DEBUG"
+                )
+                self._warned_nonfinite_init_noise = True
+            else:
+                logger.debug("_apply_seed_blending: computed init_noise contains NaN/Inf -- keeping previous")
+            return
+
         # Update stream noise.
         # IMPORTANT: do NOT zero stock_noise here. Resetting it destroys the RCFG residual
         # continuity established over previous frames, causing a cold-restart artifact on every
@@ -1104,8 +1174,11 @@ class StreamParameterUpdater(OrchestratorUser):
         dot_product = torch.clamp(torch.dot(flat1_norm, flat2_norm), -1.0, 1.0)
         theta = torch.acos(dot_product)
 
-        # Handle parallel vectors
-        if theta.abs() < 1e-6:
+        # Handle parallel AND antiparallel vectors -- both make sin_theta -> 0, which would
+        # otherwise divide-by-zero into NaN below (theta==pi is reachable: dot_product is
+        # clamped to exactly -1.0 for genuinely antiparallel noise, e.g. a seed reused with
+        # a sign flip upstream).
+        if theta.abs() < 1e-6 or (math.pi - theta.abs()) < 1e-6:
             result = (1 - t) * flat1 + t * flat2
         else:
             # SLERP formula

--- a/tests/unit/test_prompt_interpolation.py
+++ b/tests/unit/test_prompt_interpolation.py
@@ -348,6 +348,135 @@ class TestApplyPromptBlendingDispatch:
 
 
 # ---------------------------------------------------------------------------
+# Regression: all-zero (degenerate-sum) weights used to reach an unguarded
+# weights / weights.sum() in _normalize_weights, producing a 0/0 -> NaN
+# embedding that then latches permanently into cross-frame pipeline buffers
+# (x_t_latent_buffer, stock_noise) with no recovery -- the "Normpweights off +
+# both prompts at 0 -> permanently black" bug. Repro: TD's own all-zero guard
+# (StreamDiffusionExt.py Promptblock) only fires when its Normpweights toggle
+# is on, so toggling it off forwards literal 0.0 weights straight to the
+# backend, which had no guard of its own.
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeWeightsDegenerateSum:
+    def setup_method(self):
+        self.upd = _make_updater()
+
+    def test_all_zero_normalize_true_returns_uniform(self):
+        out = self.upd._normalize_weights([0.0, 0.0], normalize=True)
+        assert torch.isfinite(out).all(), "degenerate sum must not divide by zero into NaN"
+        assert torch.allclose(out, torch.tensor([0.5, 0.5]))
+
+    def test_all_zero_normalize_false_returns_uniform(self):
+        """The guard applies regardless of `normalize` -- an all-zero weight list has
+        no useful interpretation either way, and normalize=False would otherwise let
+        a literal-zeros embedding (average) disagree with slerp/cosine's fallback."""
+        out = self.upd._normalize_weights([0.0, 0.0, 0.0], normalize=False)
+        assert torch.isfinite(out).all()
+        assert torch.allclose(out, torch.tensor([1.0 / 3, 1.0 / 3, 1.0 / 3]))
+
+    def test_near_zero_sum_also_treated_as_degenerate(self):
+        out = self.upd._normalize_weights([1e-10, -1e-10], normalize=True)
+        assert torch.isfinite(out).all()
+
+    def test_nonzero_weights_unaffected_normalize_true(self):
+        out = self.upd._normalize_weights([0.7, 0.3], normalize=True)
+        assert torch.allclose(out, torch.tensor([0.7, 0.3]), atol=1e-6)
+
+    def test_nonzero_weights_unaffected_normalize_false(self):
+        out = self.upd._normalize_weights([0.7, 0.3], normalize=False)
+        assert torch.allclose(out, torch.tensor([0.7, 0.3]), atol=1e-6)
+
+    def test_warns_once(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="streamdiffusion.stream_parameter_updater"):
+            self.upd._normalize_weights([0.0, 0.0], normalize=True)
+            self.upd._normalize_weights([0.0, 0.0], normalize=True)
+        degenerate_warnings = [
+            r for r in caplog.records if "degenerate" not in r.message and "all weights are" in r.message
+        ]
+        assert len(degenerate_warnings) == 1, "expected exactly one warning across repeated degenerate calls"
+
+
+class TestApplyPromptBlendingZeroWeights:
+    """Same regression, exercised through the real blend entry point
+    (_apply_prompt_blending) for all three interpolation methods and both
+    normalize settings -- this is where the NaN was actually born and then
+    unconditionally assigned to stream.prompt_embeds (:831)."""
+
+    def setup_method(self):
+        self.upd = _make_updater()
+        e1 = _rand_embed(seed=200)
+        e2 = _rand_embed(seed=201)
+        self.upd._prompt_cache = {"cat": {"embed": e1}, "dog": {"embed": e2}}
+        self.upd._current_negative_prompt = ""
+
+    def _assert_finite_for(self, method: str, normalize: bool):
+        self.upd._current_prompt_list = [("cat", 0.0), ("dog", 0.0)]
+        self.upd.normalize_prompt_weights = normalize
+        self.upd._apply_prompt_blending(method)
+        embeds = self.upd.stream.prompt_embeds
+        assert embeds is not None
+        assert torch.isfinite(embeds).all(), (
+            f"method={method} normalize={normalize}: all-zero prompt weights produced a non-finite embedding"
+        )
+
+    def test_slerp_normalize_true(self):
+        self._assert_finite_for("slerp", True)
+
+    def test_slerp_normalize_false(self):
+        self._assert_finite_for("slerp", False)
+
+    def test_average_normalize_true(self):
+        self._assert_finite_for("average", True)
+
+    def test_average_normalize_false(self):
+        self._assert_finite_for("average", False)
+
+    def test_cosine_weighted_normalize_true(self):
+        self._assert_finite_for("cosine_weighted", True)
+
+    def test_cosine_weighted_normalize_false(self):
+        self._assert_finite_for("cosine_weighted", False)
+
+
+class TestApplySeedBlendingZeroWeights:
+    """Seed path shares _normalize_weights (:1022, :1050) -- a zero-sum seed_list
+    would poison init_noise, the pipeline's only clean recovery source for guard 1
+    (see plan Part 2)."""
+
+    def setup_method(self):
+        self.upd = _make_updater()
+        n1 = _rand_noise(seed=210)
+        n2 = _rand_noise(seed=211)
+        self.upd._seed_cache = {0: {"noise": n1, "seed": 210}, 1: {"noise": n2, "seed": 211}}
+
+    def _assert_finite_for(self, method: str, normalize: bool):
+        self.upd._current_seed_list = [(210, 0.0), (211, 0.0)]
+        self.upd.normalize_seed_weights = normalize
+        self.upd._apply_seed_blending(method)
+        noise = self.upd.stream.init_noise
+        assert noise is not None
+        assert torch.isfinite(noise).all(), (
+            f"method={method} normalize={normalize}: all-zero seed weights produced non-finite init_noise"
+        )
+
+    def test_slerp_normalize_true(self):
+        self._assert_finite_for("slerp", True)
+
+    def test_average_normalize_true(self):
+        self._assert_finite_for("average", True)
+
+    def test_cosine_weighted_normalize_true(self):
+        self._assert_finite_for("cosine_weighted", True)
+
+    def test_average_normalize_false(self):
+        self._assert_finite_for("average", False)
+
+
+# ---------------------------------------------------------------------------
 # _cosine_adjusted_weights — shared reweighting helper (used by both the prompt
 # path via _cosine_weighted_blend and the seed path directly)
 # ---------------------------------------------------------------------------
@@ -433,6 +562,49 @@ class TestMultiSlerpNoise:
         result_with = self.upd._multi_slerp_noise([n1, n2, n_zero], [0.6, 0.4, 0.0])
         result_without = self.upd._multi_slerp_noise([n1, n2], [0.6, 0.4])
         assert torch.allclose(result_with, result_without, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Cold-guard regression: _slerp_noise's sin_theta divisor goes to zero not only
+# at theta~=0 (parallel, already handled) but also at theta~=pi (antiparallel).
+# dot_product is explicitly clamped to exactly -1.0 (:1176), so theta==pi is
+# reachable -- e.g. a seed noise tensor reused with a sign flip upstream -- and
+# the pre-fix code divided by that zero into a NaN that would poison init_noise,
+# the pipeline's only clean recovery source for guard 1.
+# ---------------------------------------------------------------------------
+
+
+class TestSlerpNoiseAntiparallel:
+    def setup_method(self):
+        self.upd = _make_updater()
+
+    def test_exactly_antiparallel_vectors_stay_finite(self):
+        n1 = _rand_noise(seed=95)
+        n2 = -n1  # theta == pi exactly
+        result = self.upd._slerp_noise(n1, n2, 0.5)
+        assert torch.isfinite(result).all(), "antiparallel noise must not divide-by-zero into NaN"
+
+    def test_exactly_antiparallel_vectors_match_linear_fallback(self):
+        """At theta==pi the fix takes the same linear-fallback branch as theta==0;
+        pin the expected formula so this doesn't silently regress to something
+        merely finite-but-wrong."""
+        n1 = _rand_noise(seed=96)
+        n2 = -n1
+        t = 0.3
+        result = self.upd._slerp_noise(n1, n2, t)
+        expected = (1 - t) * n1 + t * n2
+        assert torch.allclose(result, expected, atol=1e-5)
+
+    def test_nearly_antiparallel_vectors_stay_finite(self):
+        """theta very close to (but not exactly) pi -- sin(theta) is a tiny nonzero
+        denominator pre-fix, which blows up the result rather than NaN-ing it
+        outright; must still land in the linear-fallback branch."""
+        n1 = _rand_noise(seed=97)
+        # Perturb slightly so dot_product clamps to just inside -1.0, not exactly it.
+        n2 = -n1 + 1e-7 * _rand_noise(seed=98)
+        result = self.upd._slerp_noise(n1, n2, 0.5)
+        assert torch.isfinite(result).all()
+        assert result.norm().item() < 1e6, "near-antiparallel slerp should not blow up"
 
 
 # ---------------------------------------------------------------------------
@@ -700,3 +872,60 @@ class TestStickyInterpolationMethods:
         assert fresh._last_seed_interpolation_method == "cosine_weighted"
         assert fresh.stream.prompt_embeds is None
         assert fresh.stream.init_noise is None
+
+
+# ---------------------------------------------------------------------------
+# Part 3 regression: toggling Normpweights/normalize_seed_weights alone (no
+# prompt/seed list edit) used to have zero effect until the next list update,
+# because update_stream_params only re-blended on prompt_list/seed_list or an
+# *_interpolation_method change. This mirrors TestStickyInterpolationMethods'
+# method-only re-blend tests, but for the normalize-flag-only path.
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeFlagOnlyReblendsImmediately:
+    def setup_method(self):
+        self.upd = _make_updater()
+        e1 = _rand_embed(seed=300)
+        e2 = _rand_embed(seed=301)
+        self.upd._prompt_cache = {"cat": {"embed": e1}, "dog": {"embed": e2}}
+        self.upd._current_prompt_list = [("cat", 0.5), ("dog", 0.5)]
+        self.upd._current_negative_prompt = ""
+
+        n1 = _rand_noise(seed=310)
+        n2 = _rand_noise(seed=311)
+        self.upd._seed_cache = {0: {"noise": n1, "seed": 310}, 1: {"noise": n2, "seed": 311}}
+        self.upd._current_seed_list = [(310, 0.5), (311, 0.5)]
+
+    def test_normalize_prompt_weights_only_reblends_immediately(self):
+        assert self.upd.stream.prompt_embeds is None  # nothing blended yet
+        self.upd.update_stream_params(normalize_prompt_weights=False)
+        assert self.upd.normalize_prompt_weights is False
+        assert self.upd.stream.prompt_embeds is not None, (
+            "a normalize_prompt_weights-only change must re-blend the cached prompts "
+            "immediately, not wait for the next prompt_list update"
+        )
+
+    def test_normalize_seed_weights_only_reblends_immediately(self):
+        assert self.upd.stream.init_noise is None
+        self.upd.update_stream_params(normalize_seed_weights=False)
+        assert self.upd.normalize_seed_weights is False
+        assert self.upd.stream.init_noise is not None, (
+            "a normalize_seed_weights-only change must re-blend the cached seed noise "
+            "immediately, not wait for the next seed_list update"
+        )
+
+    def test_normalize_prompt_weights_flag_actually_changes_output(self):
+        """Not just 'it re-blended' -- confirm the flag is wired through to the
+        blend math (Totalpweights-equivalent: un-normalized weights amplify)."""
+        self.upd._current_prompt_list = [("cat", 2.0), ("dog", 2.0)]
+        self.upd.update_stream_params(normalize_prompt_weights=True)
+        normalized_embeds = self.upd.stream.prompt_embeds.clone()
+
+        self.upd.update_stream_params(normalize_prompt_weights=False)
+        unnormalized_embeds = self.upd.stream.prompt_embeds.clone()
+
+        assert not torch.allclose(normalized_embeds, unnormalized_embeds), (
+            "toggling normalize_prompt_weights with an identical prompt_list produced "
+            "identical output -- the flag isn't reaching the blend"
+        )

--- a/tests/unit/test_prompt_interpolation.py
+++ b/tests/unit/test_prompt_interpolation.py
@@ -394,9 +394,7 @@ class TestNormalizeWeightsDegenerateSum:
         with caplog.at_level(logging.WARNING, logger="streamdiffusion.stream_parameter_updater"):
             self.upd._normalize_weights([0.0, 0.0], normalize=True)
             self.upd._normalize_weights([0.0, 0.0], normalize=True)
-        degenerate_warnings = [
-            r for r in caplog.records if "degenerate" not in r.message and "all weights are" in r.message
-        ]
+        degenerate_warnings = [r for r in caplog.records if "all weights are" in r.message]
         assert len(degenerate_warnings) == 1, "expected exactly one warning across repeated degenerate calls"
 
 
@@ -605,6 +603,44 @@ class TestSlerpNoiseAntiparallel:
         result = self.upd._slerp_noise(n1, n2, 0.5)
         assert torch.isfinite(result).all()
         assert result.norm().item() < 1e6, "near-antiparallel slerp should not blow up"
+
+
+class TestSlerpAntiparallel:
+    """Same theta==pi divide-by-zero, but in _slerp (prompt embeddings). _slerp backs
+    the 2-way "slerp" prompt path and, via _multi_slerp, the N-way "slerp" and
+    "cosine_weighted" paths, so an unguarded antiparallel pair would have tripped the
+    cold NaN guard in _apply_prompt_blending and silently frozen the blend instead
+    of producing the linear-fallback result."""
+
+    def setup_method(self):
+        self.upd = _make_updater()
+
+    def test_exactly_antiparallel_embeddings_stay_finite(self):
+        e1 = _rand_embed(seed=120)
+        e2 = -e1  # theta == pi exactly
+        result = self.upd._slerp(e1, e2, 0.5)
+        assert torch.isfinite(result).all(), "antiparallel embeddings must not divide-by-zero into NaN"
+
+    def test_exactly_antiparallel_embeddings_match_linear_fallback(self):
+        e1 = _rand_embed(seed=121)
+        e2 = -e1
+        t = 0.3
+        result = self.upd._slerp(e1, e2, t)
+        expected = (1 - t) * e1 + t * e2
+        assert torch.allclose(result, expected, atol=1e-5)
+
+    def test_nearly_antiparallel_embeddings_stay_finite(self):
+        e1 = _rand_embed(seed=122)
+        e2 = -e1 + 1e-7 * _rand_embed(seed=123)
+        result = self.upd._slerp(e1, e2, 0.5)
+        assert torch.isfinite(result).all()
+        assert result.norm().item() < 1e6, "near-antiparallel slerp should not blow up"
+
+    def test_multi_slerp_antiparallel_pair_stays_finite(self):
+        """The N-way path folds pairs through _slerp; an antiparallel pair must survive it."""
+        e1 = _rand_embed(seed=124)
+        result = self.upd._multi_slerp([e1, -e1], [0.5, 0.5])
+        assert torch.isfinite(result).all()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

With `normalize_prompt_weights` off and every prompt weight at 0 (e.g. TD's *Normpweights* toggled off while both prompt sliders sit at 0), `_normalize_weights` divided 0/0. The resulting NaN embed propagated into the cross-frame buffers and the stream rendered solid black until a full re-prepare, with no exception and nothing in the log.

## Fix

`src/streamdiffusion/stream_parameter_updater.py`:

- `_normalize_weights`: when the weight sum is ~0, fall back to uniform weights (`1/n` each) instead of dividing by zero. Logged once at WARNING.
- `_apply_prompt_blending` / `_apply_seed_blending`: if the blended result is non-finite, keep the previous finite buffer and log once, rather than publishing NaN into `stream.prompt_embeds` / `stream.init_noise`.
- `_slerp_noise`: linear fallback when the two noise vectors are parallel or antiparallel (`sin(theta)` ~ 0), which otherwise also yields NaN.
- `update_stream_params`: a change to only `prompt_interpolation_method` / `normalize_prompt_weights` (and the seed equivalents) now re-blends immediately, so toggling the normalize flag takes effect on the next frame instead of waiting for the next prompt/seed list edit.
- Second commit (from the review pass): the same antiparallel guard applied to `_slerp`, the embedding slerp behind the 2-way `slerp` path and, via `_multi_slerp`, the N-way `slerp` / `cosine_weighted` prompt paths.

No behavior change when weights are non-degenerate: the normalized and un-normalized blend math is untouched.

## Test plan

`tests/unit/test_prompt_interpolation.py` gains five classes: `TestNormalizeWeightsDegenerateSum`, `TestApplyPromptBlendingZeroWeights`, `TestApplySeedBlendingZeroWeights`, `TestSlerpNoiseAntiparallel`, `TestSlerpAntiparallel`, `TestNormalizeFlagOnlyReblendsImmediately`.

```
venv/Scripts/python.exe -m pytest tests/unit -q
597 passed, 1 skipped
```

(On this branch, cherry-picked onto `SDTD_040_beta_release` @ f2588a9.)

Reviewed on fork PR forkni/StreamDiffusion#31 (claude-code-review.yml). Its first-pass finding, the missing `_slerp` guard, is fixed in the second commit. The re-review passed with one non-blocking note worth stating here: the post-blend `isfinite().all()` checks force a host sync. They run only inside `update_stream_params` when a prompt/seed weight or interpolation setting actually changes (so once per frame while a TD slider is being dragged, never on the steady-state render loop), on a single `[1, 77, 768]`-scale tensor, so the cost is negligible next to the slerp/hook work in the same call.
