### PR TITLE
test(diag): exercise CUDALINK_ prefix via CUDALINK_DOORBELL, not retired CUDALINK_LIB_PATH

### DIFF
--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -174,11 +174,14 @@ class TestCollectDiagnostics:
         assert diag["config"]["where"] == "streaming_loop"
 
     def test_env_allowlist_only(self, monkeypatch):
-        monkeypatch.setenv("CUDALINK_LIB_PATH", "C:/venv/site-packages")
+        # CUDALINK_LIB_PATH is retired (cuda_link resolution no longer uses an env var --
+        # see cuda_link_bootstrap.py's layered lookup); CUDALINK_DOORBELL is still a live,
+        # installer-persisted var, so it exercises the same CUDALINK_ prefix allowlist path.
+        monkeypatch.setenv("CUDALINK_DOORBELL", "1")
         monkeypatch.setenv("HF_HOME", "C:/hf")
         monkeypatch.setenv("SECRET_TOKEN", "should-not-appear")
         diag = diagnostics.collect_diagnostics()
-        assert diag["env"].get("CUDALINK_LIB_PATH") == "C:/venv/site-packages"
+        assert diag["env"].get("CUDALINK_DOORBELL") == "1"
         assert diag["env"].get("HF_HOME") == "C:/hf"
         assert "SECRET_TOKEN" not in diag["env"]
 


### PR DESCRIPTION
## Summary

`CUDALINK_LIB_PATH` is being retired: `cuda_link` resolution no longer depends on an
env var. It's replaced by a layered lookup (explicit arg → `Basefolder` par → APPDATA
`streamdiffusion_config.json` → plain `import cuda_link` off `sys.path`) implemented in
`cuda_link_bootstrap.py` on the StreamDiffusionTD side.

This PR updates `tests/unit/test_diagnostics.py` so it no longer asserts on a variable
that's going away. It swaps the `CUDALINK_` prefix-allowlist coverage over to
`CUDALINK_DOORBELL`, which is a live, installer-persisted variable unrelated to library
path resolution, so the same allowlist behavior is still exercised without depending on
the retired var. `diagnostics.py` itself needed no source change — its `CUDALINK_`
prefix match is generic.

## Companion PRs (same root-cause fix, split by repo ownership)

- forkni/cuda-link#44 — `CUDAIPCExtension` compiles even when `cuda_link` fails to
  import (was the actual crash: `ModuleNotFoundError: No module named 'SHMProtocol'`
  raised at class-body import time, `tdAttributeError` on every frame thereafter).
- dotsimulate/StreamDiffusionTD#20 — `cuda_link_bootstrap.py` layered resolver, drops
  the `CUDALINK_LIB_PATH` dependency entirely.
- dotsimulate/StreamDiffusion-installer#6 — installer/verifier stop writing/checking
  `CUDALINK_LIB_PATH` via `setx`.

## Test plan

- [x] `./venv/Scripts/python.exe -m pytest tests/unit/test_diagnostics.py` — 29 passed
- [x] `./scripts/git/commit_enhanced.sh` lint/format gate passed on the changed file
- [x] `./scripts/git/push_validated.sh` pre-push lint passed (code lint clean; Markdown
      lint skipped via `--skip-md-lint` — 424 pre-existing errors in unrelated files
      `SESSION_LOG.md`, `_hf_tracing_patches.md`, two READMEs, none touched by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)